### PR TITLE
Fix typo in index.html for docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1043,7 +1043,7 @@ new Book({id: 1}).fetch({withRelated: ['author']}).then(function(book) {
       <b class="header">belongsToMany</b><code>model.belongsToMany(Target, [table], [foreignKey], [otherKey])</code>
       <br />
       The <tt>belongsToMany</tt> method defines a many-to-many relation, where the current <b>model</b>
-      is joined to one ore more of a <b>Target</b> model through another <b>table</b>. The default name for
+      is joined to one or more of a <b>Target</b> model through another <b>table</b>. The default name for
       the joining table is the two table names, joined by an underscore, ordered alphabetically. For example, a
       <tt>users</tt> table and an <tt>accounts</tt> table would have a joining table of <tt>accounts_users</tt>.
 


### PR DESCRIPTION
As shown in screenshot below, there is a typo in the documentation for belongsToMany. The only change I've made to the index.html file is to fix this typo from "ore" to "or".

![typo in belongstomany](https://f.cloud.github.com/assets/2865947/2521789/22d47520-b4b1-11e3-8d66-0713911f92f6.png)
