### PR TITLE
allow bookshelf assign knex instance

### DIFF
--- a/bookshelf.js
+++ b/bookshelf.js
@@ -60,7 +60,7 @@ Bookshelf.initialize = function(knex) {
 
   Model.prototype._builder =
   Collection.prototype._builder = function(tableName) {
-    var builder  = knex(tableName);
+    var builder  = bookshelf.knex(tableName);
     var instance = this;
     return builder.on('query', function(data) {
       instance.trigger('query', data);

--- a/browser/bookshelf.js
+++ b/browser/bookshelf.js
@@ -61,7 +61,7 @@ Bookshelf.initialize = function(knex) {
 
   Model.prototype._builder =
   Collection.prototype._builder = function(tableName) {
-    var builder  = knex(tableName);
+    var builder  = bookshelf.knex(tableName);
     var instance = this;
     return builder.on('query', function(data) {
       instance.trigger('query', data);


### PR DESCRIPTION
After bookshelf instanciation with require, we can dynamically pass another knex instance to bookshelf.

```
var knex = require('knex')({...});
var bookshelf = require('bookshelf')(knex);

knex = require('knex')({...});
bookshelf.knex = knex;
```
