### PR TITLE
Make tests pass again

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -40,7 +40,7 @@ describe('Bookshelf', function () {
   it('VERSION should equal version number in package.json',
     function () {
     var Knex = require('knex');
-    var bookshelf = Bookshelf(Knex({}));
+    var bookshelf = Bookshelf({});
     var p = require('../package.json');
     expect(p.version).to.equal(bookshelf.VERSION);
   });

--- a/test/integration.js
+++ b/test/integration.js
@@ -23,7 +23,7 @@ module.exports = function(Bookshelf) {
   var MySQL = require('../bookshelf')(mysql);
   var PostgreSQL = require('../bookshelf')(pg);
   var SQLite3 = require('../bookshelf')(sqlite3);
-  var Swapped = require('../bookshelf')(Knex({}));
+  var Swapped = require('../bookshelf')({});
   Swapped.knex = sqlite3;
 
   it('should allow creating a new Bookshelf instance with "new"', function() {
@@ -32,7 +32,7 @@ module.exports = function(Bookshelf) {
   });
 
   it('should allow swapping in another knex instance', function() {
-    var bookshelf = new Bookshelf(Knex({}));
+    var bookshelf = new Bookshelf({});
     var Models = require('./integration/helpers/objects')(bookshelf).Models;
     var site = new Models.Site();
 

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -986,14 +986,6 @@ module.exports = {
           first_name: 'Bazooka',
           last_name: 'Joe',
           posts: [{
-            id: 2,
-            owner_id: 2,
-            blog_id: 2,
-            name: 'This is a new Title 2!',
-            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.',
-            _pivot_author_id: 2,
-            _pivot_post_id: 2
-          },{
             id: 1,
             owner_id: 1,
             blog_id: 1,
@@ -1001,6 +993,14 @@ module.exports = {
             content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.',
             _pivot_author_id: 2,
             _pivot_post_id: 1
+          },{
+            id: 2,
+            owner_id: 2,
+            blog_id: 2,
+            name: 'This is a new Title 2!',
+            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.',
+            _pivot_author_id: 2,
+            _pivot_post_id: 2
           }]
         }]
       }
@@ -3693,17 +3693,17 @@ module.exports = {
         first_name: 'Bazooka',
         last_name: 'Joe',
         blogs: [{
-          id: 2,
-          site_id: 1,
-          name: 'Alternate Site Blog',
-          _pivot_owner_id: 2,
-          _pivot_blog_id: 2
-        },{
           id: 1,
           site_id: 1,
           name: 'Main Site Blog',
           _pivot_owner_id: 2,
           _pivot_blog_id: 1
+        },{
+          id: 2,
+          site_id: 1,
+          name: 'Alternate Site Blog',
+          _pivot_owner_id: 2,
+          _pivot_blog_id: 2
         }]
       },{
         id: 3,

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -235,13 +235,20 @@ module.exports = function(Bookshelf) {
 
         it('eager loads "hasMany" -> "belongsToMany" (site -> authors.posts)', function() {
           return new Site({id: 1}).fetch({
-            withRelated: ['authors.posts']
+            withRelated: {
+              'authors.posts': function (qb) {
+                return qb.orderBy('id', 'ASC')
+              }
+            }
           }).then(checkTest(this));
         });
 
         it('does multi deep eager loads (site -> authors.ownPosts, authors.site, blogs.posts)', function() {
           return new Site({id: 1}).fetch({
-            withRelated: ['authors.ownPosts', 'authors.site', 'blogs.posts']
+            withRelated: ['authors.ownPosts', 'authors.site',
+            {'blogs.posts': function (qb) {
+              return qb.orderBy('id', 'ASC')
+            }}]
           }).then(checkTest(this));
         });
 
@@ -712,7 +719,11 @@ module.exports = function(Bookshelf) {
         });
 
         it('eager loads belongsToMany `through`', function() {
-          return Author.fetchAll({withRelated: 'blogs'}).tap(checkTest(this));
+          return Author.fetchAll({withRelated:
+            { blogs: function (qb) {
+              return qb.orderBy('id', 'ASC')
+            }}
+          }).tap(checkTest(this));
         });
 
         it('eager loads belongsTo `through`', function() {


### PR DESCRIPTION
I don't know how or why, but tests were not passing, at least not locally, with `mysql 8` and `postgres 9.6+PostGIS`. For the record, I created the following `docker-compose.yml` to run the tests:

```yml
version: '2'
services:
  api:
    container_name: bookshelf-test
    image: node:6
    tty: true
    volumes:
      - .:/usr/bookshelftest
    working_dir: /usr/bookshelftest
    command: bash -c 'npm install && npm run build && npm test'
    environment:
      BOOKSHELF_TEST: ../config.js
    links:
      - mysql
      - postgres

  mysql:
    image: mysql:latest
    container_name: bookshelf-test-mysql
    environment:
      MYSQL_ROOT_PASSWORD: rootpassword
      MYSQL_DATABASE: bookshelf_test

  postgres:
    container_name: bookshelf-test-postgres
    image: mdillon/postgis:9.6-alpine
    environment:
      POSTGRES_DB: bookshelf_test
```

using this config file

```javascript
module.exports = {
  mysql: {
    database: 'bookshelf_test',
    user: 'root',
    password: 'rootpassword',
    encoding: 'utf8',
    host: 'mysql',
    port: 3306
  },

  postgres: {
    user: 'postgres',
    database: 'bookshelf_test',
    host: 'postgres',
    port: 5432,
    charset: 'utf8',
    ssl: false
  },

  sqlite3: {
    filename: ':memory:'
  }
}
```

The two main problems were:
1. Creation of `knex` with `Knex({})` was failing. Maybe there was some recent change in knex?
1. (at least) Some tests overspecify the order of the results in returned arrays.

This pull request fixes that, although really fixing (2) would require quite a refactor.

I'm preparing another pull request to fix #1299 but this one needs to be merged first.

PS: I can prepare a similar but more generic docker and config file and update the CONTRIB docs if you'd find it interesting.