### PR TITLE
Added error references to models/collections as shown in the docs.

### DIFF
--- a/bookshelf.js
+++ b/bookshelf.js
@@ -150,6 +150,8 @@ Bookshelf.initialize = function(knex) {
   Model.fetchAll = function(options) { return this.forge().fetchAll(options); };
 
   Model.extend = Collection.extend = require('simple-extend');
+  Model.NotFoundError = Errors.NotFoundError;
+  Collection.EmptyError = Errors.EmptyError;
 
   return bookshelf;
 };


### PR DESCRIPTION
In the docs, there is an example, which was not working because the error constructors are not attached to the models.

```
Customer.login(email, password)
  .then(function(customer) {
    res.json(customer.omit('password'));
  }).catch(Customer.NotFoundError, function() {
    res.json(400, {error: email + ' not found'});
  }).catch(function(err) {
    console.error(err);
  });
```
