### PR TITLE
Fix parentIdAttribute on belongsTo relation

### DIFF
--- a/src/relation.js
+++ b/src/relation.js
@@ -144,7 +144,11 @@ export default RelationBase.extend({
           return this.parentIdAttribute;
         }
 
-        if (this.isForeignKeyTargeted()) {
+        if (this.type === 'belongsTo' && this.foreignKey) {
+          return this.foreignKey;
+        }
+
+        if (this.type !== 'belongsTo' && this.isForeignKeyTargeted()) {
           return this.foreignKeyTarget;
         }
 

--- a/test/integration/relation.js
+++ b/test/integration/relation.js
@@ -474,7 +474,7 @@ module.exports = function(Bookshelf) {
         // Init
         equal(relatedData.parentId, undefined);
         equal(relatedData.parentTableName, 'translations');
-        equal(relatedData.parentIdAttribute, 'isoCode');
+        equal(relatedData.parentIdAttribute, 'code');
         equal(relatedData.parentFk, 'en');
 
         // init the select constraints


### PR DESCRIPTION
This PR fixes the `parentIdAttribute` calculation on a `belongsTo` relation, which should be `foreignKey` if explicitly passed on the relation constructor, but never `foreignKeyTarget` as it references the target table.
