### PR TITLE
Fix collection pagination and add test

### DIFF
--- a/src/plugins/pagination.js
+++ b/src/plugins/pagination.js
@@ -211,7 +211,11 @@ module.exports = function paginationPlugin (bookshelf) {
   }
 
   bookshelf.Collection.prototype.fetchPage = function (...args) {
-    return fetchPage.apply(this.model.forge(), ...args);
+    const model = new this.model();
+    model._knex = this.query().clone();
+    this.resetQuery();
+    if (this.relatedData) model.relatedData = this.relatedData;
+    return model.fetchPage(...args);
   };
 
 }

--- a/test/integration/plugins/pagination.js
+++ b/test/integration/plugins/pagination.js
@@ -95,6 +95,14 @@ module.exports = function (bookshelf) {
           });
         })
       })
+
+      it('fetches a page from a collection with specified page size', function () {
+        return Models.Customer.collection().fetchPage({ page: 2, pageSize: 2 }).then(function (results) {
+          var m = results.models
+          expect(parseInt(m[0].get('id'))).to.equal(3);
+          expect(parseInt(m[1].get('id'))).to.equal(4);
+        });
+      })
     })
 
   });


### PR DESCRIPTION
This might have been an issue with `babel` compilation -- essentially, the options passed in to `fetchPage` were not actually being passed for Collections, resulting in `fetchPage` always returning the default page and pageSize.

Fixes #1258
