### PR TITLE
Option to return fetch response as json

### DIFF
--- a/dialects/sql/collection.js
+++ b/dialects/sql/collection.js
@@ -49,7 +49,9 @@ exports.Collection = CollectionBase.extend({
       if (err !== null) throw err;
       this.reset([], {silent: true});
     })
-    .yield(this);
+    .then(function() {
+      return options.json ? Helpers.json(this) : this;
+    });
   }),
 
   // Fetches a single model from the collection, useful on related collections.

--- a/dialects/sql/helpers.js
+++ b/dialects/sql/helpers.js
@@ -47,6 +47,10 @@ exports.Helpers = {
       obj._knex[method].apply(obj._knex, args.slice(1));
     }
     return obj;
+  },
+
+  json: function(obj) {
+    return JSON.parse(JSON.stringify(obj));
   }
 
 };

--- a/dialects/sql/model.js
+++ b/dialects/sql/model.js
@@ -99,7 +99,9 @@ exports.Model = ModelBase.extend({
     return sync.tap(function(response) {
       return this.triggerThen('fetched', this, response, options);
     })
-    .yield(this)
+    .then(function() {
+      return options.json ? Helpers.json(this) : this;
+    })
     .caught(function(err) {
       if (err === null) return err;
       throw err;

--- a/test/integration/collection.js
+++ b/test/integration/collection.js
@@ -39,6 +39,21 @@ module.exports = function(Bookshelf) {
           .fetch();
       });
 
+      it('allows passing {json: true} in the options to return json rather than the populated collection', function() {
+        return Bookshelf.Collection.extend({tableName: 'posts'})
+          .forge()
+          .fetch({json: true}).then(function(obj) {
+            expect(obj).to.have.length(5);
+            expect(obj[0]).to.eql({
+              "id":1,
+              "owner_id":1,
+              "blog_id":1,
+              "name":"This is a new Title!",
+              "content":"Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est."
+            });
+          });
+      });
+
     });
 
     describe('fetchOne', function() {

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -283,6 +283,13 @@ module.exports = function(Bookshelf) {
         return expect(model.fetch()).to.be.fulfilled;
       });
 
+      it('allows passing {json: true} in the options to return json rather than the populated model', function() {
+        var model = new Site({id: 1});
+        return model.fetch({json: true}).then(function(obj) {
+          expect(obj).to.eql({id: 1, name: 'knexjs.org'});
+        });
+      });
+
     });
 
     describe('save', function() {


### PR DESCRIPTION
Got a request about how to just get the json from a query, so I thought I'd maybe see what others thought and whether this should be added as a built in flag, or left to the user to implement... It's pretty simple, and I'm wary of "optionitis" by adding another flag to the fetch, but I could see the benefits.

Still correctly populates the underlying model & collection.
