### PR TITLE
Add a withRelatedColumns option for fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -559,6 +559,7 @@ new Book({'ISBN-13': '9780440180296'})
       the model, may be retrieved with the <a href="#Model-related">related</a> method, and will
       be serialized as properties on a <a href="#Model-toJSON">toJSON</a> call unless
       <tt>{shallow: true}</tt> is passed.
+      You can specify <tt>withRelatedColumns</tt> in order to only fetch specific columns.
     </p>
 
 <pre><code>
@@ -573,7 +574,8 @@ var Book = bookshelf.Model.extend({
 })
 
 new Book({'ISBN-13': '9780440180296'}).fetch({
-  withRelated: ['genre', 'editions']
+  withRelated: ['genre', 'editions'],
+  withRelatedColumns: {genre: ['id']}
 }).then(function(book) {
   console.log(book.related('genre').toJSON());
   console.log(book.related('editions').toJSON());
@@ -1752,6 +1754,7 @@ var tabs = new TabSet([tab1, tab2, tab3]);
       the respective models, may be retrieved with the <a href="#Model-related">related</a> method, and will
       be serialized as properties on a <a href="#Model-toJSON">toJSON</a> call unless
       <tt>{shallow: true}</tt> is passed.
+      You can specify <tt>withRelatedColumns</tt> in order to only fetch specific columns.
     </p>
 
     <p id="Collection-fetchOne">

--- a/lib/base/eager.js
+++ b/lib/base/eager.js
@@ -63,11 +63,16 @@ _.extend(EagerBase.prototype, {
     // all necessary pairing with parent objects, etc.
     var pendingDeferred = [];
     for (relationName in handled) {
-      pendingDeferred.push(this.eagerFetch(relationName, handled[relationName], _.extend({}, options, {
+      var eagerFetchOptions =  _.extend({}, options, {
         isEager: true,
         withRelated: subRelated[relationName],
-        beforeFn: withRelated[relationName] || noop
-      })));
+        beforeFn: withRelated[relationName] || noop,
+      });
+      if (options.withRelatedColumns) {
+        eagerFetchOptions.columns = options.withRelatedColumns[relationName];
+      }
+
+      pendingDeferred.push(this.eagerFetch(relationName, handled[relationName], eagerFetchOptions));
     }
 
     // Return a deferred handler for all of the nested object sync

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -159,6 +159,38 @@ module.exports = {
       }
     }
   },
+  'eager loads "hasOne" relationships withRelatedColumns correctly (site -> meta)': {
+    mysql: {
+      result: {
+        id: 1,
+        name: 'knexjs.org',
+        meta: {
+          id: 1,
+          site_id: 1,
+        }
+      }
+    },
+    postgresql: {
+      result: {
+        id: 1,
+        name: 'knexjs.org',
+        meta: {
+          id: 1,
+          site_id: 1,
+        }
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 1,
+        name: 'knexjs.org',
+        meta: {
+          id: 1,
+          site_id: 1,
+        }
+      }
+    }
+  },
   'eager loads "hasMany" relationships correctly (site -> authors, blogs)': {
     mysql: {
       result: {
@@ -453,6 +485,77 @@ module.exports = {
           id: 2,
           site_id: 2,
           description: 'This is a description for the Bookshelfjs Site'
+        }
+      },{
+        id: 3,
+        name: 'backbonejs.org',
+        meta: {
+
+        }
+      }]
+    }
+  },
+  'eager loads "hasOne" models withRelatedColumns correctly (sites -> meta)': {
+    mysql: {
+      result: [{
+        id: 1,
+        name: 'knexjs.org',
+        meta: {
+          id: 1,
+          site_id: 1,
+        }
+      },{
+        id: 2,
+        name: 'bookshelfjs.org',
+        meta: {
+          id: 2,
+          site_id: 2,
+        }
+      },{
+        id: 3,
+        name: 'backbonejs.org',
+        meta: {
+
+        }
+      }]
+    },
+    postgresql: {
+      result: [{
+        id: 1,
+        name: 'knexjs.org',
+        meta: {
+          id: 1,
+          site_id: 1,
+        }
+      },{
+        id: 2,
+        name: 'bookshelfjs.org',
+        meta: {
+          id: 2,
+          site_id: 2,
+        }
+      },{
+        id: 3,
+        name: 'backbonejs.org',
+        meta: {
+
+        }
+      }]
+    },
+    sqlite3: {
+      result: [{
+        id: 1,
+        name: 'knexjs.org',
+        meta: {
+          id: 1,
+          site_id: 1,
+        }
+      },{
+        id: 2,
+        name: 'bookshelfjs.org',
+        meta: {
+          id: 2,
+          site_id: 2,
         }
       },{
         id: 3,


### PR DESCRIPTION
I wanted to be able  to specify which columns would be fetched when I use the withRelated option of fetch. This can now be done using the withRelatedColumns option. For example

```
new Book({'ISBN-13': '9780440180296'}).fetch({
  withRelated: ['genre', 'editions'],
  withRelatedColumns: {genre: ['id']}
});
```

will fetch all columns for `editions`, but only the `id` for the `genre` table.
