### PR TITLE
Add oracledb integration tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
 # .travis.yml
 language: node_js
+dist: trusty
+sudo: required
 
 services:
   - postgresql
   - mysql
 
-sudo: false
-
 node_js:
   - '4'
   - '6'
   - '7'
+
+before_install:
+  - wget https://raw.githubusercontent.com/Vincit/travis-oracledb-xe/master/accept_the_license_agreement_for_oracledb_xe_11g_and_install.sh
+  - bash ./accept_the_license_agreement_for_oracledb_xe_11g_and_install.sh
+  - npm install oracledb
 
 before_script:
   - psql -c 'create database bookshelf_test;' -U postgres
@@ -19,5 +24,14 @@ before_script:
 notifications:
   email: false
 
+env:
+  - CXX=g++-4.8 KNEX_TEST_TIMEOUT=60000 ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe ORACLE_SID=XE OCI_LIB_DIR=/u01/app/oracle/product/11.2.0/xe/lib LD_LIBRARY_PATH=/u01/app/oracle/product/11.2.0/xe/lib
+
 matrix:
   fast_finish: true
+
+addons:
+  apt:
+    packages:
+    - g++-4.8
+    - gcc-4.8

--- a/test/integration.js
+++ b/test/integration.js
@@ -19,10 +19,12 @@ module.exports = function(Bookshelf) {
       }
     }
   });
+  var oracledb = require('knex')({client: 'oracledb', connection: config.oracledb});
 
   var MySQL = require('../bookshelf')(mysql);
   var PostgreSQL = require('../bookshelf')(pg);
   var SQLite3 = require('../bookshelf')(sqlite3);
+  var OracleDB = require('../bookshelf')(oracledb);
   var Swapped = require('../bookshelf')(Knex({}));
   Swapped.knex = sqlite3;
 
@@ -48,7 +50,7 @@ module.exports = function(Bookshelf) {
     });
   });
 
-  _.each([MySQL, PostgreSQL, SQLite3, Swapped], function(bookshelf) {
+  _.each([MySQL, PostgreSQL, SQLite3, OracleDB, Swapped], function(bookshelf) {
 
     var dialect = bookshelf.knex.client.dialect;
 
@@ -57,6 +59,7 @@ module.exports = function(Bookshelf) {
       this.dialect = dialect;
 
       before(function() {
+        this.timeout(300000);
         return require('./integration/helpers/migration')(bookshelf).then(function() {
            return require('./integration/helpers/inserts')(bookshelf);
         });

--- a/test/integration/collection.js
+++ b/test/integration/collection.js
@@ -16,6 +16,7 @@ module.exports = function(bookshelf) {
     var formatNumber = {
       mysql:      _.identity,
       sqlite3:    _.identity,
+      oracle:     _.identity,
       postgresql: function(count) { return count.toString() }
     }[dialect];
     var checkCount = function(actual, expected) {

--- a/test/integration/helpers/config.js
+++ b/test/integration/helpers/config.js
@@ -13,6 +13,14 @@ module.exports = {
 
   sqlite3: {
     filename: ':memory:'
+  },
+
+  oracledb: {
+    user          : "travis",
+    password      : "travis",
+    connectString : "localhost/XE",
+    // https://github.com/oracle/node-oracledb/issues/525
+    stmtCacheSize : 0
   }
 
 };

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -26,6 +26,7 @@ module.exports = function(bookshelf) {
     var formatNumber = {
       mysql:      _.identity,
       sqlite3:    _.identity,
+      oracle:     _.identity,
       postgresql: function(count) { return count.toString() }
     }[dialect];
     var checkCount = function(actual, expected) {
@@ -496,7 +497,7 @@ module.exports = function(bookshelf) {
       it('saves a new object', function() {
 
         return new Site({name: 'Fourth Site'}).save().then(function(m) {
-          equal(m.get('id'), 4);
+          equal(Number(m.get('id')), 4);
           return new bookshelf.Collection(null, {model: Site}).fetch();
         })
         .then(function(c) {
@@ -672,7 +673,7 @@ module.exports = function(bookshelf) {
           acmeOrg1 = new Models.OrgModel ({id: 1})
           return acmeOrg1.fetch();
         }).then (function () {
-          equal (acmeOrg1.attributes.id, 1);
+          equal (Number(acmeOrg1.attributes.id), 1);
           equal (acmeOrg1.attributes.name, "ACME, Inc");
           equal (acmeOrg1.attributes.organization_id, undefined);
           equal (acmeOrg1.attributes.organization_name, undefined);
@@ -680,7 +681,7 @@ module.exports = function(bookshelf) {
           expect (acmeOrg.attributes.name).to.equal ("ACME, Inc");
           // field name needs to be processed through model.parse
           equal (acmeOrg.attributes.organization_id, undefined);
-          expect (acmeOrg.attributes.id).to.equal (1);
+          expect (Number(acmeOrg.attributes.id)).to.equal (1);
         });
       });
 

--- a/test/integration/output/Collection.js
+++ b/test/integration/output/Collection.js
@@ -98,6 +98,39 @@ module.exports = {
         name: 'This is a new Title 5!',
         content: 'Lorem ipsum Commodo consectetur eu ea amet laborum nulla eiusmod minim veniam ullamco nostrud sed mollit consectetur veniam mollit Excepteur quis cupidatat.'
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        owner_id: 1,
+        blog_id: 1,
+        name: 'This is a new Title!',
+        content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.'
+      },{
+        id: 2,
+        owner_id: 2,
+        blog_id: 2,
+        name: 'This is a new Title 2!',
+        content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.'
+      },{
+        id: 3,
+        owner_id: 2,
+        blog_id: 1,
+        name: 'This is a new Title 3!',
+        content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
+      },{
+        id: 4,
+        owner_id: 3,
+        blog_id: 3,
+        name: 'This is a new Title 4!',
+        content: 'Lorem ipsum Anim sed eu sint aute.'
+      },{
+        id: 5,
+        owner_id: 4,
+        blog_id: 4,
+        name: 'This is a new Title 5!',
+        content: 'Lorem ipsum Commodo consectetur eu ea amet laborum nulla eiusmod minim veniam ullamco nostrud sed mollit consectetur veniam mollit Excepteur quis cupidatat.'
+      }]
     }
   }
 };

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -382,6 +382,13 @@ module.exports = {
         site_id: null,
         name: 'Orphan Blog Without a Site'
       }
+    },
+    oracle: {
+      result: {
+        id: 5,
+        site_id: null,
+        name: 'Orphan Blog Without a Site'
+      }
     }
   },
   'eager loads "belongsToMany" models correctly (post -> tags)': {

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -4956,17 +4956,17 @@ module.exports = {
         first_name: 'Bazooka',
         last_name: 'Joe',
         blogs: [{
-          id: 2,
-          site_id: 1,
-          name: 'Alternate Site Blog',
-          _pivot_owner_id: 2,
-          _pivot_blog_id: 2
-        },{
           id: 1,
           site_id: 1,
           name: 'Main Site Blog',
           _pivot_owner_id: 2,
           _pivot_blog_id: 1
+        },{
+          id: 2,
+          site_id: 1,
+          name: 'Alternate Site Blog',
+          _pivot_owner_id: 2,
+          _pivot_blog_id: 2
         }]
       },{
         id: 3,

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -854,6 +854,10 @@ module.exports = {
           id: 2,
           name: 'bookshelfjs.org'
         }
+      },{
+        id: 5,
+        site_id: null,
+        name: 'Orphan Blog Without a Site'
       }]
     }
   },

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -17,6 +17,12 @@ module.exports = {
         id: 2,
         name: 'bookshelfjs.org'
       }
+    },
+    oracle: {
+      result: {
+        id: 2,
+        name: 'bookshelfjs.org'
+      }
     }
   },
   'handles hasMany (posts)': {
@@ -64,6 +70,21 @@ module.exports = {
         name: 'This is a new Title 3!',
         content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        owner_id: 1,
+        blog_id: 1,
+        name: 'This is a new Title!',
+        content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.'
+      },{
+        id: 3,
+        owner_id: 2,
+        blog_id: 1,
+        name: 'This is a new Title 3!',
+        content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
+      }]
     }
   },
   'handles hasOne (meta)': {
@@ -82,6 +103,13 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        site_id: 1,
+        description: 'This is a description for the Knexjs Site'
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         site_id: 1,
@@ -122,6 +150,17 @@ module.exports = {
         _pivot_author_id: 1,
         _pivot_post_id: 1
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        owner_id: 1,
+        blog_id: 1,
+        name: 'This is a new Title!',
+        content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.',
+        _pivot_author_id: 1,
+        _pivot_post_id: 1
+      }]
     }
   },
   'eager loads "hasOne" relationships correctly (site -> meta)': {
@@ -148,6 +187,17 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        name: 'knexjs.org',
+        meta: {
+          id: 1,
+          site_id: 1,
+          description: 'This is a description for the Knexjs Site'
+        }
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org',
@@ -237,6 +287,32 @@ module.exports = {
           name: 'Alternate Site Blog'
         }]
       }
+    },
+    oracle: {
+      result: {
+        id: 1,
+        name: 'knexjs.org',
+        authors: [{
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser'
+        },{
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe'
+        }],
+        blogs: [{
+          id: 1,
+          site_id: 1,
+          name: 'Main Site Blog'
+        },{
+          id: 2,
+          site_id: 1,
+          name: 'Alternate Site Blog'
+        }]
+      }
     }
   },
   'eager loads "belongsTo" relationships correctly (blog -> site)': {
@@ -263,6 +339,17 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 3,
+        site_id: 2,
+        name: 'Main Site Blog',
+        site: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      }
+    },
+    oracle: {
       result: {
         id: 3,
         site_id: 2,
@@ -349,6 +436,31 @@ module.exports = {
           _pivot_tag_id: 3
         }]
       }
+    },
+    oracle: {
+      result: {
+        id: 1,
+        owner_id: 1,
+        blog_id: 1,
+        name: 'This is a new Title!',
+        content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.',
+        tags: [{
+          id: 1,
+          name: 'cool',
+          _pivot_post_id: 1,
+          _pivot_tag_id: 1
+        },{
+          id: 2,
+          name: 'boring',
+          _pivot_post_id: 1,
+          _pivot_tag_id: 2
+        },{
+          id: 3,
+          name: 'exciting',
+          _pivot_post_id: 1,
+          _pivot_tag_id: 3
+        }]
+      }
     }
   },
   'Attaches an empty related model or collection if the `EagerRelation` comes back blank': {
@@ -375,6 +487,17 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 3,
+        name: 'backbonejs.org',
+        meta: {
+
+        },
+        blogs: [],
+        authors: []
+      }
+    },
+    oracle: {
       result: {
         id: 3,
         name: 'backbonejs.org',
@@ -418,6 +541,21 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        name: 'knexjs.org',
+        authors: [{
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim'
+        },{
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka'
+        }]
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org',
@@ -485,6 +623,31 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        id: 1,
+        name: 'knexjs.org',
+        meta: {
+          id: 1,
+          site_id: 1,
+          description: 'This is a description for the Knexjs Site'
+        }
+      },{
+        id: 2,
+        name: 'bookshelfjs.org',
+        meta: {
+          id: 2,
+          site_id: 2,
+          description: 'This is a description for the Bookshelfjs Site'
+        }
+      },{
+        id: 3,
+        name: 'backbonejs.org',
+        meta: {
+
+        }
+      }]
+    },
+    oracle: {
       result: [{
         id: 1,
         name: 'knexjs.org',
@@ -615,6 +778,41 @@ module.exports = {
           name: 'bookshelfjs.org'
         }
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        site_id: 1,
+        name: 'Main Site Blog',
+        site: {
+          id: 1,
+          name: 'knexjs.org'
+        }
+      },{
+        id: 2,
+        site_id: 1,
+        name: 'Alternate Site Blog',
+        site: {
+          id: 1,
+          name: 'knexjs.org'
+        }
+      },{
+        id: 3,
+        site_id: 2,
+        name: 'Main Site Blog',
+        site: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      },{
+        id: 4,
+        site_id: 2,
+        name: 'Alternate Site Blog',
+        site: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      }]
     }
   },
   'eager loads "hasMany" models correctly (site -> blogs)': {
@@ -649,6 +847,21 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        name: 'knexjs.org',
+        blogs: [{
+          id: 1,
+          site_id: 1,
+          name: 'Main Site Blog'
+        },{
+          id: 2,
+          site_id: 1,
+          name: 'Alternate Site Blog'
+        }]
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org',
@@ -760,6 +973,38 @@ module.exports = {
         content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.',
         tags: []
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        owner_id: 1,
+        blog_id: 1,
+        name: 'This is a new Title!',
+        content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.',
+        tags: [{
+          id: 1,
+          name: 'cool',
+          _pivot_post_id: 1,
+          _pivot_tag_id: 1
+        },{
+          id: 2,
+          name: 'boring',
+          _pivot_post_id: 1,
+          _pivot_tag_id: 2
+        },{
+          id: 3,
+          name: 'exciting',
+          _pivot_post_id: 1,
+          _pivot_tag_id: 3
+        }]
+      },{
+        id: 3,
+        owner_id: 2,
+        blog_id: 1,
+        name: 'This is a new Title 3!',
+        content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.',
+        tags: []
+      }]
     }
   },
   'eager loads "hasMany" -> "hasMany" (site -> authors.ownPosts)': {
@@ -838,6 +1083,43 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        name: 'knexjs.org',
+        authors: [{
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser',
+          ownPosts: [{
+            id: 1,
+            owner_id: 1,
+            blog_id: 1,
+            name: 'This is a new Title!',
+            content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.'
+          }]
+        },{
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe',
+          ownPosts: [{
+            id: 2,
+            owner_id: 2,
+            blog_id: 2,
+            name: 'This is a new Title 2!',
+            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.'
+          },{
+            id: 3,
+            owner_id: 2,
+            blog_id: 1,
+            name: 'This is a new Title 3!',
+            content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
+          }]
+        }]
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org',
@@ -1004,6 +1286,49 @@ module.exports = {
           }]
         }]
       }
+    },
+    oracle: {
+      result: {
+        id: 1,
+        name: 'knexjs.org',
+        authors: [{
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser',
+          posts: [{
+            id: 1,
+            owner_id: 1,
+            blog_id: 1,
+            name: 'This is a new Title!',
+            content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.',
+            _pivot_author_id: 1,
+            _pivot_post_id: 1
+          }]
+        },{
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe',
+          posts: [{
+            id: 1,
+            owner_id: 1,
+            blog_id: 1,
+            name: 'This is a new Title!',
+            content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.',
+            _pivot_author_id: 2,
+            _pivot_post_id: 1
+          },{
+            id: 2,
+            owner_id: 2,
+            blog_id: 2,
+            name: 'This is a new Title 2!',
+            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.',
+            _pivot_author_id: 2,
+            _pivot_post_id: 2
+          }]
+        }]
+      }
     }
   },
   'does multi deep eager loads (site -> authors.ownPosts, authors.site, blogs.posts)': {
@@ -1156,6 +1481,80 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        name: 'knexjs.org',
+        authors: [{
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser',
+          ownPosts: [{
+            id: 1,
+            owner_id: 1,
+            blog_id: 1,
+            name: 'This is a new Title!',
+            content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.'
+          }],
+          site: {
+            id: 1,
+            name: 'knexjs.org'
+          }
+        },{
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe',
+          ownPosts: [{
+            id: 2,
+            owner_id: 2,
+            blog_id: 2,
+            name: 'This is a new Title 2!',
+            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.'
+          },{
+            id: 3,
+            owner_id: 2,
+            blog_id: 1,
+            name: 'This is a new Title 3!',
+            content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
+          }],
+          site: {
+            id: 1,
+            name: 'knexjs.org'
+          }
+        }],
+        blogs: [{
+          id: 1,
+          site_id: 1,
+          name: 'Main Site Blog',
+          posts: [{
+            id: 1,
+            owner_id: 1,
+            blog_id: 1,
+            name: 'This is a new Title!',
+            content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.'
+          },{
+            id: 3,
+            owner_id: 2,
+            blog_id: 1,
+            name: 'This is a new Title 3!',
+            content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
+          }]
+        },{
+          id: 2,
+          site_id: 1,
+          name: 'Alternate Site Blog',
+          posts: [{
+            id: 2,
+            owner_id: 2,
+            blog_id: 2,
+            name: 'This is a new Title 2!',
+            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.'
+          }]
+        }]
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org',
@@ -1437,6 +1836,75 @@ module.exports = {
         name: 'backbonejs.org',
         authors: []
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        name: 'knexjs.org',
+        authors: [{
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser',
+          ownPosts: [{
+            id: 1,
+            owner_id: 1,
+            blog_id: 1,
+            name: 'This is a new Title!',
+            content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.'
+          }]
+        },{
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe',
+          ownPosts: [{
+            id: 2,
+            owner_id: 2,
+            blog_id: 2,
+            name: 'This is a new Title 2!',
+            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.'
+          },{
+            id: 3,
+            owner_id: 2,
+            blog_id: 1,
+            name: 'This is a new Title 3!',
+            content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
+          }]
+        }]
+      },{
+        id: 2,
+        name: 'bookshelfjs.org',
+        authors: [{
+          id: 3,
+          site_id: 2,
+          first_name: 'Charlie',
+          last_name: 'Brown',
+          ownPosts: [{
+            id: 4,
+            owner_id: 3,
+            blog_id: 3,
+            name: 'This is a new Title 4!',
+            content: 'Lorem ipsum Anim sed eu sint aute.'
+          }]
+        },{
+          id: 4,
+          site_id: 2,
+          first_name: 'Ron',
+          last_name: 'Burgundy',
+          ownPosts: [{
+            id: 5,
+            owner_id: 4,
+            blog_id: 4,
+            name: 'This is a new Title 5!',
+            content: 'Lorem ipsum Commodo consectetur eu ea amet laborum nulla eiusmod minim veniam ullamco nostrud sed mollit consectetur veniam mollit Excepteur quis cupidatat.'
+          }]
+        }]
+      },{
+        id: 3,
+        name: 'backbonejs.org',
+        authors: []
+      }]
     }
   },
   'eager loads relations on a populated model (site -> blogs, authors.site)': {
@@ -1453,6 +1921,12 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        name: 'knexjs.org'
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org'
@@ -1495,6 +1969,18 @@ module.exports = {
         id: 3,
         name: 'backbonejs.org'
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        name: 'knexjs.org'
+      },{
+        id: 2,
+        name: 'bookshelfjs.org'
+      },{
+        id: 3,
+        name: 'backbonejs.org'
+      }]
     }
   },
   'works with many-to-many (user -> roles)': {
@@ -1515,6 +2001,14 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        rid: 4,
+        name: 'admin',
+        _pivot_uid: 1,
+        _pivot_rid: 4
+      }]
+    },
+    oracle: {
       result: [{
         rid: 4,
         name: 'admin',
@@ -1559,6 +2053,18 @@ module.exports = {
           _pivot_rid: 4
         }]
       }
+    },
+    oracle: {
+      result: {
+        uid: 1,
+        username: 'root',
+        roles: [{
+          rid: 4,
+          name: 'admin',
+          _pivot_uid: 1,
+          _pivot_rid: 4
+        }]
+      }
     }
   },
   'handles morphOne (photo)': {
@@ -1581,6 +2087,15 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 1,
+        imageable_type: 'authors'
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         url: 'https://www.google.com/images/srpr/logo4w.png',
@@ -1635,6 +2150,21 @@ module.exports = {
         imageable_id: 1,
         imageable_type: 'sites'
       }]
+    },
+    oracle: {
+      result: [{
+        id: 3,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 1,
+        imageable_type: 'sites'
+      },{
+        id: 4,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 1,
+        imageable_type: 'sites'
+      }]
     }
   },
   'handles morphTo (imageable "authors")': {
@@ -1661,6 +2191,14 @@ module.exports = {
         first_name: 'Tim',
         last_name: 'Griesser'
       }
+    },
+    oracle: {
+      result: {
+        id: 1,
+        site_id: 1,
+        first_name: 'Tim',
+        last_name: 'Griesser'
+      }
     }
   },
   'handles morphTo (imageble "authors", PhotoParsed)': {
@@ -1681,6 +2219,14 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id_parsed: 1,
+        site_id_parsed: 1,
+        first_name_parsed: 'Tim',
+        last_name_parsed: 'Griesser'
+      }
+    },
+    oracle: {
       result: {
         id_parsed: 1,
         site_id_parsed: 1,
@@ -1716,6 +2262,15 @@ module.exports = {
         url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
         caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.'
       }
+    },
+    oracle: {
+      result: {
+        imageable_id_parsed: 1,
+        imageable_type_parsed: 'authors',
+        id_parsed: 1,
+        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
+        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.'
+      }
     }
   },
   'handles morphTo (imageable "sites")': {
@@ -1732,6 +2287,12 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        name: 'knexjs.org'
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org'
@@ -1818,6 +2379,45 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        id: 1,
+        name: 'knexjs.org',
+        photos: [{
+          id: 3,
+          url: 'https://www.google.com/images/srpr/logo4w.png',
+          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id: 1,
+          imageable_type: 'sites'
+        },{
+          id: 4,
+          url: 'https://www.google.com/images/srpr/logo4w.png',
+          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id: 1,
+          imageable_type: 'sites'
+        }]
+      },{
+        id: 2,
+        name: 'bookshelfjs.org',
+        photos: [{
+          id: 5,
+          url: 'https://www.google.com/images/srpr/logo4w.png',
+          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id: 2,
+          imageable_type: 'sites'
+        },{
+          id: 6,
+          url: 'https://www.google.com/images/srpr/logo4w.png',
+          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          imageable_id: 2,
+          imageable_type: 'sites'
+        }]
+      },{
+        id: 3,
+        name: 'backbonejs.org',
+        photos: []
+      }]
+    },
+    oracle: {
       result: [{
         id: 1,
         name: 'knexjs.org',
@@ -2011,6 +2611,82 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        id: 1,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 1,
+        imageable_type: 'authors',
+        imageable: {
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser'
+        }
+      },{
+        id: 2,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 2,
+        imageable_type: 'authors',
+        imageable: {
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe'
+        }
+      },{
+        id: 3,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 1,
+        imageable_type: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org'
+        }
+      },{
+        id: 4,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 1,
+        imageable_type: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org'
+        }
+      },{
+        id: 5,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 2,
+        imageable_type: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      },{
+        id: 6,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 2,
+        imageable_type: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      },{
+        id: 7,
+        url: 'http://image.dev',
+        caption: 'this is a test image',
+        imageable_id: 10,
+        imageable_type: 'sites',
+        imageable: {
+
+        }
+      }]
+    },
+    oracle: {
       result: [{
         id: 1,
         url: 'https://www.google.com/images/srpr/logo4w.png',
@@ -2447,6 +3123,126 @@ module.exports = {
 
         }
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 1,
+        imageable_type: 'authors',
+        imageable: {
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser'
+        }
+      },{
+        id: 2,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 2,
+        imageable_type: 'authors',
+        imageable: {
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe'
+        }
+      },{
+        id: 3,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 1,
+        imageable_type: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org',
+          authors: [{
+            id: 1,
+            site_id: 1,
+            first_name: 'Tim',
+            last_name: 'Griesser'
+          },{
+            id: 2,
+            site_id: 1,
+            first_name: 'Bazooka',
+            last_name: 'Joe'
+          }]
+        }
+      },{
+        id: 4,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 1,
+        imageable_type: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org',
+          authors: [{
+            id: 1,
+            site_id: 1,
+            first_name: 'Tim',
+            last_name: 'Griesser'
+          },{
+            id: 2,
+            site_id: 1,
+            first_name: 'Bazooka',
+            last_name: 'Joe'
+          }]
+        }
+      },{
+        id: 5,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 2,
+        imageable_type: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org',
+          authors: [{
+            id: 3,
+            site_id: 2,
+            first_name: 'Charlie',
+            last_name: 'Brown'
+          },{
+            id: 4,
+            site_id: 2,
+            first_name: 'Ron',
+            last_name: 'Burgundy'
+          }]
+        }
+      },{
+        id: 6,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 2,
+        imageable_type: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org',
+          authors: [{
+            id: 3,
+            site_id: 2,
+            first_name: 'Charlie',
+            last_name: 'Brown'
+          },{
+            id: 4,
+            site_id: 2,
+            first_name: 'Ron',
+            last_name: 'Burgundy'
+          }]
+        }
+      },{
+        id: 7,
+        url: 'http://image.dev',
+        caption: 'this is a test image',
+        imageable_id: 10,
+        imageable_type: 'sites',
+        imageable: {
+
+        }
+      }]
     }
   },
   'handles morphOne with custom columnNames (thumbnail)': {
@@ -2469,6 +3265,15 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 1,
+        ImageableType: 'authors'
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         url: 'https://www.google.com/images/srpr/logo4w.png',
@@ -2523,6 +3328,21 @@ module.exports = {
         ImageableId: 1,
         ImageableType: 'sites'
       }]
+    },
+    oracle: {
+      result: [{
+        id: 3,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 1,
+        ImageableType: 'sites'
+      },{
+        id: 4,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 1,
+        ImageableType: 'sites'
+      }]
     }
   },
   'handles morphTo with custom columnNames (imageable "authors")': {
@@ -2549,6 +3369,14 @@ module.exports = {
         first_name: 'Tim',
         last_name: 'Griesser'
       }
+    },
+    oracle: {
+      result: {
+        id: 1,
+        site_id: 1,
+        first_name: 'Tim',
+        last_name: 'Griesser'
+      }
     }
   },
   'handles morphTo with custom columnNames (imageable "sites")': {
@@ -2565,6 +3393,12 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        name: 'knexjs.org'
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org'
@@ -2651,6 +3485,45 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        id: 1,
+        name: 'knexjs.org',
+        thumbnails: [{
+          id: 3,
+          url: 'https://www.google.com/images/srpr/logo4w.png',
+          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          ImageableId: 1,
+          ImageableType: 'sites'
+        },{
+          id: 4,
+          url: 'https://www.google.com/images/srpr/logo4w.png',
+          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          ImageableId: 1,
+          ImageableType: 'sites'
+        }]
+      },{
+        id: 2,
+        name: 'bookshelfjs.org',
+        thumbnails: [{
+          id: 5,
+          url: 'https://www.google.com/images/srpr/logo4w.png',
+          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          ImageableId: 2,
+          ImageableType: 'sites'
+        },{
+          id: 6,
+          url: 'https://www.google.com/images/srpr/logo4w.png',
+          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+          ImageableId: 2,
+          ImageableType: 'sites'
+        }]
+      },{
+        id: 3,
+        name: 'backbonejs.org',
+        thumbnails: []
+      }]
+    },
+    oracle: {
       result: [{
         id: 1,
         name: 'knexjs.org',
@@ -2844,6 +3717,82 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        id: 1,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 1,
+        ImageableType: 'authors',
+        imageable: {
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser'
+        }
+      },{
+        id: 2,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 2,
+        ImageableType: 'authors',
+        imageable: {
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe'
+        }
+      },{
+        id: 3,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 1,
+        ImageableType: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org'
+        }
+      },{
+        id: 4,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 1,
+        ImageableType: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org'
+        }
+      },{
+        id: 5,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 2,
+        ImageableType: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      },{
+        id: 6,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 2,
+        ImageableType: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      },{
+        id: 7,
+        url: 'http://image.dev',
+        caption: 'this is a test image',
+        ImageableId: 10,
+        ImageableType: 'sites',
+        imageable: {
+
+        }
+      }]
+    },
+    oracle: {
       result: [{
         id: 1,
         url: 'https://www.google.com/images/srpr/logo4w.png',
@@ -3280,6 +4229,126 @@ module.exports = {
 
         }
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 1,
+        ImageableType: 'authors',
+        imageable: {
+          id: 1,
+          site_id: 1,
+          first_name: 'Tim',
+          last_name: 'Griesser'
+        }
+      },{
+        id: 2,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 2,
+        ImageableType: 'authors',
+        imageable: {
+          id: 2,
+          site_id: 1,
+          first_name: 'Bazooka',
+          last_name: 'Joe'
+        }
+      },{
+        id: 3,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 1,
+        ImageableType: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org',
+          authors: [{
+            id: 1,
+            site_id: 1,
+            first_name: 'Tim',
+            last_name: 'Griesser'
+          },{
+            id: 2,
+            site_id: 1,
+            first_name: 'Bazooka',
+            last_name: 'Joe'
+          }]
+        }
+      },{
+        id: 4,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 1,
+        ImageableType: 'sites',
+        imageable: {
+          id: 1,
+          name: 'knexjs.org',
+          authors: [{
+            id: 1,
+            site_id: 1,
+            first_name: 'Tim',
+            last_name: 'Griesser'
+          },{
+            id: 2,
+            site_id: 1,
+            first_name: 'Bazooka',
+            last_name: 'Joe'
+          }]
+        }
+      },{
+        id: 5,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 2,
+        ImageableType: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org',
+          authors: [{
+            id: 3,
+            site_id: 2,
+            first_name: 'Charlie',
+            last_name: 'Brown'
+          },{
+            id: 4,
+            site_id: 2,
+            first_name: 'Ron',
+            last_name: 'Burgundy'
+          }]
+        }
+      },{
+        id: 6,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        ImageableId: 2,
+        ImageableType: 'sites',
+        imageable: {
+          id: 2,
+          name: 'bookshelfjs.org',
+          authors: [{
+            id: 3,
+            site_id: 2,
+            first_name: 'Charlie',
+            last_name: 'Brown'
+          },{
+            id: 4,
+            site_id: 2,
+            first_name: 'Ron',
+            last_name: 'Burgundy'
+          }]
+        }
+      },{
+        id: 7,
+        url: 'http://image.dev',
+        caption: 'this is a test image',
+        ImageableId: 10,
+        ImageableType: 'sites',
+        imageable: {
+
+        }
+      }]
     }
   },
   'handles hasMany `through`': {
@@ -3306,6 +4375,17 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        id: 1,
+        post_id: 1,
+        name: '(blank)',
+        email: 'test@example.com',
+        comment: 'this is neat.',
+        _pivot_id: 1,
+        _pivot_blog_id: 1
+      }]
+    },
+    oracle: {
       result: [{
         id: 1,
         post_id: 1,
@@ -3361,6 +4441,27 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        id: 1,
+        site_id: 1,
+        name: 'Main Site Blog',
+        comments: [{
+          id: 1,
+          post_id: 1,
+          name: '(blank)',
+          email: 'test@example.com',
+          comment: 'this is neat.',
+          _pivot_id: 1,
+          _pivot_blog_id: 1
+        }]
+      },{
+        id: 2,
+        site_id: 1,
+        name: 'Alternate Site Blog',
+        comments: []
+      }]
+    },
+    oracle: {
       result: [{
         id: 1,
         site_id: 1,
@@ -3445,6 +4546,27 @@ module.exports = {
         name: 'Alternate Site Blog',
         comments: []
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        site_id: 1,
+        name: 'Main Site Blog',
+        comments: [{
+          id: 1,
+          post_id: 1,
+          name: '(blank)',
+          email: 'test@example.com',
+          comment: 'this is neat.',
+          _pivot_id: 1,
+          _pivot_blog_id: 1
+        }]
+      },{
+        id: 2,
+        site_id: 1,
+        name: 'Alternate Site Blog',
+        comments: []
+      }]
     }
   },
   'handles hasOne `through`': {
@@ -3467,6 +4589,15 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        meta_id: 1,
+        other_description: 'This is an info block for hasOne -> through test',
+        _pivot_id: 1,
+        _pivot_site_id: 1
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         meta_id: 1,
@@ -3524,6 +4655,29 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        id: 1,
+        name: 'knexjs.org',
+        info: {
+          id: 1,
+          meta_id: 1,
+          other_description: 'This is an info block for hasOne -> through test',
+          _pivot_id: 1,
+          _pivot_site_id: 1
+        }
+      },{
+        id: 2,
+        name: 'bookshelfjs.org',
+        info: {
+          id: 2,
+          meta_id: 2,
+          other_description: 'This is an info block for an eager hasOne -> through test',
+          _pivot_id: 2,
+          _pivot_site_id: 2
+        }
+      }]
+    },
+    oracle: {
       result: [{
         id: 1,
         name: 'knexjs.org',
@@ -3736,6 +4890,69 @@ module.exports = {
         last_name: null,
         blogs: []
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        site_id: 1,
+        first_name: 'Tim',
+        last_name: 'Griesser',
+        blogs: [{
+          id: 1,
+          site_id: 1,
+          name: 'Main Site Blog',
+          _pivot_owner_id: 1,
+          _pivot_blog_id: 1
+        }]
+      },{
+        id: 2,
+        site_id: 1,
+        first_name: 'Bazooka',
+        last_name: 'Joe',
+        blogs: [{
+          id: 2,
+          site_id: 1,
+          name: 'Alternate Site Blog',
+          _pivot_owner_id: 2,
+          _pivot_blog_id: 2
+        },{
+          id: 1,
+          site_id: 1,
+          name: 'Main Site Blog',
+          _pivot_owner_id: 2,
+          _pivot_blog_id: 1
+        }]
+      },{
+        id: 3,
+        site_id: 2,
+        first_name: 'Charlie',
+        last_name: 'Brown',
+        blogs: [{
+          id: 3,
+          site_id: 2,
+          name: 'Main Site Blog',
+          _pivot_owner_id: 3,
+          _pivot_blog_id: 3
+        }]
+      },{
+        id: 4,
+        site_id: 2,
+        first_name: 'Ron',
+        last_name: 'Burgundy',
+        blogs: [{
+          id: 4,
+          site_id: 2,
+          name: 'Alternate Site Blog',
+          _pivot_owner_id: 4,
+          _pivot_blog_id: 4
+        }]
+      },{
+        id: 5,
+        site_id: 99,
+        first_name: 'Anonymous',
+        last_name: null,
+        blogs: []
+      }]
     }
   },
   'eager loads belongsTo `through`': {
@@ -3786,6 +5003,22 @@ module.exports = {
           _pivot_blog_id: 1
         }
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        post_id: 1,
+        name: '(blank)',
+        email: 'test@example.com',
+        comment: 'this is neat.',
+        blog:
+        { id: 1,
+          site_id: 1,
+          name: 'Main Site Blog',
+          _pivot_id: 1,
+          _pivot_blog_id: 1
+        }
+      }]
     }
   },
   '#65 - should eager load correctly for models': {
@@ -3812,6 +5045,17 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        hostname: 'google.com',
+        instance_id: 3,
+        route: null,
+        instance: {
+          id: 3,
+          name: 'search engine'
+        }
+      }
+    },
+    oracle: {
       result: {
         hostname: 'google.com',
         instance_id: 3,
@@ -3863,6 +5107,25 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        hostname: 'google.com',
+        instance_id: 3,
+        route: null,
+        instance: {
+          id: 3,
+          name: 'search engine'
+        }
+      },{
+        hostname: 'apple.com',
+        instance_id: 10,
+        route: null,
+        instance: {
+          id: 10,
+          name: 'computers'
+        }
+      }]
+    },
+    oracle: {
       result: [{
         hostname: 'google.com',
         instance_id: 3,
@@ -4170,6 +5433,102 @@ module.exports = {
 
         }
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 1,
+        imageable_type: 'authors',
+        imageableParsed: {
+          id_parsed: 1,
+          site_id_parsed: 1,
+          first_name_parsed: 'Tim',
+          last_name_parsed: 'Griesser'
+        }
+      },{
+        id: 2,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 2,
+        imageable_type: 'authors',
+        imageableParsed: {
+          id_parsed: 2,
+          site_id_parsed: 1,
+          first_name_parsed: 'Bazooka',
+          last_name_parsed: 'Joe'
+        }
+      },{
+        id: 3,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 1,
+        imageable_type: 'sites',
+        imageableParsed: {
+          id_parsed: 1,
+          name_parsed: 'knexjs.org',
+          meta: {
+            id: 1,
+            site_id: 1,
+            description: 'This is a description for the Knexjs Site'
+          }
+        }
+      },{
+        id: 4,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 1,
+        imageable_type: 'sites',
+        imageableParsed: {
+          id_parsed: 1,
+          name_parsed: 'knexjs.org',
+          meta: {
+            id: 1,
+            site_id: 1,
+            description: 'This is a description for the Knexjs Site'
+          }
+        }
+      },{
+        id: 5,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 2,
+        imageable_type: 'sites',
+        imageableParsed: {
+          id_parsed: 2,
+          name_parsed: 'bookshelfjs.org',
+          meta: {
+            id: 2,
+            site_id: 2,
+            description: 'This is a description for the Bookshelfjs Site'
+          }
+        }
+      },{
+        id: 6,
+        url: 'https://www.google.com/images/srpr/logo4w.png',
+        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
+        imageable_id: 2,
+        imageable_type: 'sites',
+        imageableParsed: {
+          id_parsed: 2,
+          name_parsed: 'bookshelfjs.org',
+          meta: {
+            id: 2,
+            site_id: 2,
+            description: 'This is a description for the Bookshelfjs Site'
+          }
+        }
+      },{
+        id: 7,
+        url: 'http://image.dev',
+        caption: 'this is a test image',
+        imageable_id: 10,
+        imageable_type: 'sites',
+        imageableParsed: {
+
+        }
+      }]
     }
   },
   "works with hasOne relation (locale -> translation)": {
@@ -4186,6 +5545,12 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        code: 'pt',
+        customer: 'Customer1'
+      }
+    },
+    oracle: {
       result: {
         code: 'pt',
         customer: 'Customer1'
@@ -4219,6 +5584,15 @@ module.exports = {
           customer: 'Customer1'
         }
       }
+    },
+    oracle: {
+      result: {
+        isoCode: 'pt',
+        translation: {
+          code: 'pt',
+          customer: 'Customer1'
+        }
+      }
     }
   },
   "works with hasMany relation (locale -> translations)": {
@@ -4241,6 +5615,15 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        code: 'en',
+        customer: 'Customer1'
+      }, {
+        code: 'en',
+        customer: 'Customer2'
+      }]
+    },
+    oracle: {
       result: [{
         code: 'en',
         customer: 'Customer1'
@@ -4286,6 +5669,18 @@ module.exports = {
           customer: 'Customer2'
         }]
       }
+    },
+    oracle: {
+      result: {
+        isoCode: 'en',
+        translations: [{
+          code: 'en',
+          customer: 'Customer1'
+        }, {
+          code: 'en',
+          customer: 'Customer2'
+        }]
+      }
     }
   },
   "works with belongsTo relation (translation -> locale)": {
@@ -4300,6 +5695,11 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        isoCode: 'pt'
+      }
+    },
+    oracle: {
       result: {
         isoCode: 'pt'
       }
@@ -4325,6 +5725,15 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        code: 'pt',
+        customer: 'Customer1',
+        locale: {
+          isoCode: 'pt'
+        }
+      }
+    },
+    oracle: {
       result: {
         code: 'pt',
         customer: 'Customer1',
@@ -4362,6 +5771,19 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        id: 1,
+        name: 'Customer1',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer1'
+      }, {
+        id: 2,
+        name: 'Customer2',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer2'
+      }]
+    },
+    oracle: {
       result: [{
         id: 1,
         name: 'Customer1',
@@ -4423,6 +5845,22 @@ module.exports = {
           _pivot_customer: 'Customer2'
         }]
       }
+    },
+    oracle: {
+      result: {
+        isoCode: 'en',
+        customers: [{
+          id: 1,
+          name: 'Customer1',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer1'
+        }, {
+          id: 2,
+          name: 'Customer2',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer2'
+        }]
+      }
     }
   },
   "works with hasOne `through` relation (customer -> locale)": {
@@ -4441,6 +5879,13 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        isoCode: 'en',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer2'
+      }
+    },
+    oracle: {
       result: {
         isoCode: 'en',
         _pivot_code: 'en',
@@ -4481,6 +5926,17 @@ module.exports = {
           _pivot_customer: 'Customer2'
         }
       }
+    },
+    oracle: {
+      result: {
+        id: 2,
+        name: 'Customer2',
+        locale: {
+          isoCode: 'en',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer2'
+        }
+      }
     }
   },
   "works with hasMany `through` relation (customer -> locales)": {
@@ -4507,6 +5963,17 @@ module.exports = {
       }]
     },
     sqlite3: {
+      result: [{
+        isoCode: 'en',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer1'
+      }, {
+        isoCode: 'pt',
+        _pivot_code: 'pt',
+        _pivot_customer: 'Customer1'
+      }]
+    },
+    oracle: {
       result: [{
         isoCode: 'en',
         _pivot_code: 'en',
@@ -4563,6 +6030,21 @@ module.exports = {
           _pivot_customer: 'Customer1'
         }]
       }
+    },
+    oracle: {
+      result: {
+        id: 1,
+        name: 'Customer1',
+        locales: [{
+          isoCode: 'en',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer1'
+        }, {
+          isoCode: 'pt',
+          _pivot_code: 'pt',
+          _pivot_customer: 'Customer1'
+        }]
+      }
     }
   },
   "works with belongsTo `through` relation (locale -> customer)": {
@@ -4583,6 +6065,14 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        id: 1,
+        name: 'Customer1',
+        _pivot_code: 'pt',
+        _pivot_customer: 'Customer1'
+      }
+    },
+    oracle: {
       result: {
         id: 1,
         name: 'Customer1',
@@ -4615,6 +6105,17 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        isoCode: 'pt',
+        customer: {
+          id: 1,
+          name: 'Customer1',
+          _pivot_code: 'pt',
+          _pivot_customer: 'Customer1'
+        }
+      }
+    },
+    oracle: {
       result: {
         isoCode: 'pt',
         customer: {
@@ -4665,6 +6166,19 @@ module.exports = {
         _pivot_code: 'en',
         _pivot_customer: 'Customer2'
       }]
+    },
+    oracle: {
+      result: [{
+        id: 1,
+        name: 'Customer1',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer1'
+      }, {
+        id: 2,
+        name: 'Customer2',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer2'
+      }]
     }
   },
   "works with eager belongsToMany `through` relation (locale -> customers)": {
@@ -4701,6 +6215,22 @@ module.exports = {
       }
     },
     sqlite3: {
+      result: {
+        isoCode: 'en',
+        customersThrough: [{
+          id: 1,
+          name: 'Customer1',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer1'
+        }, {
+          id: 2,
+          name: 'Customer2',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer2'
+        }]
+      }
+    },
+    oracle: {
       result: {
         isoCode: 'en',
         customersThrough: [{

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -243,7 +243,7 @@ module.exports = function(Bookshelf) {
           return new Site({id: 1}).fetch({
             withRelated: {
               'authors.posts': function (qb) {
-                return qb.orderBy('id', 'ASC')
+                return qb.orderBy('posts.id', 'ASC')
               }
             }
           }).then(checkTest(this));
@@ -253,7 +253,7 @@ module.exports = function(Bookshelf) {
           return new Site({id: 1}).fetch({
             withRelated: ['authors.ownPosts', 'authors.site',
             {'blogs.posts': function (qb) {
-              return qb.orderBy('id', 'ASC')
+              return qb.orderBy('posts.id', 'ASC')
             }}]
           }).then(checkTest(this));
         });
@@ -727,7 +727,7 @@ module.exports = function(Bookshelf) {
         it('eager loads belongsToMany `through`', function() {
           return Author.fetchAll({withRelated:
             { blogs: function (qb) {
-              return qb.orderBy('id', 'ASC')
+              return qb.orderBy('blogs.id', 'ASC');
             }}
           }).tap(checkTest(this));
         });


### PR DESCRIPTION
- Tests on this will fail until #1527 gets in. This bug is because it appears I am the latest person to run travis after these breaking changes.
- I copied the Oracle travis settings from knex in `.travis.yml` and the connection settings.
- I had to increase the timeout for migrations, as Oracle takes a long time.
- git has difficulty properly displaying the differences to the relations output file. I have only copied the sqlite3 output for the most part.
- Oracle 'id's are sometimes String types, making comparisons fail. I converted them to Numbers in places this failed.
- For `eager loads "hasMany" -> "belongsToMany" (site -> authors.posts)`, I had to switch the order of the posts for Oracle.

Let me know your thoughts on the tests and any other changes you'd like to make. Also let me know what you think of adding oracle to the list of supported databases. Thanks.