### PR TITLE
Add bookshelf-secure-password to Community Plugins section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ User.where('id', 1).fetch({withRelated: ['posts.tags']}).then(function(user) {
 * [bookshelf-uuid](https://github.com/estate/bookshelf-uuid) - Automatically generates UUIDs for your models.
 * [bookshelf-modelbase](https://github.com/bsiddiqui/bookshelf-modelbase) - An alternative to extend `Model`, adding timestamps, attribute validation and some native CRUD methods.
 * [bookshelf-advanced-serialization](https://github.com/sequiturs/bookshelf-advanced-serialization) - A more powerful visibility plugin, supporting serializing models and collections according to access permissions, application context, and after ensuring relations have been loaded.
+* [bookshelf-secure-password](https://github.com/venables/bookshelf-secure-password) - A plugin for easily securing passwords using bcrypt.
 
 ## Support
 


### PR DESCRIPTION
This is a simple plugin to enable hashing/verification of passwords using BCrypt.  It is similar to Rails' has_secure_password functionality, leaving very little room to make a mistake.  

It offers both synchronous (immediately as the password is set on the model) and asynchronous (when the password is to be saved) methods for hashing the password.