### PR TITLE
Fix #1159 by formating attributes

### DIFF
--- a/src/eager.js
+++ b/src/eager.js
@@ -6,8 +6,14 @@ import Helpers from './helpers';
 import Promise from './base/promise';
 import EagerBase from './base/eager';
 
-const getAttributeUnique = (models, attribute) =>
-  _.uniq(_.map(models, m => m.get(attribute)));
+const getAttributeUnique = (models, attribute) => {
+  return _.uniq(_.map(models, m => {
+    // use formatted attributes so that morphKey and foreignKey will match
+    // attribute keys
+    const formatted = m.format(_.clone(m.attributes));
+    return formatted[attribute];
+  }));
+};
 
 // An `EagerRelation` object temporarily stores the models from an eager load,
 // and handles matching eager loaded objects with their parent(s). The
@@ -45,7 +51,12 @@ export default class EagerRelation extends EagerBase {
       typeColumn = `${morphName}_type`, idColumn = `${morphName}_id`
     ] = columnNames;
 
-    const parentsByType = _.groupBy(this.parent, model => model.get(typeColumn));
+    const parentsByType = _.groupBy(this.parent, model => {
+      // use formatted attributes so that morphKey and foreignKey will match
+      // attribute keys
+      const attributes = model.format(_.clone(model.attributes));
+      return attributes[typeColumn];
+    });
     const TargetByType = _.mapValues(parentsByType, (parents, type) =>
       Helpers.morphCandidate(relatedData.candidates, type)
     );

--- a/src/eager.js
+++ b/src/eager.js
@@ -6,14 +6,8 @@ import Helpers from './helpers';
 import Promise from './base/promise';
 import EagerBase from './base/eager';
 
-const getAttributeUnique = (models, attribute) => {
-  return _.uniq(_.map(models, m => {
-    // use formatted attributes so that morphKey and foreignKey will match
-    // attribute keys
-    const formatted = m.format(_.clone(m.attributes));
-    return formatted[attribute];
-  }));
-};
+const getAttributeUnique = (models, attribute) =>
+  _.uniq(_.map(models, m => m.get(Helpers.parseAttribute(m, attribute))));
 
 // An `EagerRelation` object temporarily stores the models from an eager load,
 // and handles matching eager loaded objects with their parent(s). The
@@ -51,12 +45,9 @@ export default class EagerRelation extends EagerBase {
       typeColumn = `${morphName}_type`, idColumn = `${morphName}_id`
     ] = columnNames;
 
-    const parentsByType = _.groupBy(this.parent, model => {
-      // use formatted attributes so that morphKey and foreignKey will match
-      // attribute keys
-      const attributes = model.format(_.clone(model.attributes));
-      return attributes[typeColumn];
-    });
+    const parentsByType = _.groupBy(this.parent, model =>
+      model.get(Helpers.parseAttribute(model, typeColumn))
+    );
     const TargetByType = _.mapValues(parentsByType, (parents, type) =>
       Helpers.morphCandidate(relatedData.candidates, type)
     );

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -121,6 +121,12 @@ const helpers = {
     return obj.query(qb => {
       qb.orderBy(_sort, _order);
     });
+  },
+
+  // Needed when the `parse` and `format` method are override
+  // so that `morphKey` and `foreignKey` match attribute keys
+  parseAttribute (model, attribute) {
+    return _.head(_.keys(model.parse({ [attribute]: null })));
   }
 
 };

--- a/src/relation.js
+++ b/src/relation.js
@@ -397,15 +397,13 @@ export default RelationBase.extend({
     // Loop over the `parentModels` and attach the grouped sub-models,
     // keeping the `relatedData` on the new related instance.
     _.each(parentModels, (model) => {
-      let groupedKey;
-      if (!this.isInverse()) {
-        groupedKey = model.get(this.parentIdAttribute);
+      let keyColumn;
+      if (this.isInverse()) {
+        keyColumn = this.key(this.isThrough() ? 'throughForeignKey': 'foreignKey');
       } else {
-        const keyColumn = this.key(
-          this.isThrough() ? 'throughForeignKey': 'foreignKey'
-        );
-        groupedKey = model.get(Helpers.parseAttribute(model, keyColumn));
+        keyColumn = this.parentIdAttribute;
       }
+      const groupedKey = model.get(Helpers.parseAttribute(model, keyColumn));
       const relation = model.relations[relationName] = this.relatedInstance(grouped[groupedKey]);
       relation.relatedData = this;
       if (this.isJoined()) _.extend(relation, pivotHelpers);

--- a/src/relation.js
+++ b/src/relation.js
@@ -370,7 +370,10 @@ export default RelationBase.extend({
     // If this is a morphTo, we only want to pair on the morphValue for the current relation.
     if (this.type === 'morphTo') {
       parentModels = _.filter(parentModels, (m) => {
-        return m.get(this.key('morphKey')) === this.key('morphValue');
+        // use formatted attributes so that morphKey will match
+        // attribute keys
+        const formatted = m.format(_.clone(m.attributes));
+        return formatted[this.key('morphKey')] === this.key('morphValue');
       });
     }
 

--- a/src/relation.js
+++ b/src/relation.js
@@ -369,12 +369,9 @@ export default RelationBase.extend({
   eagerPair(relationName, related, parentModels) {
     // If this is a morphTo, we only want to pair on the morphValue for the current relation.
     if (this.type === 'morphTo') {
-      parentModels = _.filter(parentModels, (m) => {
-        // use formatted attributes so that morphKey will match
-        // attribute keys
-        const formatted = m.format(_.clone(m.attributes));
-        return formatted[this.key('morphKey')] === this.key('morphValue');
-      });
+      parentModels = _.filter(parentModels, (m) =>
+        m.get(Helpers.parseAttribute(m, this.key('morphKey'))) === this.key('morphValue')
+      );
     }
 
     // If this is a `through` or `belongsToMany` relation, we need to cleanup & setup the `interim` model.
@@ -407,8 +404,7 @@ export default RelationBase.extend({
         const keyColumn = this.key(
           this.isThrough() ? 'throughForeignKey': 'foreignKey'
         );
-        const formatted = model.format(_.clone(model.attributes));
-        groupedKey = formatted[keyColumn];
+        groupedKey = model.get(Helpers.parseAttribute(model, keyColumn));
       }
       const relation = model.relations[relationName] = this.relatedInstance(grouped[groupedKey]);
       relation.relatedData = this;

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -2449,6 +2449,717 @@ module.exports = {
       }]
     }
   },
+  'eager loads morphMany on parsed model (sites -> photos)': {
+    mysql: {
+      result: [{
+        id_parsed: 1,
+        name_parsed: 'knexjs.org',
+        photos: [{
+          id_parsed: 3,
+          url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+          caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id_parsed: 1,
+          imageable_type_parsed: 'sites'
+        },{
+          id_parsed: 4,
+          url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+          caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id_parsed: 1,
+          imageable_type_parsed: 'sites'
+        }]
+      },{
+        id_parsed: 2,
+        name_parsed: 'bookshelfjs.org',
+        photos: [{
+          id_parsed: 5,
+          url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+          caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id_parsed: 2,
+          imageable_type_parsed: 'sites'
+        },{
+          id_parsed: 6,
+          url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+          caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id_parsed: 2,
+          imageable_type_parsed: 'sites'
+        }]
+      },{
+        id_parsed: 3,
+        name_parsed: 'backbonejs.org',
+        photos: []
+      }]
+    },
+    postgresql: {
+      result: [{
+        id_parsed: 1,
+        name_parsed: 'knexjs.org',
+        photos: [{
+          id_parsed: 3,
+          url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+          caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id_parsed: 1,
+          imageable_type_parsed: 'sites'
+        },{
+          id_parsed: 4,
+          url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+          caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id_parsed: 1,
+          imageable_type_parsed: 'sites'
+        }]
+      },{
+        id_parsed: 2,
+        name_parsed: 'bookshelfjs.org',
+        photos: [{
+          id_parsed: 5,
+          url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+          caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id_parsed: 2,
+          imageable_type_parsed: 'sites'
+        },{
+          id_parsed: 6,
+          url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+          caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id_parsed: 2,
+          imageable_type_parsed: 'sites'
+        }]
+      },{
+        id_parsed: 3,
+        name_parsed: 'backbonejs.org',
+        photos: []
+      }]
+    },
+    sqlite3: {
+      result: [{
+        id_parsed: 1,
+        name_parsed: 'knexjs.org',
+        photos: [{
+          id_parsed: 3,
+          url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+          caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id_parsed: 1,
+          imageable_type_parsed: 'sites'
+        },{
+          id_parsed: 4,
+          url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+          caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id_parsed: 1,
+          imageable_type_parsed: 'sites'
+        }]
+      },{
+        id_parsed: 2,
+        name_parsed: 'bookshelfjs.org',
+        photos: [{
+          id_parsed: 5,
+          url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+          caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id_parsed: 2,
+          imageable_type_parsed: 'sites'
+        },{
+          id_parsed: 6,
+          url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+          caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id_parsed: 2,
+          imageable_type_parsed: 'sites'
+        }]
+      },{
+        id_parsed: 3,
+        name_parsed: 'backbonejs.org',
+        photos: []
+      }]
+    }
+  },
+  'eager loads morphTo on parsed model (photos -> imageable)': {
+    mysql: {
+      result: [{
+        id_parsed: 1,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'authors',
+        imageable: {
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser'
+        }
+      },{
+        id_parsed: 2,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'authors',
+        imageable: {
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe'
+        }
+      },{
+        id_parsed: 3,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org'
+        }
+      },{
+        id_parsed: 4,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org'
+        }
+      },{
+        id_parsed: 5,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      },{
+        id_parsed: 6,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      },{
+        id_parsed: 7,
+        url_parsed: 'http://image.dev',
+        caption_parsed: 'this is a test image',
+        imageable_id_parsed: 10,
+        imageable_type_parsed: 'sites',
+        imageable: {
+
+        }
+      }]
+    },
+    postgresql: {
+      result: [{
+        id_parsed: 1,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'authors',
+        imageable: {
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser'
+        }
+      },{
+        id_parsed: 2,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'authors',
+        imageable: {
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe'
+        }
+      },{
+        id_parsed: 3,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org'
+        }
+      },{
+        id_parsed: 4,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org'
+        }
+      },{
+        id_parsed: 5,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      },{
+        id_parsed: 6,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      },{
+        id_parsed: 7,
+        url_parsed: 'http://image.dev',
+        caption_parsed: 'this is a test image',
+        imageable_id_parsed: 10,
+        imageable_type_parsed: 'sites',
+        imageable: {
+
+        }
+      }]
+    },
+    sqlite3: {
+      result: [{
+        id_parsed: 1,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'authors',
+        imageable: {
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser'
+        }
+      },{
+        id_parsed: 2,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'authors',
+        imageable: {
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe'
+        }
+      },{
+        id_parsed: 3,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org'
+        }
+      },{
+        id_parsed: 4,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org'
+        }
+      },{
+        id_parsed: 5,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      },{
+        id_parsed: 6,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      },{
+        id_parsed: 7,
+        url_parsed: 'http://image.dev',
+        caption_parsed: 'this is a test image',
+        imageable_id_parsed: 10,
+        imageable_type_parsed: 'sites',
+        imageable: {
+
+        }
+      }]
+    }
+  },
+  'eager loads beyond the morphTo on parsed model, where possible': {
+    mysql: {
+      result: [{
+        id_parsed: 1,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'authors',
+        imageable: {
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser'
+        }
+      },{
+        id_parsed: 2,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'authors',
+        imageable: {
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe'
+        }
+      },{
+        id_parsed: 3,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org',
+          authors: [{
+            id: 1,
+            site_id: 1,
+            first_name: 'Tim',
+            last_name: 'Griesser'
+          },{
+            id: 2,
+            site_id: 1,
+            first_name: 'Bazooka',
+            last_name: 'Joe'
+          }]
+        }
+      },{
+        id_parsed: 4,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org',
+          authors: [{
+            id: 1,
+            site_id: 1,
+            first_name: 'Tim',
+            last_name: 'Griesser'
+          },{
+            id: 2,
+            site_id: 1,
+            first_name: 'Bazooka',
+            last_name: 'Joe'
+          }]
+        }
+      },{
+        id_parsed: 5,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org',
+          authors: [{
+            id: 3,
+            site_id: 2,
+            first_name: 'Charlie',
+            last_name: 'Brown'
+          },{
+            id: 4,
+            site_id: 2,
+            first_name: 'Ron',
+            last_name: 'Burgundy'
+          }]
+        }
+      },{
+        id_parsed: 6,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org',
+          authors: [{
+            id: 3,
+            site_id: 2,
+            first_name: 'Charlie',
+            last_name: 'Brown'
+          },{
+            id: 4,
+            site_id: 2,
+            first_name: 'Ron',
+            last_name: 'Burgundy'
+          }]
+        }
+      },{
+        id_parsed: 7,
+        url_parsed: 'http://image.dev',
+        caption_parsed: 'this is a test image',
+        imageable_id_parsed: 10,
+        imageable_type_parsed: 'sites',
+        imageable: {
+
+        }
+      }]
+    },
+    postgresql: {
+      result: [{
+        id_parsed: 1,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'authors',
+        imageable: {
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser'
+        }
+      },{
+        id_parsed: 2,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'authors',
+        imageable: {
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe'
+        }
+      },{
+        id_parsed: 3,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org',
+          authors: [{
+            id: 1,
+            site_id: 1,
+            first_name: 'Tim',
+            last_name: 'Griesser'
+          },{
+            id: 2,
+            site_id: 1,
+            first_name: 'Bazooka',
+            last_name: 'Joe'
+          }]
+        }
+      },{
+        id_parsed: 4,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org',
+          authors: [{
+            id: 1,
+            site_id: 1,
+            first_name: 'Tim',
+            last_name: 'Griesser'
+          },{
+            id: 2,
+            site_id: 1,
+            first_name: 'Bazooka',
+            last_name: 'Joe'
+          }]
+        }
+      },{
+        id_parsed: 5,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org',
+          authors: [{
+            id: 3,
+            site_id: 2,
+            first_name: 'Charlie',
+            last_name: 'Brown'
+          },{
+            id: 4,
+            site_id: 2,
+            first_name: 'Ron',
+            last_name: 'Burgundy'
+          }]
+        }
+      },{
+        id_parsed: 6,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org',
+          authors: [{
+            id: 3,
+            site_id: 2,
+            first_name: 'Charlie',
+            last_name: 'Brown'
+          },{
+            id: 4,
+            site_id: 2,
+            first_name: 'Ron',
+            last_name: 'Burgundy'
+          }]
+        }
+      },{
+        id_parsed: 7,
+        url_parsed: 'http://image.dev',
+        caption_parsed: 'this is a test image',
+        imageable_id_parsed: 10,
+        imageable_type_parsed: 'sites',
+        imageable: {
+
+        }
+      }]
+    },
+    sqlite3: {
+      result: [{
+        id_parsed: 1,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'authors',
+        imageable: {
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser'
+        }
+      },{
+        id_parsed: 2,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'authors',
+        imageable: {
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe'
+        }
+      },{
+        id_parsed: 3,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org',
+          authors: [{
+            id: 1,
+            site_id: 1,
+            first_name: 'Tim',
+            last_name: 'Griesser'
+          },{
+            id: 2,
+            site_id: 1,
+            first_name: 'Bazooka',
+            last_name: 'Joe'
+          }]
+        }
+      },{
+        id_parsed: 4,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org',
+          authors: [{
+            id: 1,
+            site_id: 1,
+            first_name: 'Tim',
+            last_name: 'Griesser'
+          },{
+            id: 2,
+            site_id: 1,
+            first_name: 'Bazooka',
+            last_name: 'Joe'
+          }]
+        }
+      },{
+        id_parsed: 5,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org',
+          authors: [{
+            id: 3,
+            site_id: 2,
+            first_name: 'Charlie',
+            last_name: 'Brown'
+          },{
+            id: 4,
+            site_id: 2,
+            first_name: 'Ron',
+            last_name: 'Burgundy'
+          }]
+        }
+      },{
+        id_parsed: 6,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id_parsed: 2,
+        imageable_type_parsed: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org',
+          authors: [{
+            id: 3,
+            site_id: 2,
+            first_name: 'Charlie',
+            last_name: 'Brown'
+          },{
+            id: 4,
+            site_id: 2,
+            first_name: 'Ron',
+            last_name: 'Burgundy'
+          }]
+        }
+      },{
+        id_parsed: 7,
+        url_parsed: 'http://image.dev',
+        caption_parsed: 'this is a test image',
+        imageable_id_parsed: 10,
+        imageable_type_parsed: 'sites',
+        imageable: {
+
+        }
+      }]
+    }
+  },
   'handles morphOne with custom columnNames (thumbnail)': {
     mysql: {
       result: {

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -22,6 +22,7 @@ module.exports = function(Bookshelf) {
 
     // Models
     var Site         = Models.Site;
+    var SiteParsed   = Models.SiteParsed;
     var SiteMeta     = Models.SiteMeta;
     var Admin        = Models.Admin;
     var Author       = Models.Author;
@@ -643,6 +644,18 @@ module.exports = function(Bookshelf) {
 
         it('eager loads beyond the morphTo, where possible', function() {
           return Photo.fetchAll({withRelated: ['imageable.authors']}).tap(checkTest(this));
+        });
+
+        //it('eager loads morphMany on parsed model (sites -> photos)', function() {
+        //  return new SiteParsed().fetchAll({withRelated: ['photos']}).tap(checkTest(this));
+        //});
+
+        it('eager loads morphTo on parsed model (photos -> imageable)', function() {
+          return PhotoParsed.fetchAll({withRelated: ['imageable']}).tap(checkTest(this));
+        });
+
+        it('eager loads beyond the morphTo on parsed model, where possible', function() {
+          return PhotoParsed.fetchAll({withRelated: ['imageable.authors']}).tap(checkTest(this));
         });
 
 

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -646,9 +646,9 @@ module.exports = function(Bookshelf) {
           return Photo.fetchAll({withRelated: ['imageable.authors']}).tap(checkTest(this));
         });
 
-        //it('eager loads morphMany on parsed model (sites -> photos)', function() {
-        //  return new SiteParsed().fetchAll({withRelated: ['photos']}).tap(checkTest(this));
-        //});
+        it('eager loads morphMany on parsed model (sites -> photos)', function() {
+          return new SiteParsed().fetchAll({withRelated: ['photos']}).tap(checkTest(this));
+        });
 
         it('eager loads morphTo on parsed model (photos -> imageable)', function() {
           return PhotoParsed.fetchAll({withRelated: ['imageable']}).tap(checkTest(this));


### PR DESCRIPTION
If `this.parent` contains the same models it might be more efficient to use the `parse` method on `typeColumn` and `idColumn` instead.  I don't know enough the codebase to find the answer by myself. But at least this fix the bug.

Let me know what do you think.

Solves [#1159](https://github.com/tgriesser/bookshelf/issues/1159)
