### PR TITLE
upgrade bluebird dependency to >=2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "backbone": "1.1.0",
     "inflection": "~1.3.5",
     "trigger-then": "0.3.x",
-    "bluebird": "~2.0.5",
+    "bluebird": ">=2.0.5",
     "lodash": ">=2.0.0",
     "simple-extend": "0.1.0",
     "inherits": "~2.0.1",


### PR DESCRIPTION
Same story as https://github.com/tgriesser/knex/pull/401.
This changes the bluebird dependency to pull in the more recent releases.

Tests passed locally.
