### PR TITLE
Feature/refresh entire model

### DIFF
--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -15,7 +15,7 @@ var modelOmitted = [
 ];
 
 // List of attributes attached directly from the `options` passed to the constructor.
-var modelProps = ['tableName', 'hasTimestamps', 'refreshEntireModel'];
+var modelProps = ['tableName', 'hasTimestamps', 'refreshEntireModel', 'disableImplicitReturning'];
 
 // The "ModelBase" is similar to the 'Active Model' in Rails,
 // it defines a standard interface from which other objects may

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -15,7 +15,7 @@ var modelOmitted = [
 ];
 
 // List of attributes attached directly from the `options` passed to the constructor.
-var modelProps = ['tableName', 'hasTimestamps'];
+var modelProps = ['tableName', 'hasTimestamps', 'refreshEntireModel'];
 
 // The "ModelBase" is similar to the 'Active Model' in Rails,
 // it defines a standard interface from which other objects may

--- a/lib/model.js
+++ b/lib/model.js
@@ -209,10 +209,18 @@ _.extend(BookshelfModel.prototype, {
       .then(function(resp) {
 
         // After a successful database save, the id is updated if the model was created
-        if (method === 'insert' && this.id == null) {
-          this.attributes[this.idAttribute] = this.id = resp[0];
-        } else if (method === 'update' && resp === 0) {
-          throw new Error('No rows were affected in the update, did you mean to pass the {method: "insert"} option?');
+        if (method === 'insert') {
+          if (this.refreshEntireModel) {
+            this._handleResponse(resp);
+          } else if (this.id == null) {
+            this.attributes[this.idAttribute] = this.id = resp[0];
+          }
+        } else if (method === 'update') {
+          var length = this.refreshEntireModel ? resp.length : resp;
+          if (length === 0 && options.require) {
+            throw new Error('No rows were affected in the update, did you mean to pass the {method: "insert"} option?');
+          }
+          if (this.refreshEntireModel) { this._handleResponse(resp); }
         }
 
         // In case we need to reference the `previousAttributes` for the this

--- a/lib/model.js
+++ b/lib/model.js
@@ -217,7 +217,7 @@ _.extend(BookshelfModel.prototype, {
           }
         } else if (method === 'update') {
           var length = this.refreshEntireModel ? resp.length : resp;
-          if (length === 0 && options.require) {
+          if (length === 0) { // should there be an options.require check here?
             throw new Error('No rows were affected in the update, did you mean to pass the {method: "insert"} option?');
           }
           if (this.refreshEntireModel) { this._handleResponse(resp); }

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -71,8 +71,12 @@ _.extend(Sync.prototype, {
   // Issues an `insert` command on the query - only used by models.
   insert: Promise.method(function() {
     var syncing = this.syncing;
-    var returning = syncing.refreshEntireModel ? '*' : syncing.idAttribute;
-    return this.query.insert(syncing.format(_.extend(Object.create(null), syncing.attributes)), returning);
+    var query = this.query.insert(syncing.format(_.extend(Object.create(null), syncing.attributes)));
+    if (!syncing.disableImplicitReturning) {
+      var returning = syncing.refreshEntireModel ? '*' : syncing.idAttribute;
+      query.returning(returning);
+    }
+    return query;
   }),
 
   // Issues an `update` command on the query - only used by models.
@@ -82,7 +86,7 @@ _.extend(Sync.prototype, {
     if (_.where(query._statements, {grouping: 'where'}).length === 0) {
       throw new Error('A model cannot be updated without a "where" clause or an idAttribute.');
     }
-    if (syncing.refreshEntireModel) { query.returning('*'); }
+    if (syncing.refreshEntireModel && !syncing.disableImplicitReturning) { query.returning('*'); }
     return query.update(syncing.format(_.extend(Object.create(null), attrs)));
   }),
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -71,7 +71,8 @@ _.extend(Sync.prototype, {
   // Issues an `insert` command on the query - only used by models.
   insert: Promise.method(function() {
     var syncing = this.syncing;
-    return this.query.insert(syncing.format(_.extend(Object.create(null), syncing.attributes)), syncing.idAttribute);
+    var returning = syncing.refreshEntireModel ? '*' : syncing.idAttribute;
+    return this.query.insert(syncing.format(_.extend(Object.create(null), syncing.attributes)), returning);
   }),
 
   // Issues an `update` command on the query - only used by models.
@@ -81,6 +82,7 @@ _.extend(Sync.prototype, {
     if (_.where(query._statements, {grouping: 'where'}).length === 0) {
       throw new Error('A model cannot be updated without a "where" clause or an idAttribute.');
     }
+    if (syncing.refreshEntireModel) { query.returning('*'); }
     return query.update(syncing.format(_.extend(Object.create(null), attrs)));
   }),
 


### PR DESCRIPTION
A couple of options that we found handy when working with postgres. Bookshelf by default just does `returning id` to run the same codepath as mysql, I'm guessing? 

But postgres supports `returning *`, and it's often very useful to refresh the entire model on updates and inserts. 

Similarly, you can't override the `returning` option set in `sync.js`, if you need to do any other transformations on the row, because it sets the `returning` option again just before running the query. So the second option is there to avoid setting that, on the assumption that the user will specify the appropriate `returning` in the `fetching` and `saving` hooks. 

I get the sense that these two options are _not at all_ the Bookshelf Way of implementing these features, so I'm happy to work with you guys here to make them into something that fits in Bookshelf proper.

(Also, I would appreciate advice on what tests where would be desirable.)

Thanks!
