### PR TITLE
Only format attributes locally for selecting keys for inverse relationships

### DIFF
--- a/lib/relation.js
+++ b/lib/relation.js
@@ -27,15 +27,18 @@ _.extend(BookshelfRelation.prototype, {
     this.parentIdAttribute = _.result(parent, 'idAttribute');
 
     if (this.isInverse()) {
+      // use formatted attributes so that morphKey and foreignKey will match
+      // attribute keys
+      var attributes = parent.format(_.clone(parent.attributes));
+
       // If the parent object is eager loading, and it's a polymorphic `morphTo` relation,
       // we can't know what the target will be until the models are sorted and matched.
       if (this.type === 'morphTo' && !parent._isEager) {
-        parent.attributes = parent.format(parent.attributes);
-        this.target = Helpers.morphCandidate(this.candidates, parent.get(this.key('morphKey')));
+        this.target = Helpers.morphCandidate(this.candidates, attributes[this.key('morphKey')]);
         this.targetTableName   = _.result(this.target.prototype, 'tableName');
         this.targetIdAttribute = _.result(this.target.prototype, 'idAttribute');
       }
-      this.parentFk = parent.get(this.key('foreignKey'));
+      this.parentFk = attributes[this.key('foreignKey')];
     } else {
       this.parentFk = parent.id;
     }

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -1642,6 +1642,35 @@ module.exports = {
       }
     }
   },
+  'has no side effects for morphTo (imageable "authors", PhotoParsed)': {
+    mysql: {
+      result: {
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'authors',
+        id_parsed: 1,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.'
+      }
+    },
+    postgresql: {
+      result: {
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'authors',
+        id_parsed: 1,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.'
+      }
+    },
+    sqlite3: {
+      result: {
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'authors',
+        id_parsed: 1,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.'
+      }
+    }
+  },
   'handles morphTo (imageable "sites")': {
     mysql: {
       result: {

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -422,6 +422,14 @@ module.exports = function(Bookshelf) {
             .fetch().tap(checkTest(this));
         });
 
+        it('has no side effects for morphTo (imageable "authors", PhotoParsed)', function() {
+          var photoParsed = new PhotoParsed({imageable_id_parsed: 1, imageable_type_parsed: 'authors'})
+          return photoParsed.imageableParsed().fetch()
+          .then( function() {
+            return photoParsed.fetch()
+          }).then(checkTest(this));
+        });
+
         it('handles morphTo (imageable "sites")', function() {
           return new Photo({imageable_id: 1, imageable_type: 'sites'})
             .imageable()


### PR DESCRIPTION
In pull request #430, I formatted the models attributes in order to correctly obtain the morphValue and foreignKey. I should only have done this locally, not formatted the model's attributes, as this is an undesired side effect. 
