### PR TITLE
Cast plugin

### DIFF
--- a/plugins/cast.js
+++ b/plugins/cast.js
@@ -1,0 +1,41 @@
+var _       = require('lodash');
+
+module.exports = function (Bookshelf) {
+
+  var proto = Bookshelf.Model.prototype;
+
+  var Model = Bookshelf.Model.extend({
+
+    set: function (key, value, options) {
+      if (!key) {
+        return this;
+      }
+      var attrs, value;
+      if (_.isObject(key)) {
+        attrs = key;
+        options = value;
+      } else {
+        (attrs = {})[key] = value;
+      }
+      if (this.cast) {
+        var cast;
+        for (var attr in attrs) {
+          if (cast = _cast(this, attr, attrs[attr])) {
+            attrs[attr] = cast;
+          }
+        }
+      }
+      return proto.set.call(this, attrs, options);
+    },
+
+  });
+
+  Bookshelf.Model = Model;
+
+}
+
+function _cast (model, attr, value) {
+  if (!value) return;
+  var cast = model.cast[attr];
+  if (cast) return cast(value);
+}

--- a/test/integration/plugins/cast.js
+++ b/test/integration/plugins/cast.js
@@ -1,0 +1,53 @@
+var _         = require('lodash');
+var equal     = require('assert').equal;
+var deepEqual = require('assert').deepEqual;
+
+module.exports = function (bookshelf) {
+
+  describe('Cast plugin', function () {
+    before(function() {
+      bookshelf.plugin('cast');
+    });
+
+    it('allows to cast model properties using a function', function () {
+      var m = new (bookshelf.Model.extend({
+        cast: {
+          dateTime: function(value) {
+            return new Date(value);
+          }
+        }
+      }))({dateTime: '2015-01-01'});
+
+      equal(m.dateTime, new Date('2015-01-01'));
+    });
+
+    it('allows casted properties to be set and get like normal properties', function () {
+      var m = new (bookshelf.Model.extend({
+        cast: {
+          dateTime: function(value) {
+            return new Date(value);
+          }
+        }
+      }))({dateTime: '2015-01-01'});
+
+      equal(m.get('dateTime'), new Date('2015-01-01'));
+
+      m.set({dateTime: '2015-02-02'});
+      equal(m.get('dateTime'), new Date('2015-02-02'));
+    });
+
+    it('allows casted properties to be set in the constructor', function () {
+      var m = new (bookshelf.Model.extend({
+        cast: {
+          dateTime: function(value) {
+            return new Date(value);
+          }
+        }
+      }))({dateTime: '2015-01-01'});
+
+      equal(m.get('dateTime'), new Date('2015-01-01'));
+    });
+
+  });
+  
+};


### PR DESCRIPTION
Plugin to specify a function for casting property values.

``` javascript
var Book = Bookshelf.Model.extend({
  cast: {
    dateTime: function (value) {
      return new Date(value);
    }
  }
});

var b = new Book({dateTime: '2015-01-01'});
b.get('date'); // returns Date object

```
