### PR TITLE
Extract parse into a private method that wraps the public method

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "sinon": "^1.11.1",
     "sinon-chai": "^2.6.0",
     "sqlite3": "^3.0.5",
+    "timekeeper": "^1.0.0",
     "uuid": "~3.0.0"
   },
   "peerDependencies": {

--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -209,7 +209,7 @@ CollectionBase.prototype.set = function(models, options) {
       }
       if (merge) {
         attrs = attrs === model ? model.attributes : attrs;
-        if (options.parse) attrs = existing.parse(attrs, options);
+        if (options.parse) attrs = existing._parseWrapper(attrs, options);
         existing.set(attrs, options);
       }
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -1,5 +1,4 @@
 import { clone, omit, isString, isArray, extend, toArray } from 'lodash';
-
 import Sync from './sync';
 import Helpers from './helpers';
 import EagerRelation from './eager';

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,2 @@
 export const PIVOT_PREFIX = '_pivot_';
+export const DEFAULT_TIMESTAMP_KEYS = ['created_at', 'updated_at'];

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,7 +18,7 @@ const helpers = {
       data[relatedData.key('foreignKey')] = relatedData.parentFk || model.get(relatedData.key('foreignKey'));
       if (relatedData.isMorph()) data[relatedData.key('morphKey')] = relatedData.key('morphValue');
     }
-    return model.set(model.parse(data));
+    return model.set(model._parseWrapper(data));
   },
 
   // Finds the specific `morphTo` table we should be working with, or throws

--- a/src/model.js
+++ b/src/model.js
@@ -1017,7 +1017,7 @@ const BookshelfModel = ModelBase.extend({
         if (method === 'insert' && this.id == null) {
           const updatedCols = {};
           updatedCols[this.idAttribute] = this.id = resp[0];
-          const updatedAttrs = this.parse(updatedCols);
+          const updatedAttrs = this._parseWrapper(updatedCols);
           _.assign(this.attributes, updatedAttrs);
         } else if (method === 'update' && resp === 0) {
           if (options.require !== false) {
@@ -1322,7 +1322,7 @@ const BookshelfModel = ModelBase.extend({
    */
   _handleResponse(response) {
     const relatedData = this.relatedData;
-    this.set(this.parse(response[0]), {silent: true})._reset();
+    this.set(this._parseWrapper(response[0]), {silent: true})._reset();
     if (relatedData && relatedData.isJoined()) {
       relatedData.parsePivot([this]);
     }

--- a/src/relation.js
+++ b/src/relation.js
@@ -415,7 +415,7 @@ export default RelationBase.extend({
     // Now that related models have been successfully paired, update each with
     // its parsed attributes
     related.map(model => {
-      model.attributes = model.parse(model.attributes)
+      model.attributes = model._parseWrapper(model.attributes)
     });
 
     return related;
@@ -725,8 +725,8 @@ const pivotHelpers = {
         JoinModel   = relatedData.throughTarget,
         joinModel   = new JoinModel();
 
-    fks  = joinModel.parse(fks);
-    data = joinModel.parse(data);
+    fks  = joinModel._parseWrapper(fks);
+    data = joinModel._parseWrapper(data);
 
     if (method === 'insert') {
       return joinModel.set(data).save(null, options);

--- a/src/sync.js
+++ b/src/sync.js
@@ -71,7 +71,7 @@ _.extend(Sync.prototype, {
         if (relatedData.isThrough()) {
           fks[relatedData.key('foreignKey')] = relatedData.parentFk;
           const through = new relatedData.throughTarget(fks);
-          relatedData.pivotColumns = through.parse(relatedData.pivotColumns);
+          relatedData.pivotColumns = through._parseWrapper(relatedData.pivotColumns);
         } else if(relatedData.type === 'hasMany') {
           const fk = relatedData.key('foreignKey');
           knex.where(fk, relatedData.parentFk);
@@ -134,7 +134,7 @@ _.extend(Sync.prototype, {
 
           return through.triggerThen('fetching', through, relatedData.pivotColumns, options)
             .then(function () {
-              relatedData.pivotColumns = through.parse(relatedData.pivotColumns);
+              relatedData.pivotColumns = through._parseWrapper(relatedData.pivotColumns);
             });
         }
       });

--- a/test/index.js
+++ b/test/index.js
@@ -40,7 +40,7 @@ describe('Bookshelf', function () {
   it('VERSION should equal version number in package.json',
     function () {
     var Knex = require('knex');
-    var bookshelf = Bookshelf(Knex({}));
+    var bookshelf = Bookshelf(Knex({ client: 'pg' }));
     var p = require('../package.json');
     expect(p.version).to.equal(bookshelf.VERSION);
   });

--- a/test/integration.js
+++ b/test/integration.js
@@ -23,7 +23,7 @@ module.exports = function(Bookshelf) {
   var MySQL = require('../bookshelf')(mysql);
   var PostgreSQL = require('../bookshelf')(pg);
   var SQLite3 = require('../bookshelf')(sqlite3);
-  var Swapped = require('../bookshelf')(Knex({}));
+  var Swapped = require('../bookshelf')(Knex({ client : 'pg' }));
   Swapped.knex = sqlite3;
 
   it('should allow creating a new Bookshelf instance with "new"', function() {
@@ -32,7 +32,7 @@ module.exports = function(Bookshelf) {
   });
 
   it('should allow swapping in another knex instance', function() {
-    var bookshelf = new Bookshelf(Knex({}));
+    var bookshelf = new Bookshelf(Knex({ client : 'pg'}));
     var Models = require('./integration/helpers/objects')(bookshelf).Models;
     var site = new Models.Site();
 

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -82,7 +82,10 @@ module.exports = function(Bookshelf) {
 
   var Admin = Bookshelf.Model.extend({
     tableName: 'admins',
-    hasTimestamps: true
+    hasTimestamps: true,
+    parse: function(res){
+      return res;
+    }
   });
 
   // Author of a blog post.

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -935,7 +935,6 @@ module.exports = function(bookshelf) {
 
         before(function(){
           tk.freeze(testDate);
-
           return Admin.forge({username: 'test3', password: 'password'})
             .save()
             .then(function(_newAdmin){
@@ -987,7 +986,7 @@ module.exports = function(bookshelf) {
         });
 
         it('will return expected date format for related items', function(){
-          Site.forge({id: 1})
+          return Site.forge({id: 1})
             .fetch({ withRelated: 'admins' })
             .then(function(site){
               var admin = site.related('admins').shift();

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -969,7 +969,7 @@ module.exports = function(bookshelf) {
             .where('username', '=', 'test3')
             .fetchAll()
             .then(function(admins){
-              let admin = admins.shift();
+              var admin = admins.shift();
               expect(admin.get('created_at').getTime()).to.equal(testDate.getTime());
               expect(admin.get('updated_at').getTime()).to.equal(testDate.getTime());
             });
@@ -980,7 +980,7 @@ module.exports = function(bookshelf) {
             .admins()
             .fetch()
             .then(function(admins){
-              let admin = admins.shift();
+              var admin = admins.shift();
               expect(admin.get('created_at').getTime()).to.equal(testDate.getTime());
               expect(admin.get('updated_at').getTime()).to.equal(testDate.getTime());
             });
@@ -990,7 +990,7 @@ module.exports = function(bookshelf) {
           Site.forge({id: 1})
             .fetch({ withRelated: 'admins' })
             .then(function(site){
-              let admin = site.related('admins').shift();
+              var admin = site.related('admins').shift();
               expect(admin.get('created_at').getTime()).to.equal(testDate.getTime());
               expect(admin.get('updated_at').getTime()).to.equal(testDate.getTime());
             });


### PR DESCRIPTION
Response to issue #1068 

Created a wrapper function around the parse method. The user can still define custom parse methods as defined in the API but the response passed to the user-defined method has timestamp values converted to javascript dates. This change helps with consistency in fields used by the library when using SQLite databases. 