### PR TITLE
Fix spacing in relation error message

### DIFF
--- a/bookshelf.js
+++ b/bookshelf.js
@@ -48,7 +48,7 @@ var Bookshelf = function(knex) {
     _relation: function(type, Target, options) {
       if (type !== 'morphTo' && !_.isFunction(Target)) {
         throw new Error('A valid target model must be defined for the ' +
-          _.result(this, 'tableName') + ' ' + type + 'relation');
+          _.result(this, 'tableName') + ' ' + type + ' relation');
       }
       return new Relation(type, Target, options);
     }


### PR DESCRIPTION
Just came across this error in my usage of Bookshelf.js, and noticed it was missing a space in the error log. Kinda bothered me, so I thought I'd just fix it.

Before:
`A valid target model must be defined for the users belongsTorelation`

After:
`A valid target model must be defined for the users belongsTo relation`
