### PR TITLE
allow _pivot_ keys to be hidden in model.toJSON()

### DIFF
--- a/dialects/base/model.js
+++ b/dialects/base/model.js
@@ -89,7 +89,7 @@ _.extend(ModelBase.prototype, _.omit(Backbone.Model.prototype, modelOmitted), Ev
     var relations = this.relations;
     for (var key in relations) {
       var relation = relations[key];
-      attrs[key] = relation.toJSON ? relation.toJSON() : relation;
+      attrs[key] = relation.toJSON ? relation.toJSON(options) : relation;
     }
     if (options && options.noPivot) return attrs;
     if (this.pivot) {


### PR DESCRIPTION
I found this really useful, since I end up dumping models through an API with little (if any) modification on the server side.

This way only information that's actually directly on the model or its relations gets shown.
