### PR TITLE
Support `isNew` returning a Promise.

### DIFF
--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -2,6 +2,8 @@
 // ---------------
 'use strict';
 
+var _helpers = require('../helpers');
+
 var _ = require('lodash');
 var inherits = require('inherits');
 
@@ -414,15 +416,35 @@ ModelBase.prototype.saveMethod = function (options) {
  *
  * @returns {Object} A hash of timestamp attributes that were set.
  */
-ModelBase.prototype.timestamp = function (options) {
+ModelBase.prototype.timestamp = function () {
+  var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+  // Ensure that passed in `options.method` is checked before `isNew`
+  // to support returning a promise from an overridden `isNew`.
+  options.method = _helpers.normalizeSaveMethod(options.method) || (this.isNew() ? 'insert' : 'update');
+
+  return this._timestamp(options);
+};
+
+ModelBase.prototype._timestampKeys = function () {
+  var timestamps = this.hasTimestamps;
+  if (_.isArray(timestamps)) {
+    return timestamps;
+  }
+  return timestamps ? ['created_at', 'updated_at'] : [];
+};
+
+ModelBase.prototype._timestamp = function (options) {
   if (!this.hasTimestamps) return {};
 
   var now = new Date();
   var attributes = {};
-  var method = this.saveMethod(options);
-  var keys = _.isArray(this.hasTimestamps) ? this.hasTimestamps : ['created_at', 'updated_at'];
-  var createdAtKey = keys[0];
-  var updatedAtKey = keys[1];
+  var method = options.method;
+
+  var _timestampKeys = this._timestampKeys();
+
+  var createdAtKey = _timestampKeys[0];
+  var updatedAtKey = _timestampKeys[1];
 
   if (updatedAtKey) {
     attributes[updatedAtKey] = now;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -7,6 +7,16 @@ var chalk = require('chalk');
 
 var helpers = {
 
+  normalizeSaveMethod: function normalizeSaveMethod(method) {
+    if (method == null) return undefined;
+    var result = undefined;
+    if (_.isString(method)) {
+      result = method.toLowerCase();
+    }
+    if (result !== 'update' && result !== 'insert') throw new TypeError('Expected `method` to be either "update" or "insert". Got `' + method + '`');
+    return result;
+  },
+
   // Sets the constraints necessary during a `model.save` call.
   saveConstraints: function saveConstraints(model, relatedData) {
     var data = {};

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
 var _lodash = require('lodash');
@@ -558,7 +560,7 @@ var BookshelfModel = _baseModel2['default'].extend({
 
     // If this is new, we use all its attributes. Otherwise we just grab the
     // primary key.
-    var attributes = this.isNew() ? this.attributes : _lodash2['default'].pick(this.attributes, this.idAttribute);
+    var attributes = this.id == null ? this.attributes : _lodash2['default'].pick(this.attributes, this.idAttribute);
 
     return this._doFetch(attributes, options);
   },
@@ -898,6 +900,8 @@ var BookshelfModel = _baseModel2['default'].extend({
    * @returns {Promise<Model>} A promise resolving to the saved and updated model.
    */
   save: _basePromise2['default'].method(function (key, val, options) {
+    var _this2 = this;
+
     var attrs = undefined;
 
     // Handle both `"key", value` and `{key: value}` -style arguments.
@@ -909,40 +913,38 @@ var BookshelfModel = _baseModel2['default'].extend({
       options = options ? _lodash2['default'].clone(options) : {};
     }
 
-    return _basePromise2['default'].bind(this).then(function () {
-      return this.saveMethod(options);
-    }).then(function (method) {
+    return _basePromise2['default'].resolve(this.isNew()).then(function (isNew) {
 
       // Determine whether which kind of save we will do, update or insert.
-      options.method = method;
+      var method = options.method = _helpers.normalizeSaveMethod(options.method) || (isNew ? 'insert' : 'update');
 
       // If the object is being created, we merge any defaults here rather than
       // during object creation.
       if (method === 'insert' || options.defaults) {
-        var defaults = _lodash2['default'].result(this, 'defaults');
+        var defaults = _lodash2['default'].result(_this2, 'defaults');
         if (defaults) {
-          attrs = _lodash2['default'].extend({}, defaults, this.attributes, attrs);
+          attrs = _extends({}, defaults, _this2.attributes, attrs);
         }
       }
 
       // Set the attributes on the model. Note that we do this before adding
       // timestamps, as `timestamp` calls `set` internally.
-      this.set(attrs, { silent: true });
+      _this2.set(attrs, { silent: true });
 
       // Now set timestamps if appropriate. Extend `attrs` so that the
       // timestamps will be provided for a patch operation.
-      if (this.hasTimestamps) {
-        _lodash2['default'].extend(attrs, this.timestamp(_lodash2['default'].extend(options, { silent: true })));
+      if (_this2.hasTimestamps) {
+        _lodash2['default'].extend(attrs, _this2._timestamp(_extends({ silent: true }, options)));
       }
 
       // If there are any save constraints, set them on the model.
-      if (this.relatedData && this.relatedData.type !== 'morphTo') {
-        _helpers2['default'].saveConstraints(this, this.relatedData);
+      if (_this2.relatedData && _this2.relatedData.type !== 'morphTo') {
+        _helpers2['default'].saveConstraints(_this2, _this2.relatedData);
       }
 
       // Gives access to the `query` object in the `options`, in case we need it
       // in any event handlers.
-      var sync = this.sync(options);
+      var sync = _this2.sync(options);
       options.query = sync.query;
 
       /**
@@ -986,24 +988,27 @@ var BookshelfModel = _baseModel2['default'].extend({
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
        */
-      return this.triggerThen(method === 'insert' ? 'creating saving' : 'updating saving', this, attrs, options).bind(this).then(function () {
-        return sync[options.method](method === 'update' && options.patch ? attrs : this.attributes);
+      return _this2.triggerThen(method === 'insert' ? 'creating saving' : 'updating saving', _this2, attrs, options).then(function () {
+        // Use `options.method` (rather than `method`) here as it may have been
+        // mutated by an event handler.
+        var syncAttrs = options.method === 'update' && options.patch ? attrs : _this2.attributes;
+        return sync[options.method](syncAttrs);
       }).then(function (resp) {
 
         // After a successful database save, the id is updated if the model was created
-        if (method === 'insert' && this.id == null) {
-          this.attributes[this.idAttribute] = this.id = resp[0];
+        if (method === 'insert' && _this2.id == null) {
+          _this2.attributes[_this2.idAttribute] = _this2.id = resp[0];
         } else if (method === 'update' && resp === 0) {
           if (options.require !== false) {
-            throw new this.constructor.NoRowsUpdatedError('No Rows Updated');
+            throw new _this2.constructor.NoRowsUpdatedError('No Rows Updated');
           }
         }
 
         // In case we need to reference the `previousAttributes` for the this
         // in the following event handlers.
-        options.previousAttributes = this._previousAttributes;
+        options.previousAttributes = _this2._previousAttributes;
 
-        this._reset();
+        _this2._reset();
 
         /**
          * Saved event.
@@ -1040,7 +1045,7 @@ var BookshelfModel = _baseModel2['default'].extend({
          * @param {Object} options  Options object passed to {@link Model#save save}.
          * @returns {Promise}
          */
-        return this.triggerThen(method === 'insert' ? 'created saved' : 'updated saved', this, resp, options);
+        return _this2.triggerThen(method === 'insert' ? 'created saved' : 'updated saved', _this2, resp, options);
       });
     })['return'](this);
   }),

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -3,6 +3,7 @@
 var _        = require('lodash');
 var inherits = require('inherits');
 
+import { normalizeSaveMethod } from '../helpers';
 var Events   = require('./events');
 var slice    = Array.prototype.slice
 
@@ -412,15 +413,33 @@ ModelBase.prototype.saveMethod = function(options) {
  *
  * @returns {Object} A hash of timestamp attributes that were set.
  */
-ModelBase.prototype.timestamp = function(options) {
+ModelBase.prototype.timestamp = function(options = {}) {
+
+  // Ensure that passed in `options.method` is checked before `isNew`
+  // to support returning a promise from an overridden `isNew`.
+  options.method = normalizeSaveMethod(options.method) ||
+    (this.isNew() ? 'insert' : 'update');
+
+  return this._timestamp(options);
+}
+
+ModelBase.prototype._timestampKeys = function() {
+  const timestamps = this.hasTimestamps;
+  if (_.isArray(timestamps)) {
+    return timestamps;
+  }
+  return timestamps
+    ? ['created_at', 'updated_at']
+    : [];
+}
+
+ModelBase.prototype._timestamp = function(options) {
   if (!this.hasTimestamps) return {};
 
-  var now          = new Date();
-  var attributes   = {};
-  var method       = this.saveMethod(options);
-  var keys         = _.isArray(this.hasTimestamps) ? this.hasTimestamps : ['created_at', 'updated_at'];
-  var createdAtKey = keys[0];
-  var updatedAtKey = keys[1];
+  const now          = new Date();
+  const attributes   = {};
+  const { method }   = options;
+  const [createdAtKey, updatedAtKey] = this._timestampKeys();
 
   if (updatedAtKey) {
     attributes[updatedAtKey] = now;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,6 +5,18 @@ var chalk = require('chalk')
 
 var helpers = {
 
+  normalizeSaveMethod(method) {
+    if (method == null) return undefined;
+    let result;
+    if (_.isString(method)) {
+      result = method.toLowerCase();
+    }
+    if (result !== 'update' && result !== 'insert') throw new TypeError(
+      `Expected \`method\` to be either "update" or "insert". Got \`${method}\``
+    );
+    return result;
+  },
+
   // Sets the constraints necessary during a `model.save` call.
   saveConstraints: function(model, relatedData) {
     var data = {};

--- a/test/index.js
+++ b/test/index.js
@@ -45,7 +45,7 @@ describe('Unit Tests', function () {
 
   require('./unit/sql/sync')();
   require('./unit/sql/model')();
-
+  require('./unit/helpers')();
 });
 
 describe('Integration Tests', function () {

--- a/test/integration.js
+++ b/test/integration.js
@@ -60,5 +60,4 @@ module.exports = function(Bookshelf) {
     });
 
   });
-
 };

--- a/test/integration/json.js
+++ b/test/integration/json.js
@@ -1,7 +1,6 @@
 var _       = require('lodash');
 var Promise = global.testPromise;
 
-
 module.exports = function(bookshelf) {
 
   var isJsonSupported;

--- a/test/unit/helpers.js
+++ b/test/unit/helpers.js
@@ -1,0 +1,31 @@
+var assert = require('assert');
+var equal = assert.strictEqual;
+var helpers = require('../../lib/helpers');
+
+module.exports = function() {
+
+  describe('Helpers', function() {
+
+    describe('normalizeSaveMethod', function() {
+
+      normalizeSaveMethod = helpers.normalizeSaveMethod;
+
+      it('converts "update" and "insert" to lowercase', function() {
+        expect(normalizeSaveMethod('UPDATE')).to.equal('update');
+        expect(normalizeSaveMethod('INSERT')).to.equal('insert');
+      });
+
+      it('throws on non-string or unrecognized string', function() {
+        expect(normalizeSaveMethod.bind(null, '')).to.throw(TypeError);
+        expect(normalizeSaveMethod.bind(null, 'some-other-string')).to.throw(TypeError);
+        expect(normalizeSaveMethod.bind(null, 5)).to.throw(TypeError);
+      });
+  
+      it('returns undefined for `null` or `undefined`', function() {
+        expect(normalizeSaveMethod(null)).to.be.undefined;
+        expect(normalizeSaveMethod(undefined)).to.be.undefined;
+      });
+        
+    });
+  });
+};      

--- a/test/unit/helpers.js
+++ b/test/unit/helpers.js
@@ -8,7 +8,7 @@ module.exports = function() {
 
     describe('normalizeSaveMethod', function() {
 
-      normalizeSaveMethod = helpers.normalizeSaveMethod;
+      var normalizeSaveMethod = helpers.normalizeSaveMethod;
 
       it('converts "update" and "insert" to lowercase', function() {
         expect(normalizeSaveMethod('UPDATE')).to.equal('update');


### PR DESCRIPTION
Permits overriding `Model#isNew` to return a promise that resolves to a boolean. This restores `save` to its behaviour before 0.8.2.

Fixes #885.
