### PR TITLE
Document static `where` and `query` methods

### DIFF
--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -298,7 +298,54 @@ function Bookshelf(knex) {
     );
   }
 
-  // Attach `where`, `query`, and `fetchAll` as static methods.
+  /**
+   * @method Model.where
+   * @belongsTo Model
+   * @description
+   *
+   * Static helper that allows you to specify query parameters for a
+   * {@linkcode Model#fetch fetch} or {@linkcode Model#fetchAll fetchAll}
+   * without first needing to create an instance of the Model.
+   *
+   * @see {@linkcode Model#where Model#where}
+   */
+
+  /**
+   * @method Model.query
+   * @belongsTo Model
+   * @description
+   *
+   * Static helper that allows you to specify query parameters for a
+   * {@linkcode Model#fetch fetch} or {@linkcode Model#fetchAll fetchAll}
+   * without first needing to create an instance of the Model.
+   *
+   * @see {@linkcode Model#query Model#query}
+   */
+
+  /**
+   * @method Collection.where
+   * @belongsTo Collection
+   * @description
+   *
+   * Static helper that allows you to specify query parameters for a
+   * {@linkcode Collection#fetch fetch} without first needing to create
+   * an instance of the Collection.
+   *
+   * @see {@linkcode Collection#where Collection#where}
+   */
+
+  /**
+   * @method Collection.query
+   * @belongsTo Collection
+   * @description
+   *
+   * Static helper that allows you to specify query parameters for a
+   * {@linkcode Collection#fetch fetch} without first needing to create
+   * an instance of the Collection.
+   *
+   * @see {@linkcode Collection#query Collection#query}
+   */
+  // Attach `where` and `query` as static methods.
   ['where', 'query'].forEach((method) => {
     Model[method] = Collection[method] = function() {
       const model = this.forge();


### PR DESCRIPTION
There are numerous examples throughout the docs and source showing that you can use `where()` and `query()` as static methods from Bookshelf.Model, but it isn't explicitly documented.

This patch adds documentation for these static methods.

![screen shot 2016-01-11 at 2 01 42 pm](https://cloud.githubusercontent.com/assets/309219/12244999/e05a60b8-b86b-11e5-9d0f-1924c7b405d6.png)
![screen shot 2016-01-11 at 2 01 27 pm](https://cloud.githubusercontent.com/assets/309219/12245000/e1f167f0-b86b-11e5-9715-b41f43b0d77b.png)

Would be happy to tweak the wording if needed.
