### PR TITLE
forUpdate and forShare in sync.js

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -14,7 +14,11 @@ var Sync = function(syncing, options) {
   this.syncing = syncing.resetQuery();
   this.options = options;
   if (options.debug) this.query.debug();
-  if (options.transacting) this.query.transacting(options.transacting);
+  if (options.transacting) {
+    this.query.transacting(options.transacting);
+    if (options.forUpdate) this.query.forUpdate();
+    if (options.forShare)  this.query.forShare();
+  }
 };
 
 _.extend(Sync.prototype, {


### PR DESCRIPTION
This would just be super handy. You could now pass through an `options` object into all of the child `fetch`es and `save`s of an object, without having to manually say `this.once('fetching' ... options.query.forShare())` on all of them.
