### PR TITLE
Improve virtuals

### DIFF
--- a/src/plugins/virtuals.js
+++ b/src/plugins/virtuals.js
@@ -13,8 +13,12 @@ module.exports = function (Bookshelf) {
     // If virtual properties have been defined they will be created
     // as simple getters on the model.
     constructor: function (attributes, options) {
+      // Initially model has a reference to prototype `virtuals`
+      // property. To not change the referenced `virtuals` property
+      // object it is required to deep clone it.
       const virtuals = this.virtuals = _.cloneDeep(this.virtuals);
       if (_.isObject(virtuals)) {
+        // Prepare virtual getters and setters
         for (const virtualName in virtuals) {
           let getter, setter;
           if (virtuals[virtualName].get || virtuals[virtualName].set) {
@@ -41,6 +45,9 @@ module.exports = function (Bookshelf) {
           });
         }
       }
+      // As the Model base class may call `set` method which will also use
+      // virtual setters and getters it is requred to call base constructor
+      // after preparing the virtuals. 
       proto.constructor.apply(this, arguments);
     },
 

--- a/src/plugins/virtuals.js
+++ b/src/plugins/virtuals.js
@@ -186,17 +186,11 @@ module.exports = function (Bookshelf) {
 
   function isNestedGet(virtual) {
     const virtualGet = virtual && virtual.get || virtual;
-    if (!virtualGet) {
-      return false;
-    }
-    return isNestedVirtual(virtualGet);
+    return virtualGet && isNestedVirtual(virtualGet);
   }
 
-  function exceptNestedSet(virtual) {
-    if (!virtual) {
-      return false;
-    }
-    return (virtual.set && isNestedVirtual(virtual.set)) || virtual;
+  function isNestedSet(virtual) {
+    return virtual && virtual.set && isNestedVirtual(virtual.set);
   }
 
   function getVirtual(model, virtualName) {
@@ -219,8 +213,8 @@ module.exports = function (Bookshelf) {
   }
 
   function setVirtual(value, key) {
-    const virtual = this.virtuals && exceptNestedSet(this.virtuals[key]);
-    if (virtual) {
+    const virtual = this.virtuals && this.virtuals[key];
+    if (virtual && !isNestedSet(virtual)) {
       if (virtual.set) {
         virtual.set.call(this, value);
       }

--- a/src/plugins/virtuals.js
+++ b/src/plugins/virtuals.js
@@ -17,16 +17,16 @@ module.exports = function (Bookshelf) {
       if (_.isObject(virtuals)) {
         for (const virtualName in virtuals) {
           let getter, setter;
-          if (virtuals[virtualName].get) {
-            if (virtuals[virtualName].set) {
-              setter = virtuals[virtualName].set = enableVirtualNesting(
-                virtuals[virtualName].set
-              );
-            }
-
+          if (virtuals[virtualName].get || virtuals[virtualName].set) {
             if (virtuals[virtualName].get) {
               getter = virtuals[virtualName].get = enableVirtualNesting(
                 virtuals[virtualName].get
+              );
+            }
+
+            if (virtuals[virtualName].set) {
+              setter = virtuals[virtualName].set = enableVirtualNesting(
+                virtuals[virtualName].set
               );
             }
           } else {
@@ -181,16 +181,15 @@ module.exports = function (Bookshelf) {
   }
 
   function isNestedVirtual(virtualMethod) {
-    return !!virtualMethod.in;
+    return virtualMethod && !!virtualMethod.in;
   }
 
   function isNestedGet(virtual) {
-    const virtualGet = virtual && virtual.get || virtual;
-    return virtualGet && isNestedVirtual(virtualGet);
+    return virtual && isNestedVirtual(virtual.get || virtual);
   }
 
   function isNestedSet(virtual) {
-    return virtual && virtual.set && isNestedVirtual(virtual.set);
+    return virtual && isNestedVirtual(virtual.set);
   }
 
   function hasVirtualGet(virtual) {

--- a/src/plugins/virtuals.js
+++ b/src/plugins/virtuals.js
@@ -47,7 +47,7 @@ module.exports = function (Bookshelf) {
       }
       // As the Model base class may call `set` method which will also use
       // virtual setters and getters it is requred to call base constructor
-      // after preparing the virtuals. 
+      // after preparing the virtuals.
       proto.constructor.apply(this, arguments);
     },
 

--- a/test/integration/plugins/virtuals.js
+++ b/test/integration/plugins/virtuals.js
@@ -293,5 +293,35 @@ module.exports = function (bookshelf) {
           expect(error.message).to.equal('Deliberately failing');
         })
     });
+
+    it('when setter/getter called recursively for the same attribute key, it should call non-virtual setter/getter', function () {
+      var m = new (bookshelf.Model.extend({
+        virtuals: {
+          is_owner: {
+            get: function () {
+              return this.get('is_owner');
+            },
+            set: function(value) {
+              if (value) {
+                this.set('is_authorized', true);
+              }
+              this.set('is_owner', value);
+            }
+          }
+        }
+      }))({is_owner: true});
+
+      // getter should return is_owner value from attributes
+      expect(m.get('is_owner')).to.be.true;
+      expect(m.attributes.is_owner).to.be.true;
+      expect(m.attributes.is_authorized).to.be.true;
+
+      m.set('is_owner', false);
+
+      // getter should return is_owner value from attributes
+      expect(m.get('is_owner')).to.be.false;
+      expect(m.attributes.is_owner).to.be.false;
+      expect(m.attributes.is_authorized).to.be.true;
+    });
   });
 };

--- a/test/integration/plugins/virtuals.js
+++ b/test/integration/plugins/virtuals.js
@@ -46,6 +46,45 @@ module.exports = function (bookshelf) {
       equal(m.get('lastName'), 'Shmoe');
     });
 
+    it('allows to create virtual properties with only getter present', function () {
+      var m = new (bookshelf.Model.extend({
+        virtuals: {
+          fullName: {
+            get: function () {
+              return this.get('firstName') + ' ' + this.get('lastName');
+            }
+          }
+        }
+      }))({firstName: 'Joe', lastName: 'Shmoe'});
+
+      equal(m.fullName, 'Joe Shmoe');
+      m.fullName = 'Jack Shmoe';
+
+      equal(m.fullName, 'Joe Shmoe');
+      equal(m.get('firstName'), 'Joe');
+      equal(m.get('lastName'), 'Shmoe');
+    });
+
+    it('allows to create virtual properties with only setter present', function () {
+      var m = new (bookshelf.Model.extend({
+        virtuals: {
+          fullName: {
+            set: function(value) {
+              value = value.split(' ');
+              this.set('firstName', value[0]);
+              this.set('lastName', value[1]);
+            }
+          }
+        }
+      }))({firstName: 'Joe', lastName: 'Shmoe'});
+
+      equal(m.fullName, undefined);
+      m.fullName = 'Jack Shmoe';
+
+      equal(m.get('firstName'), 'Jack');
+      equal(m.get('lastName'), 'Shmoe');
+    });
+
     it('defaults virtual properties with no setter to a noop', function () {
        var m = new (bookshelf.Model.extend({
         virtuals: {
@@ -295,10 +334,12 @@ module.exports = function (bookshelf) {
     });
 
     it('when setter/getter called recursively for the same attribute key, it should call non-virtual setter/getter', function () {
+      var getCount = 0;
       var m = new (bookshelf.Model.extend({
         virtuals: {
           is_owner: {
             get: function () {
+              getCount++;
               return this.get('is_owner');
             },
             set: function(value) {
@@ -313,6 +354,7 @@ module.exports = function (bookshelf) {
 
       // getter should return is_owner value from attributes
       expect(m.get('is_owner')).to.be.true;
+      expect(getCount).to.equal(1);
       expect(m.attributes.is_owner).to.be.true;
       expect(m.attributes.is_authorized).to.be.true;
 
@@ -320,6 +362,7 @@ module.exports = function (bookshelf) {
 
       // getter should return is_owner value from attributes
       expect(m.get('is_owner')).to.be.false;
+      expect(getCount).to.equal(2);
       expect(m.attributes.is_owner).to.be.false;
       expect(m.attributes.is_authorized).to.be.true;
     });


### PR DESCRIPTION
My inital ambition was to make it possible to apply additional business logic when a attribute gets set on a model. I thought the best place to implement is virtuals plugin.

I thought on a separate plugin. But then a user must define additional "virtuals" like object property on the model. Additionally "Virtual" is exactly describing the behavior that I was looking for.

Look into [this test](https://github.com/vellotis/bookshelf/blob/de09ada751b46d581e5734ac34649b11348964ef/test/integration/plugins/virtuals.js#L336-L369) to understand the use case.

Additionally I made `get` property optional for virtual definition. This allows to apply some business logic only for setter as well as it allows for getter currently. This is covered with [two tests](https://github.com/vellotis/bookshelf/blob/de09ada751b46d581e5734ac34649b11348964ef/test/integration/plugins/virtuals.js#L49-L86).

All previously written tests pass without modifications. Additional 3 tests added.

I would be greatful if this PR could be a part of Bookshelf Virtuals plugin. All code review suggestions are welcome.
Best regards.
