### PR TITLE
fetchOne resets query on original object

### DIFF
--- a/dialects/sql/collection.js
+++ b/dialects/sql/collection.js
@@ -56,6 +56,7 @@ exports.Collection = CollectionBase.extend({
   fetchOne: Promise.method(function(options) {
     var model = new this.model;
     model._knex = this.query().clone();
+    this.resetQuery();
     if (this.relatedData) model.relatedData = this.relatedData;
     return model.fetch(options);
   }),


### PR DESCRIPTION
Before this change, a fetchOne call does not reset the query on the original object like a fetch call does. Thus consecutive fetchOne's will result in queries after the first using the conditions from the sum of previous queries.
i.e.
Animals.query({name: 'cat'}).fetchOne() // queries for where name = "cat"
//some time later
Animals.query({name: 'dog'}).fetchOne() // queries for where name = "cat" and name = "dog"

calling resetQuery after copying the query to model solves the problem.
