### PR TITLE
Update installation documentation re: knex version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It's a lean Object Relational Mapper, allowing you to drop down to the raw knex 
 You'll need to install a copy of [knex.js](http://knexjs.org/), and either mysql, pg, or sqlite3 from npm.
 
 ```js
-$ npm install knex --save
+$ npm install knex@^0.12.0 --save
 $ npm install bookshelf --save
 
 # Then add one of the following:


### PR DESCRIPTION
Regarding https://github.com/bookshelf/bookshelf/issues/1570

Knex has released v0.13.0 which is outside the peer dependency range specified for the bookshelf package. Users following bookshelf's specific installation instructions will receive warnings of knex incompatibility/unavailability.

This simply improves the documentation until a contributor updates bookshelf to handle knex's minor version bump.