### PR TITLE
Add ability to use only created_at and updated_at

### DIFF
--- a/dialects/base/model.js
+++ b/dialects/base/model.js
@@ -131,8 +131,8 @@ _.extend(ModelBase.prototype, _.omit(Backbone.Model.prototype), Events, {
     var d = new Date();
     var keys = (_.isArray(this.hasTimestamps) ? this.hasTimestamps : ['created_at', 'updated_at']);
     var vals = {};
-    vals[keys[1]] = d;
-    if (this.isNew(options) && (!options || options.method !== 'update')) vals[keys[0]] = d;
+    if (keys[1]) vals[keys[1]] = d;
+    if (this.isNew(options) && keys[0] && (!options || options.method !== 'update')) vals[keys[0]] = d;
     return vals;
   },
 

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -534,6 +534,28 @@ module.exports = function(Bookshelf) {
         return m.save({item: 'test'}, {method: 'update'});
       });
 
+      it('will accept a falsy value as an option for created and ignore it', function() {
+        var m = new Bookshelf.Model(null, {hasTimestamps: ['createdAt', null]});
+        m.sync = function() {
+          equal(this.get('item'), 'test');
+          equal(_.isDate(this.get('createdAt')), true);
+          equal(_.isDate(this.get('updatedAt')), false);
+          return stubSync;
+        };
+        return m.save({item: 'test'});
+      });
+
+      it('will accept a falsy value as an option for updated and ignore it', function() {
+        var m = new Bookshelf.Model(null, {hasTimestamps: [null, 'updatedAt']});
+        m.sync = function() {
+          equal(this.get('item'), 'test');
+          equal(_.isDate(this.get('updatedAt')), true);
+          equal(_.isDate(this.get('createdAt')), false);
+          return stubSync;
+        };
+        return m.save({item: 'test'});
+      });
+
     });
 
     describe('timestamp', function() {


### PR DESCRIPTION
If a falsy parameter is supplied to the hasTimestamps array (0, null, undefined, etc.) a field can be ignored. For example if I did `['created_at', null]` it will not use the updated_at column at all.
