### PR TITLE
Fix description of event 'destroyed'

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -1137,13 +1137,13 @@ const BookshelfModel = ModelBase.extend({
       /**
        * Destroyed event.
        *
-       * Fired before a `delete` query. A promise may be returned from the event
+       * Fired after a `delete` query. A promise may be returned from the event
        * handler for async behaviour.
        *
        * @event Model#destroyed
        * @param {Model}  model    The model firing the event.
        * @param {Object} attrs    Model firing the event.
-       * @param {Object} options  Options object passed to {@link Model#save save}.
+       * @param {Object} options  Options object passed to {@link Model#destroy destroy}.
        * @returns {Promise}
        */
       return this.triggerThen('destroyed', this, resp, options);


### PR DESCRIPTION
Hey,

The event *destroyed* has some bad references on its documentation. This PR just fixes that.

Thanks.