### PR TITLE
Count all entries instead of distinct primary keys

### DIFF
--- a/src/plugins/pagination.js
+++ b/src/plugins/pagination.js
@@ -172,7 +172,7 @@ module.exports = function paginationPlugin (bookshelf) {
           return (notNeededQueries.indexOf(statement.type) > -1) ||
             statement.grouping === 'columns';
         });
-        qb.countDistinct.apply(qb, [`${tableName}.${idAttribute}`]);
+	qb.count.apply(qb, ['*']);
 
       }).fetchAll().then(result => {
 


### PR DESCRIPTION
If you have a composed primary key, this distinct will not work.
Counting all results of select query works properly.
