### PR TITLE
Event.once may return something or promise

### DIFF
--- a/lib/base/events.js
+++ b/lib/base/events.js
@@ -4,6 +4,18 @@
 var Promise     = require('./promise');
 var Backbone    = require('backbone');
 var triggerThen = require('trigger-then');
+var _ = require('underscore');
+
+Backbone.Events.once = function(name, callback, context) {
+    //if (!eventsApi(this, 'once', name, [callback, context]) || !callback) return this;
+    var self = this;
+    var once = _.once(function() {
+        self.off(name, once);
+        return callback.apply(this, arguments);
+    });
+    once._callback = callback;
+    return this.on(name, once, context);
+};
 
 // Mixin the `triggerThen` function into all relevant Backbone objects,
 // so we can have event driven async validations, functions, etc.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "active record"
   ],
   "dependencies": {
+    "underscore": ">=1.4.3",
     "backbone": "1.1.0",
     "inflection": "~1.3.5",
     "trigger-then": "0.3.x",


### PR DESCRIPTION
In case of resolving 'once' even by triggerThen, now 'once' **do** not return _undefined_, but the callback return value (example : a promise).
