### PR TITLE
Fixing stack overflow with model list as arguments

### DIFF
--- a/lib/base/collection.js
+++ b/lib/base/collection.js
@@ -11,7 +11,6 @@ var Promise   = require('./promise');
 var ModelBase = require('./model');
 
 var array  = [];
-var push   = array.push;
 var splice = array.splice;
 
 var CollectionBase = function(models, options) {
@@ -111,8 +110,14 @@ _.extend(CollectionBase.prototype, _.omit(Backbone.Collection.prototype, collect
       if (at != null) {
         splice.apply(this.models, [at, 0].concat(toAdd));
       } else {
-        if (order) this.models.length = 0;
-        push.apply(this.models, order || toAdd);
+        if (order) {
+          this.models.length = 0;
+        } else {
+          order = toAdd;
+        }
+        for (i = 0, l = order.length; i < l; ++i) {
+          this.models.push(order[i]);
+        }
       }
     }
 

--- a/test/base/tests/collection.js
+++ b/test/base/tests/collection.js
@@ -90,6 +90,21 @@ module.exports = function() {
         collection.set([{some_id: 3, name: 'WontAdd'}], {add: false});
         equal(collection.get(3), undefined);
       });
+
+      it('should support large arrays', function() {
+        var count = 200000;
+        var models = [];
+        var i;
+
+        for (i = 0; i < count; ++i) {
+          models.push(new collection.model({
+            some_id: i, 
+            name: 'Large-' + i
+          }));
+        }
+        collection.set(models, {add: true, remove: false, merge: false});
+        equal(collection.get(count - 1).get('name'), 'Large-' + (count - 1));
+      });
     });
 
     it('should use the `reset` method, to reset the collection', function() {


### PR DESCRIPTION
Attempting to perform a base collection set with a large (~200000+)
array results in a stack overflow as the array is expanded into
arguments for Array.prototype.push.  Switching to an array iteration to
prevent this, and added a unit test that tests the exceptionally sized
array set.
