### PR TITLE
Add support for parameterized virtual getters.

### DIFF
--- a/src/plugins/virtuals.js
+++ b/src/plugins/virtuals.js
@@ -42,17 +42,17 @@ module.exports = function (Bookshelf) {
       let attrs = proto.toJSON.call(this, options);
       if (!options || options.virtuals !== false) {
         if ((options && options.virtuals === true) || this.outputVirtuals) {
-          attrs = _.extend(attrs, getVirtuals(this));
+          attrs = _.extend(attrs, getVirtuals(this, options ? options.param : undefined));
         }
       }
       return attrs;
     },
 
     // Allow virtuals to be fetched like normal properties
-    get: function (attr) {
+    get: function (attr, param) {
       const { virtuals } = this;
       if (_.isObject(virtuals) && virtuals[attr]) {
-        return getVirtual(this, attr);
+        return getVirtual(this, attr, param);
       }
       return proto.get.apply(this, arguments);
     },
@@ -156,20 +156,20 @@ module.exports = function (Bookshelf) {
     };
   });
 
-  function getVirtual(model, virtualName) {
+  function getVirtual(model, virtualName, param) {
     const { virtuals } = model;
     if (_.isObject(virtuals) && virtuals[virtualName]) {
-      return virtuals[virtualName].get ? virtuals[virtualName].get.call(model)
-        : virtuals[virtualName].call(model);
+      return virtuals[virtualName].get ? virtuals[virtualName].get.call(model, param)
+        : virtuals[virtualName].call(model, param);
     }
   }
 
-  function getVirtuals(model) {
+  function getVirtuals(model, param) {
     const { virtuals } = model;
     const attrs = {};
     if (virtuals != null) {
       for (const virtualName in virtuals) {
-        attrs[virtualName] = getVirtual(model, virtualName);
+        attrs[virtualName] = getVirtual(model, virtualName, param);
       }
     }
     return attrs;

--- a/test/integration.js
+++ b/test/integration.js
@@ -21,11 +21,12 @@ module.exports = function(Bookshelf) {
   });
 
   var MySQL = require('../bookshelf')(mysql);
-  var PostgreSQL = require('../bookshelf')(pg);
-  var SQLite3 = require('../bookshelf')(sqlite3);
-  var Swapped = require('../bookshelf')(Knex({}));
-  Swapped.knex = sqlite3;
+  //var PostgreSQL = require('../bookshelf')(pg);
+  //var SQLite3 = require('../bookshelf')(sqlite3);
+  //var Swapped = require('../bookshelf')(Knex({}));
+  //Swapped.knex = sqlite3;
 
+  /*
   it('should allow creating a new Bookshelf instance with "new"', function() {
     var bookshelf = new Bookshelf(sqlite3);
     expect(bookshelf.knex).to.equal(sqlite3);
@@ -47,8 +48,9 @@ module.exports = function(Bookshelf) {
         });
     });
   });
+  */
 
-  _.each([MySQL, PostgreSQL, SQLite3, Swapped], function(bookshelf) {
+  _.each([MySQL /*, PostgreSQL, SQLite3, Swapped*/], function(bookshelf) {
 
     var dialect = bookshelf.knex.client.dialect;
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -21,12 +21,11 @@ module.exports = function(Bookshelf) {
   });
 
   var MySQL = require('../bookshelf')(mysql);
-  //var PostgreSQL = require('../bookshelf')(pg);
-  //var SQLite3 = require('../bookshelf')(sqlite3);
-  //var Swapped = require('../bookshelf')(Knex({}));
-  //Swapped.knex = sqlite3;
+  var PostgreSQL = require('../bookshelf')(pg);
+  var SQLite3 = require('../bookshelf')(sqlite3);
+  var Swapped = require('../bookshelf')(Knex({}));
+  Swapped.knex = sqlite3;
 
-  /*
   it('should allow creating a new Bookshelf instance with "new"', function() {
     var bookshelf = new Bookshelf(sqlite3);
     expect(bookshelf.knex).to.equal(sqlite3);
@@ -48,9 +47,8 @@ module.exports = function(Bookshelf) {
         });
     });
   });
-  */
 
-  _.each([MySQL /*, PostgreSQL, SQLite3, Swapped*/], function(bookshelf) {
+  _.each([MySQL, PostgreSQL, SQLite3, Swapped], function(bookshelf) {
 
     var dialect = bookshelf.knex.client.dialect;
 

--- a/test/integration/plugins/virtuals.js
+++ b/test/integration/plugins/virtuals.js
@@ -22,6 +22,21 @@ module.exports = function (bookshelf) {
       equal(m.fullName, 'Joe Shmoe');
     });
 
+    it('allows for normal access to parameterized virtual properties on the model', function () {
+      var m = new (bookshelf.Model.extend({
+        virtuals: {
+          fullName: function(middleName) {
+              if (middleName === undefined)
+                return this.get('firstName') + ' ' + this.get('lastName');
+              else
+                return this.get('firstName') + ' ' + middleName + ' ' + this.get('lastName');
+          }
+        }
+      }))({firstName: 'Joe', lastName: 'Shmoe'});
+
+      equal(m.fullName, 'Joe Shmoe');
+    });
+
     it('allows to create virtual properties with getter and setter', function () {
       var m = new (bookshelf.Model.extend({
         virtuals: {
@@ -46,6 +61,55 @@ module.exports = function (bookshelf) {
       equal(m.get('lastName'), 'Shmoe');
     });
 
+    it('allows for normal access to parameterized virtual properties with getter and setter', function () {
+      var m = new (bookshelf.Model.extend({
+        virtuals: {
+          fullName: {
+            get: function (middleName) {
+              if (middleName === undefined)
+                return this.get('firstName') + ' ' + this.get('lastName');
+              else
+                return this.get('firstName') + ' ' + middleName + ' ' + this.get('lastName');
+            },
+            set: function(value) {
+              value = value.split(' ');
+              this.set('firstName', value[0]);
+              this.set('lastName', value[1]);
+            }
+          }
+        }
+      }))({firstName: 'Joe', lastName: 'Shmoe'});
+
+      equal(m.fullName, 'Joe Shmoe');
+      m.fullName = 'Jack Shmoe';
+
+      equal(m.fullName, 'Jack Shmoe');
+      equal(m.get('firstName'), 'Jack');
+      equal(m.get('lastName'), 'Shmoe');
+    });
+
+    it('allows for access to parameterized virtual properties with getter and setter', function () {
+      var m = new (bookshelf.Model.extend({
+        virtuals: {
+          fullName: {
+            get: function (middleName) {
+              if (middleName === undefined)
+                return this.get('firstName') + ' ' + this.get('lastName');
+              else
+                return this.get('firstName') + ' ' + middleName + ' ' + this.get('lastName');
+            },
+            set: function(value) {
+              value = value.split(' ');
+              this.set('firstName', value[0]);
+              this.set('lastName', value[1]);
+            }
+          }
+        }
+      }))({firstName: 'Joe', lastName: 'Shmoe'});
+
+      equal(m.get('fullName', 'Trouble'), 'Joe Trouble Shmoe');
+    });
+
     it('defaults virtual properties with no setter to a noop', function () {
        var m = new (bookshelf.Model.extend({
         virtuals: {
@@ -68,6 +132,43 @@ module.exports = function (bookshelf) {
           fullName: {
             get: function () {
               return this.get('firstName') + ' ' + this.get('lastName');
+            },
+            set: function(value) {
+              value = value.split(' ');
+              this.set('firstName', value[0]);
+              this.set('lastName', value[1]);
+            }
+          }
+        }
+      }))({firstName: 'Joe', lastName: 'Shmoe'});
+
+      equal(m.get('fullName'), 'Joe Shmoe');
+
+      m.set('fullName', 'Jack Shmoe');
+      equal(m.get('firstName'), 'Jack');
+      equal(m.get('lastName'), 'Shmoe');
+
+      // setting virtual should not set attribute
+      equal(m.attributes['fullName'], undefined);
+
+      m.set({fullName: 'Peter Griffin', dogName:'Brian'});
+      equal(m.get('firstName'), 'Peter');
+      equal(m.get('lastName'), 'Griffin');
+      equal(m.get('dogName'), 'Brian');
+
+      // setting virtual should not set attribute
+      equal(m.attributes['fullName'], undefined);
+    });
+
+    it('allows parameterized virtual properties to be set and get like normal properties', function () {
+      var m = new (bookshelf.Model.extend({
+        virtuals: {
+          fullName: {
+            get: function (middleName) {
+              if (middleName === undefined)
+                return this.get('firstName') + ' ' + this.get('lastName');
+              else
+                return this.get('firstName') + ' ' + middleName + ' ' + this.get('lastName');
             },
             set: function(value) {
               value = value.split(' ');
@@ -181,6 +282,100 @@ module.exports = function (bookshelf) {
       deepEqual(_.keys(json), ['firstName', 'lastName']);
     });
 
+    it('parameterized virtuals are included in the `toJSON` result', function () {
+      var m = new (bookshelf.Model.extend({
+        outputVirtuals: false,
+        virtuals: {
+          fullName: function(middleName) {
+            if (middleName === undefined)
+              return this.get('firstName') + ' ' + this.get('lastName');
+            else
+              return this.get('firstName') + ' ' + middleName + ' ' + this.get('lastName');
+          }
+        }
+      }))({firstName: 'Joe', lastName: 'Shmoe'});
+      var json = m.toJSON({virtuals: true});
+      deepEqual(_.keys(json), ['firstName', 'lastName', 'fullName']);
+    });
+
+    it('parameterized virtuals in `toJSON` result are correct when params passed', function () {
+      var m = new (bookshelf.Model.extend({
+        outputVirtuals: false,
+        virtuals: {
+          fullName: function(middleName) {
+            if (middleName === undefined)
+              return this.get('firstName') + ' ' + this.get('lastName');
+            else
+              return this.get('firstName') + ' ' + middleName + ' ' + this.get('lastName');
+          }
+        }
+      }))({firstName: 'Joe', lastName: 'Shmoe'});
+      var json = m.toJSON({virtuals: true, param: 'Trouble'});
+      equal(json.fullName, 'Joe Trouble Shmoe');
+    });
+
+    it('parameterized virtuals in `toJSON` result are correct when no params passed', function () {
+      var m = new (bookshelf.Model.extend({
+        outputVirtuals: false,
+        virtuals: {
+          fullName: function(middleName) {
+            if (middleName === undefined)
+              return this.get('firstName') + ' ' + this.get('lastName');
+            else
+              return this.get('firstName') + ' ' + middleName + ' ' + this.get('lastName');
+          }
+        }
+      }))({firstName: 'Joe', lastName: 'Shmoe'});
+      var json = m.toJSON({virtuals: true});
+      equal(json.fullName, 'Joe Shmoe');
+    });
+
+    it('parameterized virtuals in `toJSON` result are correct when params are an object', function () {
+      var m = new (bookshelf.Model.extend({
+        outputVirtuals: false,
+        virtuals: {
+          fullName: function(nameExtras) {
+            if (nameExtras === undefined)
+              return this.get('firstName') + ' ' + this.get('lastName');
+            else
+              return nameExtras.title + " " + this.get('firstName') + ' ' + nameExtras.middle + ' ' + this.get('lastName');
+          }
+        }
+      }))({firstName: 'Joe', lastName: 'Shmoe'});
+      var json = m.toJSON({virtuals: true, param: {title:'Sir', middle:'Danger'}});
+      equal(json.fullName, 'Sir Joe Danger Shmoe');
+    });
+
+    it('non-parameterized virtuals in `toJSON` result are correct when params passed', function () {
+      var m = new (bookshelf.Model.extend({
+        outputVirtuals: false,
+        virtuals: {
+          fullName: function() {
+            return this.get('firstName') + ' ' + this.get('lastName');
+          }
+        }
+      }))({firstName: 'Joe', lastName: 'Shmoe'});
+      var json = m.toJSON({virtuals: true, param: 'Trouble'});
+      equal(json.fullName, 'Joe Shmoe');
+    });
+
+    it('multiple parameterized virtuals in `toJSON` receive the same parameters', function () {
+      var m = new (bookshelf.Model.extend({
+        outputVirtuals: false,
+        virtuals: {
+          brothersFullName: function(lastName) {
+            return this.get('brothersName') + ' ' + lastName;
+          },
+          sistersFullName: function(lastName) {
+            return this.get('sistersName') + ' ' + lastName;
+          }
+        }
+      }))({brothersName: 'Joe', sistersName: 'Flo'});
+      var json = m.toJSON({virtuals: true, param: 'Shmoe' });
+      equal(json.brothersFullName, 'Joe Shmoe');
+      equal(json.sistersFullName, 'Flo Shmoe');
+    });
+
     it('does not crash when no virtuals are set - #168', function () {
       var m = new bookshelf.Model();
       m.set('firstName', 'Joe');
@@ -193,6 +388,27 @@ module.exports = function (bookshelf) {
         virtuals: {
           fullName: function() {
               return this.get('firstName') + ' ' + this.get('lastName');
+          }
+        }
+      }))({firstName: 'Joe', lastName: 'Shmoe'});
+
+      deepEqual(m.keys(), ['firstName', 'lastName', 'fullName']);
+      deepEqual(m.values(), ['Joe', 'Shmoe', 'Joe Shmoe']);
+      deepEqual(m.toPairs(), [['firstName', 'Joe'], ['lastName', 'Shmoe'], ['fullName', 'Joe Shmoe']]);
+      deepEqual(m.invert(), {'Joe': 'firstName', 'Shmoe': 'lastName','Joe Shmoe': 'fullName'});
+      deepEqual(m.pick('fullName'), {'fullName': 'Joe Shmoe'});
+      deepEqual(m.omit('firstName'), {'lastName': 'Shmoe', 'fullName': 'Joe Shmoe'});
+    });
+
+    it('normal access to parameterized virtuals with `underscore` methods - #170', function () {
+       var m = new (bookshelf.Model.extend({
+        outputVirtuals: true,
+        virtuals: {
+          fullName: function(middleName) {
+            if (middleName === undefined)
+              return this.get('firstName') + ' ' + this.get('lastName');
+            else
+              return this.get('firstName') + ' ' + middleName + ' ' + this.get('lastName');
           }
         }
       }))({firstName: 'Joe', lastName: 'Shmoe'});


### PR DESCRIPTION
This PR adds:

- Virtual getters may now optionally take a parameter:
```
  virtuals: {
    example: function (parameter) {
      return ...;
    }
  }
```
- Parameter may optionally be passed through get:
```
  model.get('example', 42);
```
- Parameter may optionally be specified in toJSON options (same param passed to all getters):
```
  model.toJSON({virtuals:true, param:42});
```
- "Normal" access to parameterized virtuals will leave parameter undefined.

- Also adds what I believe to be a comprehensive set of test cases.

- Note that parameters need not be scalar, arbitrary objects can be passed. So even though all parameterized virtuals receive the same parameter via `toJSON` calls, passing an object gives it a lot of flexibility.

Rationale will be posted in the next comment.

Please note: This PR is 2 commits, because I screwed up the first commit and unintentionally checked in a modified integration.js. The second commit reverts integration.js.