### PR TITLE
Replace renamed reference in documentation

### DIFF
--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -156,7 +156,7 @@ function Bookshelf(knex) {
      *   {name: 'Person2'}
      * ]);
      *
-     * Promise.all(accounts.invoke('save')).then(function() {
+     * Promise.all(accounts.invokeMap('save')).then(function() {
      *   // collection models should now be saved...
      * });
      */


### PR DESCRIPTION
Replaces the `collection.invoke` call with `collection.invokeMap` in the `Collection.forge` example - per the changelog.