### PR TITLE
timestamps should be in ISO8601 format

### DIFF
--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -131,7 +131,7 @@ _.extend(ModelBase.prototype, _.omit(Backbone.Model.prototype, modelOmitted), Ev
 
   // Sets the timestamps before saving the model.
   timestamp: function(options) {
-    var d = new Date();
+    var d = (new Date()).toISOString();
     var keys = (_.isArray(this.hasTimestamps) ? this.hasTimestamps : ['created_at', 'updated_at']);
     var vals = {};
     if (keys[1]) vals[keys[1]] = d;


### PR DESCRIPTION
When dealing with databases and timestamps, its a good idea to format timestamps in ISO8601.

https://github.com/interagent/http-api-design#use-utc-times-formatted-in-iso8601
