### PR TITLE
setting attributes with a hash should process virtuals

### DIFF
--- a/plugins/virtuals.js
+++ b/plugins/virtuals.js
@@ -57,13 +57,20 @@ module.exports = function (Bookshelf) {
     // Allow virtuals to be set like normal properties
     set: function (key, val, options) {
       if (key == null) return this;
-      var virtuals = this.virtuals;
-      var virtual = virtuals && virtuals[key];
-      if (virtual && virtual.set) {
-        virtual.set.call(this, val);
-        return this;
+
+      var vSet = function (v, k) {
+        var virtual = this.virtuals && this.virtuals[k];
+        if (virtual && virtual.set) {
+          virtual.set.call(this, v);
+          return this;
+        }
+      };
+
+      if (_.isObject(key)) {
+        return proto.set.call(this, _.omit(key, vSet, this), val, options);
       }
-      return proto.set.apply(this, arguments);
+
+      return vSet.call(this, val, key) || proto.set.apply(this, arguments);
     }
   });
 

--- a/test/integration/plugins/virtuals.js
+++ b/test/integration/plugins/virtuals.js
@@ -66,6 +66,11 @@ module.exports = function (bookshelf) {
       m.set('fullName', 'Jack Shmoe');
       equal(m.get('firstName'), 'Jack');
       equal(m.get('lastName'), 'Shmoe');
+
+      m.set({fullName: 'Peter Griffin', dogName:'Brian'});
+      equal(m.get('firstName'), 'Peter');
+      equal(m.get('lastName'), 'Griffin');
+      equal(m.get('dogName'), 'Brian');
     });
 
     it('virtuals are included in the `toJSON` result by default', function () {


### PR DESCRIPTION
Thanks for this awesome library!

I noticed that calling `model.set({fullName:'joe schmoe'})` did not process the virtual. Here's a patch that implements what I believe is the desired behavior.
