### PR TITLE
Fix fetchPage on Collection (pagination plugin)

### DIFF
--- a/src/plugins/pagination.js
+++ b/src/plugins/pagination.js
@@ -211,7 +211,7 @@ module.exports = function paginationPlugin (bookshelf) {
   }
 
   bookshelf.Collection.prototype.fetchPage = function (...args) {
-    return fetchPage.apply(this.model.forge(), ...args);
+    return fetchPage.apply(this.model.forge(), args);
   };
 
 }


### PR DESCRIPTION
When calling `.fetchPage` on a Collection, arguments (specifically, the options map) are not being passed to the `fetchPage` function due to the incorrect inclusion of the spread operator (or, confusing Function.prototype.apply for Function.prototype.call).

Just had to get rid of the spread operator so that arguments are forwarded correctly.