### PR TITLE
Run modelMethods on toJSON output not attributes

### DIFF
--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -218,7 +218,7 @@ var modelMethods = ['keys', 'values', 'pairs', 'invert', 'pick', 'omit'];
 _.each(modelMethods, function(method) {
   ModelBase.prototype[method] = function() {
     var args = slice.call(arguments);
-    args.unshift(this.attributes);
+    args.unshift(this.toJSON());
     return _[method].apply(_, args);
   };
 });

--- a/plugins/virtuals.js
+++ b/plugins/virtuals.js
@@ -76,7 +76,7 @@ module.exports = function (Bookshelf) {
   _.each(modelMethods, function(method) {
     Model.prototype[method] = function() {
       var args = _.toArray(arguments);
-      args.unshift(_.extend({}, this.attributes, getVirtuals(this)));
+      args.unshift(_.extend({}, this.toJSON(), getVirtuals(this)));
       return _[method].apply(_, args);
     };
   });


### PR DESCRIPTION
The best way I've found to remove a password from a user object is via
the `omit` method.  This matches up with the documentation that shows
the following example:

``` javascript
Customer.login(email, password).then(function(customer) {
  res.json(customer.omit('password'));
})
```

This works great until you use `withRelated` to fetch a user profile,
for instance.  `omit` will run on the `attributes` not the merged
output, so using the above example would strip out the fetched
additionals.

This PR is my naive solution at fixing the problem.  I updated the base
model to use `toJSON` as well as the virtuals plugin.

Let me know if anything else needs documenting or if is avoidable
intentional behavior.
