### PR TITLE
Allow plugins to be called with an options object

### DIFF
--- a/bookshelf.js
+++ b/bookshelf.js
@@ -96,17 +96,19 @@ _.extend(Bookshelf.prototype, Events, {
 
   // Provides a nice, tested, standardized way of adding plugins to a `Bookshelf` instance,
   // injecting the current instance into the plugin, which should be a module.exports.
-  plugin: function(plugin) {
+  plugin: function(plugin, options) {
     if (_.isString(plugin)) {
       try {
-        require('./plugins/' + plugin)(this);
+        require('./plugins/' + plugin)(this, options);
       } catch (e) {
-        require(plugin)(this);
+        require(plugin)(this, options);
       }
     } else if (_.isArray(plugin)) {
-      _.each(plugin, this.plugin, this);
+      _.each(plugin, function (plugin) {
+        this.plugin(plugin, options);
+      }, this);
     } else {
-      plugin(this);
+      plugin(this, options);
     }
     return this;
   }

--- a/test/integration.js
+++ b/test/integration.js
@@ -63,6 +63,7 @@ module.exports = function(Bookshelf) {
       require('./integration/model')(bookshelf);
       require('./integration/collection')(bookshelf);
       require('./integration/relations')(bookshelf);
+      require('./integration/plugin')(bookshelf);
       require('./integration/plugins/virtuals')(bookshelf);
       require('./integration/plugins/visibility')(bookshelf);
       require('./integration/plugins/registry')(bookshelf);

--- a/test/integration/helpers/plugin.js
+++ b/test/integration/helpers/plugin.js
@@ -1,0 +1,1 @@
+module.exports = sinon.spy();

--- a/test/integration/plugin.js
+++ b/test/integration/plugin.js
@@ -1,0 +1,40 @@
+var _ = require('lodash');
+
+module.exports = function (Bookshelf) {
+
+  var options, spy;
+  beforeEach(function () {
+    options = {};
+    spy = sinon.spy();
+  });
+
+  describe('Plugin', function () {
+
+    it('can be the name of an included plugin', function () {
+      Bookshelf.plugin('registry');
+      expect(Bookshelf).to.itself.respondTo('model');
+    });
+
+    it('can be the path to a plugin', function () {
+      var plugin = require('./helpers/plugin');
+      Bookshelf.plugin('./test/integration/helpers/plugin', options);
+      expect(plugin).to.have.been.calledWith(Bookshelf, options);
+    });
+
+    it('can be an array of plugins', function () {
+      Bookshelf.plugin([spy], options);
+      expect(spy).to.have.been.calledWith(Bookshelf, options);
+    });
+
+    it('can be a function', function () {
+      Bookshelf.plugin(spy, options);
+      expect(spy).to.have.been.calledWith(Bookshelf, options);
+    });
+
+    it('returns the Bookshelf instance for chaining', function () {
+      expect(Bookshelf.plugin(spy, options)).to.equal(Bookshelf);
+    });
+
+  });
+
+};


### PR DESCRIPTION
This allows plugin calls to take place with an options object for configuration:

``` js
Bookshelf.plugin(function (bookshelf, options) {}, options);
```

It also adds tests for the various methods of passing in a plugin.
