### PR TITLE
Fixes Model fetchAll event documentation

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -731,8 +731,8 @@ const BookshelfModel = ModelBase.extend({
    *
    *   Optionally run the query in a transaction.
    *
-   * @fires Model#"fetching:collection"
-   * @fires Model#"fetched:collection"
+   * @fires Model#fetching:collection
+   * @fires Model#fetched:collection
    *
    * @throws {Collection.EmptyError}
    *
@@ -749,7 +749,7 @@ const BookshelfModel = ModelBase.extend({
          * Fired before a {@link Model#fetchAll fetchAll} operation. A promise
          * may be returned from the event handler for async behaviour.
          *
-         * @event Model#"fetching:collection"
+         * @event Model#fetching:collection
          * @param {Model}    collection The collection that has been fetched.
          * @param {string[]} columns    The columns being retrieved by the query.
          * @param {Object}   options    Options object passed to {@link Model#fetchAll fetchAll}.
@@ -762,7 +762,7 @@ const BookshelfModel = ModelBase.extend({
          * Fired after a {@link Model#fetchAll fetchAll} operation. A promise
          * may be returned from the event handler for async behaviour.
          *
-         * @event Model#"fetched:collection"
+         * @event Model#fetched:collection
          * @param {Model}  collection The collection that has been fetched.
          * @param {Object} resp       The Knex query response.
          * @param {Object} options    Options object passed to {@link Model#fetchAll fetchAll}.


### PR DESCRIPTION
The `fetching:collection` and `fetched:collection` event tags have the event name wrapped in quotes. This is causing an issue in JSDoc which is preventing these events from being rendered in the menu and in the event detail blocks. This fixes that by removing the quotes and updating the JSDoc theme to use a more accurate regular expression for simplifying event names (bookshelf/bookshelf-jsdoc-theme#3).
