### PR TITLE
Integration tests for fetching within transaction block

### DIFF
--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -283,6 +283,26 @@ module.exports = function(Bookshelf) {
         return expect(model.fetch()).to.be.fulfilled;
       });
 
+      it('fetches within transaction block', function() {
+          var transactionBlock = Bookshelf.transaction(function(t){
+            var model = new Site();
+            return model.fetch({transacting: t})
+                .then(t.commit)
+                .catch(t.rollback);
+          });
+          return expect(transactionBlock).to.be.fulfilled;
+      });
+
+      it('fails when attempting to fetch within transaction block without specifying transaction', function() {
+          var transactionBlock = Bookshelf.transaction(function(t){
+            var model = new Site();
+            return model.fetch()
+                .then(t.commit)
+                .catch(t.rollback);
+          });
+          return expect(transactionBlock).to.be.rejected;
+      });
+
     });
 
     describe('save', function() {


### PR DESCRIPTION
Unit tests for issue #247.

Currently the first test passes, while the second fails in sqlite3 and affects all further tests (presumably because the transaction doesn't get committed or rolled back).
