### PR TITLE
Workaround for broken idAttribute

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -329,8 +329,12 @@ ModelBase.prototype.has = function(attr) {
  *
  * // Example of a "parse" to convert snake_case to camelCase, using `underscore.string`
  * model.parse = function(attrs) {
+ *   var _this = this;
  *   return _.reduce(attrs, function(memo, val, key) {
  *     memo[_.camelCase(key)] = val;
+ *     if (key === _this.idAttribute) {
+ *       memo[key] = val;
+ *     }
  *     return memo;
  *   }, {});
  * };


### PR DESCRIPTION
Updated the example for parse to make sure it works around the issue presented in #1082 until that is merged. Currently idAttribute in combination with the example for snake_case in parse is broken.
