### PR TITLE
Groups related by pivot's id on belongsTo through relation.

### DIFF
--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -171,6 +171,9 @@ module.exports = function(Bookshelf) {
     },
     posts: function() {
       return this.belongsTo(Post);
+    },
+    blog: function() {
+      return this.belongsTo(Blog).through(Post);
     }
   });
 

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -2735,6 +2735,56 @@ module.exports = {
       }]
     }
   },
+  'eager loads belongsTo `through`': {
+    mysql: {
+      result: [{
+        id: 1,
+        post_id: 1,
+        name: '(blank)',
+        email: 'test@example.com',
+        comment: 'this is neat.',
+        blog:
+        { id: 1,
+          site_id: 1,
+          name: 'Main Site Blog',
+          _pivot_id: 1,
+          _pivot_blog_id: 1
+        }
+      }]
+    },
+    postgresql: {
+      result: [{
+        id: 1,
+        post_id: 1,
+        name: '(blank)',
+        email: 'test@example.com',
+        comment: 'this is neat.',
+        blog:
+        { id: 1,
+          site_id: 1,
+          name: 'Main Site Blog',
+          _pivot_id: 1,
+          _pivot_blog_id: 1
+        }
+      }]
+    },
+    sqlite3: {
+      result: [{
+        id: 1,
+        post_id: 1,
+        name: '(blank)',
+        email: 'test@example.com',
+        comment: 'this is neat.',
+        blog:
+        { id: 1,
+          site_id: 1,
+          name: 'Main Site Blog',
+          _pivot_id: 1,
+          _pivot_blog_id: 1
+        }
+      }]
+    }
+  },
   '#65 - should eager load correctly for models': {
     mysql: {
       result: {

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -32,7 +32,7 @@ module.exports = function(Bookshelf) {
     var Admins   = Collections.Admins;
     var Blogs    = Collections.Blogs;
     var Posts    = Collections.Posts;
-    var Comments = Collections.Comment;
+    var Comments = Collections.Comments;
     var Photos   = Collections.Photos;
     var Authors  = Collections.Authors;
 
@@ -475,6 +475,10 @@ module.exports = function(Bookshelf) {
 
         it('eager loads belongsToMany `through`', function() {
           return new Authors().fetch({log: true, withRelated: 'blogs'});
+        });
+
+        it('eager loads belongsTo `through`', function() {
+          return new Comments().fetch({log: true, withRelated: 'blog'});
         });
 
       });


### PR DESCRIPTION
When the relation is `belongsTo through` on eager loading, group related models by pibot's id.
This would make it possible to fetch the related model's data by eager loading on `belongsTo through` relation and
fixes issue #214.
