### PR TITLE
Stop models with no virtuals from erroring

### DIFF
--- a/plugins/virtuals.js
+++ b/plugins/virtuals.js
@@ -6,6 +6,8 @@ module.exports = function (Bookshelf) {
 
   var Model = Bookshelf.Model.extend({
     outputVirtuals: true,
+    
+    virtuals: {},
 
     // If virtual properties have been defined they will be created
     // as simple getters on the model during `initialize`


### PR DESCRIPTION
Models with no virtual properties currently cause the app to crash with this error

```
Possibly unhandled TypeError: Cannot read property '£<Object>' of undefined
```

This prevents that error by adding a virtuals key to all models, even if they don't use virtuals.
