### PR TITLE
Allow using docker for running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 * Use the same coding style as the rest of the
 [codebase](https://github.com/tgriesser/bookshelf/blob/master/src/bookshelf.js).
 
-* Make changes in the /src directory, running "npm run dev" which will kick off 
+* Make changes in the /src directory, running "npm run dev" which will kick off
 transpilation from ES6 in the background.
 
 * All pull requests should be made to the `master` branch.
@@ -29,10 +29,25 @@ $ npm install
 At this point the only thing missing are the databases that will be used for running some of the tests of the automated
 test suite.
 
-There are two options for setting up this part. The first one is to change some configuration options of the database
-servers and the other is to use a config file in case you already have your servers configured and don't want to change
-any of their config files. The first two sections below deal with the first option and then there are instructions on
-how to use the other option.
+There are three options for setting up this part. The first one is to use docker containers for the database servers, alternatively you can provide configuration options of the database
+servers and lastly is to use a config file in case you already have your servers configured and don't want to change
+any of their config files.
+
+### Docker
+
+You can install [Docker](http://www.docker.com) easily on linux / osx distros by invoking one of the following commands
+
+`curl -sSL https://get.docker.com/ | sh` or `wget -qO- https://get.docker.com/ | sh`
+
+Next we will install Docker Compose, installation instructions can be found [here](https://docs.docker.com/compose/install/)
+
+Now we can issue the command to initiate the database servers;
+
+`sudo docker-compose up`
+
+### Database Servers
+
+The two sections below deal with setting up the database servers needed for running tests.
 
 #### MySQL
 
@@ -114,7 +129,7 @@ access on clients connecting locally. Do not use this setting in a production en
 
 After editing the `pg_hba.conf` file you'll need to restart the PostgreSQL server for the changes to take effect.
 
-#### Using a config file
+### Configuration File
 
 If you don't want to go to the trouble of performing the changes explained in the previous two sections you can instead
 use a config file that tells the test suite about your database setup.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+services:
+  mysql:
+    image: mysql
+    restart: always
+    ports:
+    - "3306:3306"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: bookshelf
+      MYSQL_DATABASE: bookshelf_test
+      MYSQL_USER: root
+      MYSQL_PASSWORD:
+  postgres:
+    image: postgres
+    restart: always
+    ports:
+    - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD:
+      POSTGRES_USER: root
+      POSTGRES_DB: bookshelf_test


### PR DESCRIPTION
Allow for using dockerized containers for testing database servers, simplifies the setup process