### PR TITLE
Fixed ordering data after fetch

### DIFF
--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -986,14 +986,6 @@ module.exports = {
           first_name: 'Bazooka',
           last_name: 'Joe',
           posts: [{
-            id: 2,
-            owner_id: 2,
-            blog_id: 2,
-            name: 'This is a new Title 2!',
-            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.',
-            _pivot_author_id: 2,
-            _pivot_post_id: 2
-          },{
             id: 1,
             owner_id: 1,
             blog_id: 1,
@@ -1001,6 +993,14 @@ module.exports = {
             content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.',
             _pivot_author_id: 2,
             _pivot_post_id: 1
+          },{
+            id: 2,
+            owner_id: 2,
+            blog_id: 2,
+            name: 'This is a new Title 2!',
+            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.',
+            _pivot_author_id: 2,
+            _pivot_post_id: 2
           }]
         }]
       }
@@ -3704,19 +3704,19 @@ module.exports = {
         first_name: 'Bazooka',
         last_name: 'Joe',
         blogs: [{
-          id: 2,
-          site_id: 1,
-          name: 'Alternate Site Blog',
-          _pivot_id: 2,
-          _pivot_owner_id: 2,
-          _pivot_blog_id: 2
-        },{
           id: 1,
           site_id: 1,
           name: 'Main Site Blog',
           _pivot_id: 3,
           _pivot_owner_id: 2,
           _pivot_blog_id: 1
+        },{
+          id: 2,
+          site_id: 1,
+          name: 'Alternate Site Blog',
+          _pivot_id: 2,
+          _pivot_owner_id: 2,
+          _pivot_blog_id: 2
         }]
       },{
         id: 3,

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -11,8 +11,26 @@ module.exports = function(Bookshelf) {
     var json    = function(model) {
       return JSON.parse(JSON.stringify(model));
     };
+    var sortModels = function (models) {
+      return models.sort (function (a, b) {
+        sortRelations (a.relations);
+        sortRelations (b.relations);
+        return a.attributes.id > b.attributes.id;
+      })
+    };
+    var sortRelations = function (relations) {
+      if (!relations) return;
+      if (!Object.keys (relations).length) return;
+      for (var relModel in relations) {
+        if (!relations[relModel].models)
+          continue;
+        relations[relModel].models = sortModels (relations[relModel].models);
+      }
+    };
     var checkTest = function(ctx) {
       return function(resp) {
+        if (resp.relations) sortRelations (resp.relations);
+        if (resp.models) resp.models = sortModels (resp.models);
         expect(json(resp)).to.eql(output[ctx.test.title][dialect].result);
       };
     };


### PR DESCRIPTION
First time I've encountered this when I tried to make patch. Some tests pass randomly. For example, for a first run:

```
      AssertionError: expected [ Array(5) ] to deeply equal [ Array(5) ]
      + expected - actual

         }
         {
           "blogs": [
             {
      +        "_pivot_blog_id": 1
      +        "_pivot_id": 3
      +        "_pivot_owner_id": 2
      +        "id": 1
      +        "name": "Main Site Blog"
      +        "site_id": 1
      +      }
      +      {
               "_pivot_blog_id": 2
               "_pivot_id": 2
               "_pivot_owner_id": 2
               "id": 2
               "name": "Alternate Site Blog"
               "site_id": 1
             }
      -      {
      -        "_pivot_blog_id": 1
      -        "_pivot_id": 3
      -        "_pivot_owner_id": 2
      -        "id": 1
      -        "name": "Main Site Blog"
      -        "site_id": 1
      -      }
           ]
           "first_name": "Bazooka"
           "id": 2
           "last_name": "Joe"

```

For a second run:

```
      AssertionError: expected { Object (id, name, ...) } to deeply equal { Object (id, name, ...) }
      + expected - actual

             "last_name": "Joe"
             "posts": [
               {
                 "_pivot_author_id": 2
      +          "_pivot_post_id": 1
      +          "blog_id": 1
      +          "content": "Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est."
      +          "id": 1
      +          "name": "This is a new Title!"
      +          "owner_id": 1
      +        }
      +        {
      +          "_pivot_author_id": 2
                 "_pivot_post_id": 2
                 "blog_id": 2
                 "content": "Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco."
                 "id": 2
                 "name": "This is a new Title 2!"
                 "owner_id": 2
               }
      -        {
      -          "_pivot_author_id": 2
      -          "_pivot_post_id": 1
      -          "blog_id": 1
      -          "content": "Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est."
      -          "id": 1
      -          "name": "This is a new Title!"
      -          "owner_id": 1
      -        }
             ]
             "site_id": 1
           }
         ]
```

Reason for that is fetch _without any order_ and then comparing with ordered data. There is two possible solutions for this:
1. (simple) Order data after fetch. Not elegant, but works.
2. (complex but proper one) Add `order by` for every statement with related dataset return.

This is a patch to make sure data is ordered by id after data fetch and in test data to compare.
