### PR TITLE
Fix #96 by enabling table name aliasing

### DIFF
--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -106,6 +106,28 @@ CollectionBase.prototype.tableName = function() {
  * @method
  * @private
  * @description
+ * The `tableAlias` on the associated Model, used in relation building.
+ * @returns {string} The {@link Model#tableAlias tableAlias} of the associated model.
+ */
+CollectionBase.prototype.tableAlias = function() {
+  return _.result(this.model.prototype, 'tableAlias');
+};
+
+/**
+ * @method
+ * @private
+ * @description
+ * The `tableAlias` on the associated Model, used in relation building.
+ * @returns {string} The {@link Model#tableAlias tableAlias} of the associated model.
+ */
+CollectionBase.prototype.tableIdentifyer = function() {
+  return _.result(this, 'tableAlias') || _.result(this, 'tableName');
+};
+
+/**
+ * @method
+ * @private
+ * @description
  * The `idAttribute` on the associated Model, used in relation building.
  * @returns {string} The {@link Model#idAttribute idAttribute} of the associated model.
  */

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -10,7 +10,7 @@ const PIVOT_PREFIX = '_pivot_';
 const DEFAULT_TIMESTAMP_KEYS = ['created_at', 'updated_at'];
 
 // List of attributes attached directly from the `options` passed to the constructor.
-const modelProps = ['tableName', 'hasTimestamps'];
+const modelProps = ['tableName', 'tableAlias', 'hasTimestamps'];
 
 /**
  * @class
@@ -99,6 +99,18 @@ ModelBase.prototype.initialize = function() {};
  *   tableName: 'televisions'
  * });
  */
+
+/**
+ * @method
+ * @description  Get the current value of an attribute from the model.
+ *
+ * @returns {string} Attribute value.odel({id: 1});
+ * @example
+ * modelB.isNew(); // false
+ */
+ModelBase.prototype.tableIdentifyer = function () {
+  return _.result(this, 'tableAlias') || _.result(this, 'tableName');
+}
 
 /**
  * @member {string}

--- a/src/base/relation.js
+++ b/src/base/relation.js
@@ -1,7 +1,7 @@
 // Base Relation
 // ---------------
 
-import _, { assign } from 'lodash';
+import { assign } from 'lodash';
 import CollectionBase from './collection';
 import extend from '../extend';
 
@@ -11,7 +11,7 @@ export default class RelationBase {
 
   constructor(type, Target, options) {
     if (Target != null) {
-      this.targetTable = _.result(Target.prototype, 'table');
+      this.targetTable = this._tableDesc(Target.prototype);
     }
     assign(this, { type, target: Target }, options);
   }

--- a/src/base/relation.js
+++ b/src/base/relation.js
@@ -11,8 +11,7 @@ export default class RelationBase {
 
   constructor(type, Target, options) {
     if (Target != null) {
-      this.targetTableName   = _.result(Target.prototype, 'tableName');
-      this.targetIdAttribute = _.result(Target.prototype, 'idAttribute');
+      this.targetTable = _.result(Target.prototype, 'table');
     }
     assign(this, { type, target: Target }, options);
   }

--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -327,14 +327,14 @@ function Bookshelf(knex) {
       const aliasedTableName = candidates.map(function (tableNameOrAlias) {
         return knex.client.wrapIdentifier(tableNameOrAlias);
       }).join(' ');
-      return knex.raw(aliasedTableName);
+      return knex.client.raw(aliasedTableName);
     };
   }
 
   function builderFn(tableNameOrBuilder) {
     let builder = null;
 
-    if (_.isString(tableNameOrBuilder)) {
+    if (_.isString(tableNameOrBuilder) || tableNameOrBuilder instanceof knex.client.Raw) {
       builder = knex(tableNameOrBuilder);
     } else if (tableNameOrBuilder == null) {
       builder = knex.queryBuilder();

--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -52,16 +52,6 @@ function Bookshelf(knex) {
      * @example
      * modelB.isNew(); // false
      */
-    table,
-
-    /**
-     * @method
-     * @description  Get the current value of an attribute from the model.
-     *
-     * @returns {string} Attribute value.odel({id: 1});
-     * @example
-     * modelB.isNew(); // false
-     */
     aliasedTableName: aliasedTableName()
 
   }, {
@@ -149,8 +139,6 @@ function Bookshelf(knex) {
 
     _builder: builderFn,
 
-    table,
-
     aliasedTableName: aliasedTableName()
 
   }, {
@@ -194,7 +182,7 @@ function Bookshelf(knex) {
   Model.prototype.Collection = Collection;
 
   const Relation = BookshelfRelation.extend({
-    Model, Collection
+    Model, Collection, _aliasedTableName: aliasedTableName
   });
 
   // A `Bookshelf` instance may be used as a top-level pub-sub bus, as it mixes
@@ -302,18 +290,6 @@ function Bookshelf(knex) {
   // and more chainable.
   function forge() {
     return new this(...arguments);
-  }
-
-  function table() {
-    const desc = {
-      name: _.result(this, 'tableName'),
-      alias: _.result(this, 'tableAlias'),
-      identifyer: _.result(this, 'tableIdentifyer'),
-      aliasedName: aliasedTableName('name', 'alias'),
-      idAttribute: _.result(this, 'idAttribute')
-    };
-    if (!desc.alias) delete desc.alias;
-    return desc;
   }
 
   function aliasedTableName(tableNameProp = 'tableName', tableAliasProp = 'tableAlias') {

--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -46,11 +46,9 @@ function Bookshelf(knex) {
 
     /**
      * @method
-     * @description  Get the current value of an attribute from the model.
+     * @description Get the aliased table name if possible.
      *
-     * @returns {string} Attribute value.odel({id: 1});
-     * @example
-     * modelB.isNew(); // false
+     * @returns {string} Aliased table name or just a table name.
      */
     aliasedTableName: aliasedTableName()
 
@@ -298,7 +296,7 @@ function Bookshelf(knex) {
         _.result(this, tableNameProp),
         _.result(this, tableAliasProp)
       ];
-      // `aliasTable` is nor required and may be missing
+      // `tableAlias` is not required and may be missing
       candidates = _.compact(candidates);
       const aliasedTableName = candidates.map(function (tableNameOrAlias) {
         return knex.client.wrapIdentifier(tableNameOrAlias);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -40,16 +40,17 @@ const helpers = {
   // methods, and the values are the arguments for the query.
   query: function(obj, args) {
 
+    const [method] = args;
+
     // Ensure the object has a query builder.
     if (!obj._knex) {
-      const aliasedTableName = _.result(obj, 'aliasedTableName');
+      const useTableName = ['update', 'insert', 'delete'].indexOf(method) >= 0;
+      const aliasedTableName = _.result(obj, useTableName ? 'tableName' : 'aliasedTableName');
       obj._knex = obj._builder(aliasedTableName);
     }
 
     // If there are no arguments, return the query builder.
     if (args.length === 0) return obj._knex;
-
-    const method = args[0];
 
     if (_.isFunction(method)) {
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -25,7 +25,7 @@ const helpers = {
   // an error if none is matched.
   morphCandidate: function(candidates, foreignTable) {
     const Target = _.find(candidates, function(Candidate) {
-      return (_.result(Candidate.prototype, 'tableName') === foreignTable);
+      return (_.result(Candidate.prototype, 'tableIdentifyer') === foreignTable);
     });
     if (!Target) {
       throw new Error('The target polymorphic model was not found');
@@ -42,8 +42,8 @@ const helpers = {
 
     // Ensure the object has a query builder.
     if (!obj._knex) {
-      const tableName = _.result(obj, 'tableName');
-      obj._knex = obj._builder(tableName);
+      const aliasedTableName = _.result(obj, 'aliasedTableName');
+      obj._knex = obj._builder(aliasedTableName);
     }
 
     // If there are no arguments, return the query builder.
@@ -87,18 +87,12 @@ const helpers = {
 
   orderBy (obj, sort, order) {
 
-    let tableName;
-    let idAttribute;
+    const target = obj.model
+      ? obj.model.prototype
+      : obj.constructor.prototype;
 
-    if (obj.model) {
-      tableName = obj.model.prototype.tableName;
-      idAttribute = obj.model.prototype.idAttribute ?
-        obj.model.prototype.idAttribute : 'id';
-    } else {
-      tableName = obj.constructor.prototype.tableName;
-      idAttribute = obj.constructor.prototype.idAttribute ?
-        obj.constructor.prototype.idAttribute : 'id';
-    }
+    const tableIdentifyer = _.return(target, 'tableIdentifyer');
+    const idAttribute = _.return(target, 'idAttribute', 'id');
 
     let _sort;
 
@@ -115,7 +109,7 @@ const helpers = {
     );
 
     if (_sort.indexOf('.') === -1) {
-      _sort = `${tableName}.${_sort}`;
+      _sort = `${tableIdentifyer}.${_sort}`;
     }
 
     return obj.query(qb => {

--- a/src/model.js
+++ b/src/model.js
@@ -256,7 +256,7 @@ const BookshelfModel = ModelBase.extend({
    *
    *   Constructor of {@link Model} targeted by join.
    *
-   * @param {string=} table
+   * @param {string|string[]=} tableName|[tableName, tableAlias]
    *
    *   Name of the joining table. Defaults to the two table names, joined by an
    *   underscore, ordered alphabetically.
@@ -264,13 +264,13 @@ const BookshelfModel = ModelBase.extend({
    * @param {string=} foreignKey
    *
    *   Foreign key in this model. By default, the `foreignKey` is assumed to
-   *   be the singular form of the `Target` model's tableName, followed by `_id` /
+   *   be the singular form of this model's tableName, followed by `_id` /
    *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
    * @param {string=} otherKey
    *
    *   Foreign key in the `Target` model. By default, the `otherKey` is assumed to
-   *   be the singular form of this model's tableName, followed by `_id` /
+   *   be the singular form of the `Target` model's tableName, followed by `_id` /
    *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
    * @returns {Collection}

--- a/src/relation.js
+++ b/src/relation.js
@@ -159,12 +159,12 @@ export default RelationBase.extend({
   joinColumns: function(knex) {
     const columns = [];
     const joinTable = this.joinTable();
-    if (this.isThrough()) columns.push(this.throughIdAttribute);
+    if (this.isThrough()) columns.push(_.result(this.throughTable, 'idAttribute'));
     columns.push(this.key('foreignKey'));
     if (this.type === 'belongsToMany') columns.push(this.key('otherKey'));
     push.apply(columns, this.pivotColumns);
     knex.columns(_.map(columns, function(col) {
-      return joinTable + '.' + col + ' as _pivot_' + col;
+      return _.result(joinTable, 'identifyer') + '.' + col + ' as _pivot_' + col;
     }));
   },
 
@@ -591,7 +591,7 @@ const pivotHelpers = {
 
     // Grab the `knex` query builder for the current model, and
     // check if we have any additional constraints for the query.
-    const builder = this._builder(relatedData.joinTable());
+    const builder = this._builder(_.result(relatedData.joinTable(), 'aliasedName'));
     if (options && options.query) {
       Helpers.query.call(null, {_knex: builder}, [options.query]);
     }

--- a/src/relation.js
+++ b/src/relation.js
@@ -259,12 +259,17 @@ export default RelationBase.extend({
         _.result(this.targetTable, 'name')
       ].sort().join('_')
     );
-    return {
+    console.log(this.joinTableName);
+    const res = _.omit({
       name: joinTableName,
       alias: joinTableAlias,
       identifyer: joinTableAlias || joinTableName,
-      aliasedName: _.result(this.parent, 'aliasedName')
-    }
+      aliasedName: this.parentTable.aliasedName // FIXME: Can't access initialized `knex` instance from here.
+                                                //        Using parent models `table.aliasName` that has already
+                                                //        initialized `knex` instance.
+    }, _.isUndefined);
+    console.log(res);
+    return res;
   },
 
   // Creates a new model or collection instance, depending on

--- a/src/relation.js
+++ b/src/relation.js
@@ -242,7 +242,7 @@ export default RelationBase.extend({
   eagerKeys: function(response) {
     const key = this.isInverse() && !this.isThrough()
       ? this.key('foreignKey')
-      : this.parentIdAttribute;
+      : _.result(this.parentTable, 'idAttribute');
     return _(response).pluck(key).uniq().value();
   },
 
@@ -259,8 +259,7 @@ export default RelationBase.extend({
         _.result(this.targetTable, 'name')
       ].sort().join('_')
     );
-    console.log(this.joinTableName);
-    const res = _.omit({
+    return _.omit({
       name: joinTableName,
       alias: joinTableAlias,
       identifyer: joinTableAlias || joinTableName,
@@ -268,8 +267,6 @@ export default RelationBase.extend({
                                                 //        Using parent models `table.aliasName` that has already
                                                 //        initialized `knex` instance.
     }, _.isUndefined);
-    console.log(res);
-    return res;
   },
 
   // Creates a new model or collection instance, depending on

--- a/src/sync.js
+++ b/src/sync.js
@@ -22,10 +22,10 @@ _.extend(Sync.prototype, {
   // Prefix all keys of the passed in object with the
   // current table name
   prefixFields: function(fields) {
-    const tableName = this.syncing.tableName;
+    const tableIdentifyer = _.return(this.syncing, 'tableIdentifyer');
     const prefixed = {};
     for (const key in fields) {
-      prefixed[tableName + '.' + key] = fields[key];
+      prefixed[tableIdentifyer + '.' + key] = fields[key];
     }
     return prefixed;
   },
@@ -159,7 +159,7 @@ _.extend(Sync.prototype, {
 
           // If columns have already been selected via the `query` method
           // we will use them. Otherwise, select all columns in this table.
-          columns = [_.result(this.syncing, 'tableName') + '.*'];
+          columns = [_.result(this.syncing, 'tableIdentifyer') + '.*'];
         }
       }
 

--- a/test/integration/plugins/registry.js
+++ b/test/integration/plugins/registry.js
@@ -160,7 +160,7 @@ module.exports = function(Bookshelf) {
 
 			it('allows for *-through relations', function() {
 				var relation = this.model.throughTest();
-				expect(relation.relatedData.throughTableName).to.equal('related');
+				expect(relation.relatedData.throughTable.name).to.equal('related');
 			});
 
 			describe('morphTo', function() {

--- a/test/integration/relation.js
+++ b/test/integration/relation.js
@@ -94,14 +94,14 @@ module.exports = function(Bookshelf) {
         // Base
         equal(relatedData.type, 'hasOne');
         equal(relatedData.target, DoctorMeta);
-        equal(relatedData.targetTableName, 'doctormeta');
-        equal(relatedData.targetIdAttribute, 'customId');
+        equal(relatedData.targetTable.name, 'doctormeta');
+        equal(relatedData.targetTable.idAttribute, 'customId');
         equal(relatedData.foreignKey, 'doctoring_id');
 
         // Init
         equal(relatedData.parentId, 1);
-        equal(relatedData.parentTableName, 'doctors');
-        equal(relatedData.parentIdAttribute, 'id');
+        equal(relatedData.parentTable.name, 'doctors');
+        equal(relatedData.parentTable.idAttribute, 'id');
         equal(relatedData.parentFk, 1);
 
         // init the select constraints
@@ -119,20 +119,20 @@ module.exports = function(Bookshelf) {
         // Base
         equal(relatedData.type, 'hasOne');
         equal(relatedData.target, AccountHistory);
-        equal(relatedData.targetTableName, 'account_histories');
-        equal(relatedData.targetIdAttribute, 'id');
+        equal(relatedData.targetTable.name, 'account_histories');
+        equal(relatedData.targetTable.idAttribute, 'id');
         equal(relatedData.foreignKey, undefined);
 
         // Init
         equal(relatedData.parentId, 1);
-        equal(relatedData.parentTableName, 'suppliers');
-        equal(relatedData.parentIdAttribute, 'id');
+        equal(relatedData.parentTable.name, 'suppliers');
+        equal(relatedData.parentTable.idAttribute, 'id');
         equal(relatedData.parentFk, 1);
 
         // Through
         equal(relatedData.throughTarget, Account);
-        equal(relatedData.throughTableName, 'accounts');
-        equal(relatedData.throughIdAttribute, 'id');
+        equal(relatedData.throughTable.name, 'accounts');
+        equal(relatedData.throughTable.idAttribute, 'id');
 
         // init the select constraints
         relatedData.selectConstraints(_knex, {});
@@ -151,20 +151,20 @@ module.exports = function(Bookshelf) {
         // Base
         equal(relatedData.type, 'belongsTo');
         equal(relatedData.target, Supplier);
-        equal(relatedData.targetTableName, 'suppliers');
-        equal(relatedData.targetIdAttribute, 'id');
+        equal(relatedData.targetTable.name, 'suppliers');
+        equal(relatedData.targetTable.idAttribute, 'id');
         equal(relatedData.foreignKey, 'supplier_id');
 
         // Init
         equal(relatedData.parentId, 1);
-        equal(relatedData.parentTableName, 'account_histories');
-        equal(relatedData.parentIdAttribute, 'id');
+        equal(relatedData.parentTable.name, 'account_histories');
+        equal(relatedData.parentTable.idAttribute, 'id');
         equal(relatedData.parentFk, 1);
 
         // Through
         equal(relatedData.throughTarget, Account);
-        equal(relatedData.throughTableName, 'accounts');
-        equal(relatedData.throughIdAttribute, 'id');
+        equal(relatedData.throughTable.name, 'accounts');
+        equal(relatedData.throughTable.idAttribute, 'id');
 
         // init the select constraints
         relatedData.selectConstraints(_knex, {});
@@ -183,20 +183,20 @@ module.exports = function(Bookshelf) {
         // Base
         equal(relatedData.type, 'belongsToMany');
         equal(relatedData.target, Patient);
-        equal(relatedData.targetTableName, 'patients');
-        equal(relatedData.targetIdAttribute, 'id');
+        equal(relatedData.targetTable.name, 'patients');
+        equal(relatedData.targetTable.idAttribute, 'id');
         equal(relatedData.foreignKey, undefined);
 
         // Init
         equal(relatedData.parentId, 1);
-        equal(relatedData.parentTableName, 'doctors');
-        equal(relatedData.parentIdAttribute, 'id');
+        equal(relatedData.parentTable.name, 'doctors');
+        equal(relatedData.parentTable.idAttribute, 'id');
         equal(relatedData.parentFk, 1);
 
         // Through
         equal(relatedData.throughTarget, Appointment);
-        equal(relatedData.throughTableName, 'appointments');
-        equal(relatedData.throughIdAttribute, 'id');
+        equal(relatedData.throughTable.name, 'appointments');
+        equal(relatedData.throughTable.idAttribute, 'id');
 
         // init the select constraints
         relatedData.selectConstraints(_knex, {});
@@ -215,14 +215,14 @@ module.exports = function(Bookshelf) {
         // Base
         equal(relatedData.type, 'belongsToMany');
         equal(relatedData.target, Patient);
-        equal(relatedData.targetTableName, 'patients');
-        equal(relatedData.targetIdAttribute, 'id');
+        equal(relatedData.targetTable.name, 'patients');
+        equal(relatedData.targetTable.idAttribute, 'id');
         equal(relatedData.foreignKey, undefined);
 
         // Init
         equal(relatedData.parentId, 1);
-        equal(relatedData.parentTableName, 'doctors');
-        equal(relatedData.parentIdAttribute, 'id');
+        equal(relatedData.parentTable.name, 'doctors');
+        equal(relatedData.parentTable.idAttribute, 'id');
         equal(relatedData.parentFk, 1);
 
         // init the select constraints
@@ -242,14 +242,14 @@ module.exports = function(Bookshelf) {
         // Base
         equal(relatedData.type, 'morphMany');
         equal(relatedData.target, Photo);
-        equal(relatedData.targetTableName, 'photos');
-        equal(relatedData.targetIdAttribute, 'id');
+        equal(relatedData.targetTable.name, 'photos');
+        equal(relatedData.targetTable.idAttribute, 'id');
         equal(relatedData.foreignKey, undefined);
 
         // Init
         equal(relatedData.parentId, 1);
-        equal(relatedData.parentTableName, 'doctors');
-        equal(relatedData.parentIdAttribute, 'id');
+        equal(relatedData.parentTable.name, 'doctors');
+        equal(relatedData.parentTable.idAttribute, 'id');
         equal(relatedData.parentFk, 1);
 
         // init the select constraints


### PR DESCRIPTION
This is a really major refactoring of `RelationBase`/`Relation` class to enable using table name alias. At the same time the current API is not changed.

**This is just an initial PR for reviewing.**

Enables defining `tableAlias` model property.

``` js
var Shop = Model.extend({
  tableName: 'organization_units',
  tableAlias: 'shops',
  initialize: function() {
    Model.constructor.apply(this, arguments);
    this.attributes.type_id = this.attributes.type_id || 123
  }
});

Shop.fetch();
```

This would execute following SQL

``` sql
select `shops`.* from `organization_units` `shops` where `shops`.`type_id` = 123
```

instead of

``` sql
select `organization_units`.* from `organization_units` where `organization_units`.`type_id` = 123
```

:exclamation: **Tests need to be written** :exclamation: 

Solves #96
