### PR TITLE
Documentation of eager vs. lazy loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -889,7 +889,7 @@ new Book({id: 2}).fetch({
 </pre>
 
     <p>
-      You may also want to eagerly load related models on a model or collection after it has already been fetched.
+      You may also want to lazy load related models on a model or collection after it has already been fetched.
       For this, you may use the <a href="#Model-load">load</a> method to specify which relations should be eagerly
       loaded on the model or collection.
     </p>


### PR DESCRIPTION
Noticed this inconsistency in the docs. Eagerly loading usually refers to loading relations at the same time, not later.
