### PR TITLE
Add required knex option "client" to all tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -40,7 +40,7 @@ describe('Bookshelf', function () {
   it('VERSION should equal version number in package.json',
     function () {
     var Knex = require('knex');
-    var bookshelf = Bookshelf(Knex({}));
+    var bookshelf = Bookshelf(Knex({ client: 'postgres' }));
     var p = require('../package.json');
     expect(p.version).to.equal(bookshelf.VERSION);
   });

--- a/test/integration.js
+++ b/test/integration.js
@@ -23,7 +23,7 @@ module.exports = function(Bookshelf) {
   var MySQL = require('../bookshelf')(mysql);
   var PostgreSQL = require('../bookshelf')(pg);
   var SQLite3 = require('../bookshelf')(sqlite3);
-  var Swapped = require('../bookshelf')(Knex({}));
+  var Swapped = require('../bookshelf')(Knex({ client: 'postgres' }));
   Swapped.knex = sqlite3;
 
   it('should allow creating a new Bookshelf instance with "new"', function() {
@@ -32,7 +32,7 @@ module.exports = function(Bookshelf) {
   });
 
   it('should allow swapping in another knex instance', function() {
-    var bookshelf = new Bookshelf(Knex({}));
+    var bookshelf = new Bookshelf(Knex({ client: 'postgres' }));
     var Models = require('./integration/helpers/objects')(bookshelf).Models;
     var site = new Models.Site();
 


### PR DESCRIPTION
This is now a requirement. I selected postgres to use as the client as it was the first without side effects.

Let me know if this is a change that should be made on the knex side and I will make a pull request there.