### PR TITLE
Bind bookshelf to "this" for registry methods

### DIFF
--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -24,7 +24,8 @@ module.exports = function (bookshelf) {
       this._models[name] = ModelCtor;
     }
     return (this._models[name] = this._models[name] || bookshelf.resolve(name));
-  };
+  }.bind(bookshelf);
+
   bookshelf.collection = function(name, CollectionCtor, staticProps) {
     this._collections = this._collections || Object.create(null);
     if (CollectionCtor) {
@@ -35,7 +36,7 @@ module.exports = function (bookshelf) {
       this._collections[name] = CollectionCtor;
     }
     return (this._collections[name] = this._collections[name] || bookshelf.resolve(name));
-  };
+  }.bind(bookshelf);
 
   // Provide a custom function to resolve the location of a model or collection.
   bookshelf.resolve = function(name) { return void 0; };

--- a/test/integration/plugins/registry.js
+++ b/test/integration/plugins/registry.js
@@ -50,6 +50,20 @@ module.exports = function(Bookshelf) {
 				expect(Bookshelf.model.bind(Bookshelf, 'Model', Bookshelf.Model)).to.throw();
 			});
 
+			describe('with different calling context', function() {
+				beforeEach(function() {
+					Bookshelf._models = {};
+					this.Model = Bookshelf.Model.extend({
+						tableName: 'records'
+					});
+
+					this.ModelObj = Bookshelf.model.call(null, 'Model', this.Model);
+				});
+
+				it('returns the registered model', function() {
+					expect(this.ModelObj).to.equal(this.Model);
+				});
+			});
 		});
 
 		describe('Registering Models with plain object', function() {
@@ -105,6 +119,20 @@ module.exports = function(Bookshelf) {
 				expect(Bookshelf.collection.bind(Bookshelf, 'Collection', Bookshelf.Collection)).to.throw();
 			});
 
+			describe('with different calling context', function() {
+				beforeEach(function() {
+					Bookshelf._collections = {};
+					this.Collection = Bookshelf.Collection.extend({
+						property: {}
+					});
+
+					this.collection = Bookshelf.collection.call(null, 'Collection', this.Collection);
+				});
+
+				it('returns the registered collection', function() {
+					expect(this.collection).to.equal(this.Collection);
+				});
+			});
 		});
 
 		describe('Custom Relations', function() {
@@ -182,7 +210,7 @@ module.exports = function(Bookshelf) {
 		});
 
 		describe('bookshelf.resolve', function() {
-			
+
 			it('resolves the path to a model with a custom function', function() {
 				var one = Bookshelf.Model.extend({});
 				var two = Bookshelf.Model.extend({});


### PR DESCRIPTION
I'm using babel in a project which can change the the way certain functions are called internally. This is causing the registry plugin to fail to register models as it's finding that `this` is undefined [here](https://github.com/dannymidnight/bookshelf/blob/311c5035d4a3d49093b780cc5c2b121a36ddefb1/plugins/registry.js#L18).

This PR makes use of `bind` to ensure that `this` is always bound to the bookshelf instance regardless of how it's called.
