### PR TITLE
Reorders 'saving' and 'creating' triggers as per docs.

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -974,7 +974,7 @@ const BookshelfModel = ModelBase.extend({
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
        */
-      return this.triggerThen((method === 'insert' ? 'creating saving' : 'updating saving'), this, attrs, options)
+      return this.triggerThen((method === 'insert' ? 'saving creating' : 'saving updating'), this, attrs, options)
       .bind(this)
       .then(function() {
         return sync[options.method](method === 'update' && options.patch ? attrs : this.attributes);

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -524,6 +524,30 @@ module.exports = function(bookshelf) {
         return user.save();
       });
 
+      it('fires saving and then creating triggers', function() {
+        var user   = new bookshelf.Model({first_name: 'Testing'}, {tableName: 'users'});
+        var triggered = [];
+        user.sync  = function() {
+          return _.extend(stubSync, {
+            insert: function() {
+              deepEqual(triggered, ['saving', 'creating']);
+              return Promise.resolve({});
+            }
+          });
+        };
+        user.on('saving', function() {
+          return Promise.resolve().then(function() {
+            triggered.push('saving');
+          });
+        });
+        user.on('creating', function() {
+          return Promise.resolve().then(function() {
+            triggered.push('creating');
+          });
+        });
+        return user.save();
+      });
+
       it('rejects if the saving event throws an error', function() {
         var Test = bookshelf.Model.extend({
           tableName: 'test',


### PR DESCRIPTION
The docs suggest the ordering of triggers on the Model are:
- Saving
- Creating
- Updating
- Created
- Updated
- Saved

see: https://github.com/tgriesser/bookshelf/blob/master/docs/src_model.js.html#L951-L956

Currently Saving is triggered after Creating/Updating. I am using Saving to hook in a validation of the model, and I want to validate it before saving (for example validate that a password and password confirmation are the same, but then delete the password confirmation as I don't want to store it in the database).
