### PR TITLE
add faling test for working with default values

### DIFF
--- a/test/integration/helpers/inserts.js
+++ b/test/integration/helpers/inserts.js
@@ -193,7 +193,7 @@ module.exports = function(bookshelf) {
 
     knex('Settings').insert([
       {id: 1, Customer_id: 1, data: 'Europe/Paris'},
-      {id: 2, Customer_id: 4, data: 'UTC'}
+      {id: 2, Customer_id: 4, data: 'UTC', isActive: false}
     ]),
 
     knex('hostnames').insert([

--- a/test/integration/helpers/migration.js
+++ b/test/integration/helpers/migration.js
@@ -110,6 +110,7 @@ module.exports = function(Bookshelf) {
     .createTable('Settings', function(table) {
       table.increments('id');
       table.integer('Customer_id').notNullable();
+      table.bool('isActive').notNullable().defaultTo(true);
       table.string('data', 64);
     })
     .createTable('hostnames', function(table){

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -224,7 +224,13 @@ module.exports = function(Bookshelf) {
     model: Photo
   });
 
-  var Settings = Bookshelf.Model.extend({ tableName: 'Settings' });
+  var Settings = Bookshelf.Model.extend({
+    tableName: 'Settings',
+    parse: function(attrs) {
+      attrs.isActive = Boolean(attrs.isActive === 1);
+      return attrs;
+    }
+  });
 
   var Customer = Bookshelf.Model.extend({
     tableName: 'Customer',

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -189,6 +189,12 @@ module.exports = function(bookshelf) {
         var shallow = m.toJSON({shallow:true});
         deepEqual(_.keys(shallow), ['id', 'name']);
       });
+
+      it('should contain native boolean types', function() {
+        var m = new (bookshelf.Model.extend({
+        }))({'isTrue': true, 'isFalse': false});
+        deepEqual(m.toJSON(), {'isTrue': true, 'isFalse': false});
+      });
     });
 
     describe('parse', function() {

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -498,7 +498,8 @@ module.exports = function(Bookshelf) {
           settings: {
             id : 1,
             Customer_id : 1,
-            data : 'Europe/Paris'
+            data : 'Europe/Paris',
+            isActive: true
           }
         };
 
@@ -518,7 +519,8 @@ module.exports = function(Bookshelf) {
           settings: {
             id : 2,
             Customer_id : 4,
-            data : 'UTC'
+            data : 'UTC',
+            isActive: false
           }
         };
 


### PR DESCRIPTION
how I can get the this test pass? It looks like bookshelf/knex ignores the default value from the migration.
If I create a model like `new Settings({id: 1, Customer_id: 1, data: 'Europe/Paris'})` it looks like, bookshelf tries to insert a row with a nullable value for `isActive` instead of skipping the field.
