### PR TITLE
Ensure previousAttributes are parsed after eagerPair

### DIFF
--- a/src/relation.js
+++ b/src/relation.js
@@ -416,6 +416,7 @@ export default RelationBase.extend({
     // its parsed attributes
     related.map(model => {
       model.attributes = model.parse(model.attributes)
+      model._reset();
     });
 
     return related;

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -845,6 +845,16 @@ module.exports = function(Bookshelf) {
           });
       });
 
+      it('parses eager-loaded models previous attributes after pairing', function () {
+        return new Blog({id: 1}).fetch({ withRelated: 'parsedPosts' })
+          .then(function (blog) {
+            var prev = blog.related('parsedPosts').at(0)._previousAttributes;
+            Object.keys(prev).forEach(function (key) {
+              expect(/_parsed$/.test(key)).to.be.true;
+            });
+          });
+      });
+
       it('parses eager-loaded morphTo relations (model)', function () {
         return Photo.fetchAll({ withRelated: 'imageableParsed.meta', log: true })
           .then(function (photos) {


### PR DESCRIPTION
Ensure that previous attributes are properly parsed after eagerPair completes. Currently any models loaded via `withRelated` do not have their previous models parsed.

An unverified side effect is with `_previousAttributes` unparsed any call to `set` will cause a mismatch in parsed attributes and unparsed previous attributes resulting in values that could be equal being recorded as changed.

Should resolve https://github.com/tgriesser/bookshelf/issues/1394