### PR TITLE
Add 'visible' and 'hidden' as options to control serialization

### DIFF
--- a/dialects/base/model.js
+++ b/dialects/base/model.js
@@ -79,7 +79,12 @@ _.extend(ModelBase.prototype, _.omit(Backbone.Model.prototype), Events, {
   // along with the `toJSON` value of any relations,
   // unless `{shallow: true}` is passed in the `options`.
   toJSON: function(options) {
-    var attrs = _.extend({}, this.attributes);
+    // Check if the developer intends to show/hide certain attributes from serialization.
+    var attrs =
+      this.hidden ? _.omit(this.attributes, this.hidden) :
+      this.visible ? _.pick(this.attributes, this.visible) :
+      _.extend({}, this.attributes);
+
     if (options && options.shallow) return attrs;
     var relations = this.relations;
     for (var key in relations) {
@@ -167,7 +172,7 @@ _.extend(ModelBase.prototype, _.omit(Backbone.Model.prototype), Events, {
 });
 
 // List of attributes attached directly from the `options` passed to the constructor.
-var modelProps = ['tableName', 'hasTimestamps'];
+var modelProps = ['tableName', 'hasTimestamps', 'hidden', 'visible'];
 
 ModelBase.extend  = Backbone.Model.extend;
 

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -536,6 +536,25 @@ module.exports = function(Bookshelf) {
 
     });
 
+    describe('visibility', function () {
+
+      it('should only serialize properties we have set to visible', function() {
+        var m = new Bookshelf.Model({id: 1, test: 'hello', test2: 'world'}, {visible: ['test', 'test2']});
+        deepEqual(m.toJSON(), {test: 'hello', test2: 'world'});
+      });
+
+      it('should serialize all properties except the ones we have hidden', function () {
+        var m = new Bookshelf.Model({id: 1, test: 'hello', test2: 'world'}, {hidden: ['test', 'test2']});
+        deepEqual(m.toJSON(), {id: 1});
+      });
+
+      it('should resort to hidden by default if both are provided', function () {
+        var m = new Bookshelf.Model({id: 1, test: 'hello', test2: 'world'}, {hidden: ['test'], visible: ['test']});
+        deepEqual(m.toJSON(), {id: 1, test2: 'world' });
+      });
+
+    });
+
     describe('timestamp', function() {
 
       it('will set the `updated_at` attribute to a date, and the `created_at` for new entries', function() {


### PR DESCRIPTION
This will allow you to omit or include certain attributes from serialization like so...

``` js
var MyModel = Bookshelf.Model.extend({
  tableName: "my_table",
  visible: ["name", "age"]
});

var model = MyModel.forge({ id: 3, name: "David", age: 80 });
console.log(model.toJSON()); // { name: "David", age: 80 }
```

While I know there's a way to include only certain columns on a query there's probably some cases where you may want this kind of behavior across the board.

Before you merge this can you direct me on the best way to add documentation? That way I can add some docs on the previous pull request I had and this.
