### PR TITLE
Use created_at from query if passed

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -489,14 +489,18 @@ ModelBase.prototype.timestamp = function(options) {
 
   const [ createdAtKey, updatedAtKey ] = keys;
 
-  if (updatedAtKey) {
-    attributes[updatedAtKey] = now;
-  }
+if (updatedAtKey) {
+  attributes[updatedAtKey] = this.attributes[updatedAtKey]
+    ? new Date(this.attributes[updatedAtKey])
+    : now;
+}
 
-  if (createdAtKey && method === 'insert') {
-    attributes[createdAtKey] = now;
-  }
-
+if (createdAtKey && method === 'insert') {
+  attributes[createdAtKey] = this.attributes[createdAtKey]
+    ? new Date(this.attributes[createdAtKey])
+    : now;
+}
+  
   this.set(attributes, options);
 
   return attributes;


### PR DESCRIPTION
while running insert query passing created_at with data should set the passed created_at. But it is ignoring that and alway using `new Date()` 
Use cases for these can be when data is created in offline condition and is sync later in that case date should be of when data was created.

Example 
```js
let User = bookshelf.Model.extend({
  tableName: 'users',
  hasTimestamps: ['created_at', 'updated_at'],
});

User.forge({ firstName: 'Grayson',created_at: 1498024050269 }).save()
```
### Actual
insert user grayson with created_at `new Date()`

### Expected
insert user grayson with created_at `new Date(1498024050269)`
