### PR TITLE
Fix for plugins to actually be executed

### DIFF
--- a/bookshelf.js
+++ b/bookshelf.js
@@ -89,7 +89,7 @@ _.extend(Bookshelf.prototype, Events, {
   // injecting the current instance into the plugin, which should be a module.exports.
   plugin: function(plugin) {
     if (_.isString(plugin)) {
-      plugin = require('./plugins/' + plugin);
+      require('./plugins/' + plugin)(this);
     } else if (_.isArray(plugin)) {
       _.each(plugin, this.plugin, this);
     } else {


### PR DESCRIPTION
Just dismiss this if I missed something, but it seems like what you wanted to do is to execute the require'd plugin instead of assigning it to the `plugin` variable.
