### PR TITLE
fixes #522; more specific error thrown when no rows are updated

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -7,6 +7,9 @@ module.exports = {
 
   // Thrown when the collection is empty and {require: true} is passed in model.fetchAll or
   // collection.fetch
-  EmptyError: createError('EmptyError')
+  EmptyError: createError('EmptyError'),
+
+  // Thrown when an update affects no rows and {require: true} is passed in model.save.
+  NoRowsUpdatedError: createError('NoRowsUpdatedError')
 
 };

--- a/lib/model.js
+++ b/lib/model.js
@@ -173,6 +173,11 @@ _.extend(BookshelfModel.prototype, {
       options = options ? _.clone(options) : {};
     }
 
+    // Set options.require to true by default.
+    if (options.require !== false) {
+      options.require = true;
+    }
+
     return Promise.bind(this).then(function() {
       return this.isNew(options);
     }).then(function(isNew) {
@@ -219,8 +224,8 @@ _.extend(BookshelfModel.prototype, {
         // After a successful database save, the id is updated if the model was created
         if (method === 'insert' && this.id == null) {
           this.attributes[this.idAttribute] = this.id = resp[0];
-        } else if (method === 'update' && resp === 0) {
-          throw new Error('No rows were affected in the update, did you mean to pass the {method: "insert"} option?');
+        } else if (method === 'update' && resp === 0 && options.require) {
+          throw new Errors.NoRowsUpdatedError('EmptyResponse');
         }
 
         // In case we need to reference the `previousAttributes` for the this

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -350,9 +350,13 @@ module.exports = function(bookshelf) {
         return new Site({id: 200, name: 'This doesnt exist'}).save().then(function() {
           throw new Error('This should not succeed');
         }, function(err) {
-          expect(err.message).to.equal('No rows were affected in the update, did you mean to pass the {method: "insert"} option?');
+          expect(err.message).to.equal('EmptyResponse');
         });
 
+      });
+
+      it('does not error if if the row was not updated but require is false', function() {
+        return new Site({id: 200, name: 'This doesnt exist'}).save({}, {require: false});
       });
 
       it('should not error if updated row was not affected', function() {


### PR DESCRIPTION
Fix for #522. Some of the design decisions were made in that thread.

This should make it easier to handle cases where updates are not required to be made on a save, and also to catch a specific error in the case that updates are expected.

I'm relatively new to node and JS so any feedback is greatly appreciated.
