### PR TITLE
Document calling super() on initialize().

### DIFF
--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -90,6 +90,7 @@ const addOptions = {add: true, remove: false};
  * Override this function to add custom initialization, such as event listeners.
  * Because plugins may override this method in subclasses, make sure to call
  * your super (extended) class.  e.g.
+ *
  *     initialize: function() {
  *         this.constructor.__super__.initialize.apply(this, arguments);
  *         // Your initialization code ...

--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -86,7 +86,15 @@ const addOptions = {add: true, remove: false};
 /**
  * @method CollectionBase#initialize
  * @description
- * Custom initialization function.
+ * Called by the {@link Collection Collection constructor} when creating a new instance.
+ * Override this function to add custom initialization, such as event listeners.
+ * Because plugins may override this method in subclasses, make sure to call
+ * your super (extended) class.  e.g.
+ *     initialize: function() {
+ *         this.constructor.__super__.initialize.apply(this, arguments);
+ *         // Your initialization code ...
+ *     }
+ *
  * @see Collection
  */
 CollectionBase.prototype.initialize = noop;

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -75,6 +75,7 @@ inherits(ModelBase, Events);
  * Override this function to add custom initialization, such as event listeners.
  * Because plugins may override this method in subclasses, make sure to call
  * your super (extended) class.  e.g.
+ *
  *     initialize: function() {
  *         this.constructor.__super__.initialize.apply(this, arguments);
  *         // Your initialization code ...

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -73,6 +73,12 @@ inherits(ModelBase, Events);
  *
  * Called by the {@link Model Model constructor} when creating a new instance.
  * Override this function to add custom initialization, such as event listeners.
+ * Because plugins may override this method in subclasses, make sure to call
+ * your super (extended) class.  e.g.
+ *     initialize: function() {
+ *         this.constructor.__super__.initialize.apply(this, arguments);
+ *         // Your initialization code ...
+ *     }
  *
  * @see Model
  *
@@ -615,6 +621,7 @@ _.each(modelMethods, function(method) {
  *
  *     var Customer = bookshelf.Model.extend({
  *       initialize: function() {
+ *         this.constructor.__super__.initialize.apply(this, arguments);
  *         this.on('saving', this.validateSave);
  *       },
  *


### PR DESCRIPTION
We got bitten by this bit of missing documentation: bookshelf-schema overrides Model.initialize but one of our developers followed the docs and didn't call **super()**.  Lost about three hours debugging that...