### PR TITLE
add a forUpdate option to sync

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -9,12 +9,16 @@ var Promise = require('./base/promise');
 // If the `transacting` option is set, the query is assumed to be
 // part of a transaction, and this information is passed along to `Knex`.
 var Sync = function(syncing, options) {
+  var temp;
   options = options || {};
   this.query   = syncing.query();
   this.syncing = syncing.resetQuery();
   this.options = options;
   if (options.debug) this.query.debug();
-  if (options.transacting) this.query.transacting(options.transacting);
+  if (options.transacting) {
+    temp = this.query.transacting(options.transacting);
+    if (options.forUpdate) temp.forUpdate();
+  }
 };
 
 _.extend(Sync.prototype, {


### PR DESCRIPTION
Any chance for a quality of life change to allow something like

```
MyModel.forge({id:1}).fetch({transacting:t, forUpdate: true});
```
