### PR TITLE
Fix Pagination plugin #1258

### DIFF
--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -571,7 +571,12 @@ CollectionBase.prototype.parse = function(resp) {
  * Create a new collection with an identical list of models as this one.
  */
 CollectionBase.prototype.clone = function() {
-  return new this.constructor(this.models, _.pick(this, collectionProps));
+  // Iterate over the selected list of collection properties and invoke `clone` for
+  // each property that has a method for that porpose.
+  var clonedProps = _(this).pick(collectionProps).mapValues((val) => {
+    return (val && typeof(val.clone) === 'function') ? val.clone() : val;
+  }).value(); 
+  return new this.constructor(this.models, clonedProps);
 };
 
 /**

--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -573,9 +573,9 @@ CollectionBase.prototype.parse = function(resp) {
 CollectionBase.prototype.clone = function() {
   // Iterate over the selected list of collection properties and invoke `clone` for
   // each property that has a method for that porpose.
-  var clonedProps = _(this).pick(collectionProps).mapValues((val) => {
+  const clonedProps = _(this).pick(collectionProps).mapValues((val) => {
     return (val && typeof(val.clone) === 'function') ? val.clone() : val;
-  }).value(); 
+  }).value();
   return new this.constructor(this.models, clonedProps);
 };
 

--- a/src/base/relation.js
+++ b/src/base/relation.js
@@ -32,6 +32,11 @@ export default class RelationBase {
     return new this.target(data)._reset();
   }
 
+  // Clones a relation. Required by Pagination plugin.
+  clone() {
+    return new this.constructor(null, null, this)
+  }
+
   // Eager pair the models.
   eagerPair() {}
 }

--- a/src/sync.js
+++ b/src/sync.js
@@ -79,12 +79,12 @@ _.extend(Sync.prototype, {
       });
     }).then(function() {
       options.query = knex;
-      
+
       /**
        * Counting event.
        *
        * Fired before a `count` query. A promise may be
-       * returned from the event handler for async behaviour. 
+       * returned from the event handler for async behaviour.
        *
        * @event Model#counting
        * @param {Model}  model    The model firing the event.

--- a/test/integration/plugins/pagination.js
+++ b/test/integration/plugins/pagination.js
@@ -106,7 +106,7 @@ module.exports = function (bookshelf) {
       })
       it('fetches a page from a relation collection with additional condition', function () {
         return Models.User.forge({uid: 1}).roles().query(function (query) {
-          query.where(knex.raw('`roles`.`rid`'), '!=', 4);
+          query.where('roles.rid', '!=', 4);
         }).fetchPage().then(function (results) {
           expect(results.length).to.equal(0);
           ['models', 'pagination'].forEach(function (prop) {

--- a/test/integration/plugins/pagination.js
+++ b/test/integration/plugins/pagination.js
@@ -8,6 +8,7 @@ module.exports = function (bookshelf) {
   describe('Pagination Plugin', function () {
 
     bookshelf.plugin('pagination');
+    var knex = bookshelf.knex;
     var Models = require('../helpers/objects')(bookshelf).Models;
 
 
@@ -94,6 +95,24 @@ module.exports = function (bookshelf) {
             expect(results).to.have.property(prop);
           });
         })
+      })
+      it('fetches a page from a relation collection', function () {
+        return Models.User.forge({uid: 1}).roles().fetchPage().then(function (results) {
+          expect(results.length).to.equal(1);
+          ['models', 'pagination'].forEach(function (prop) {
+            expect(results).to.have.property(prop);
+          });
+        });
+      })
+      it('fetches a page from a relation collection with additional condition', function () {
+        return Models.User.forge({uid: 1}).roles().query(function (query) {
+          query.where(knex.raw('`roles`.`rid`'), '!=', 4);
+        }).fetchPage().then(function (results) {
+          expect(results.length).to.equal(0);
+          ['models', 'pagination'].forEach(function (prop) {
+            expect(results).to.have.property(prop);
+          });
+        });
       })
     })
 


### PR DESCRIPTION
Fix #1258
- Model shouldn't be reinitialized. It may contain IDs that are needed for relational queries. Model/Collection/RelationCollection shall be cloned instead.
- `groupBy` is needed when queries with joins are used. DB engine started to shout if it was missing for collections.

Two tests added for collection and relational collection result verification.

:exclamation: Contains PR #1271
:exclamation: Makes PR #1261 redundant
