### PR TITLE
npm install knex@0.13 in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It's a lean Object Relational Mapper, allowing you to drop down to the raw knex 
 You'll need to install a copy of [knex.js](http://knexjs.org/), and either mysql, pg, or sqlite3 from npm.
 
 ```js
-$ npm install knex --save
+$ npm install knex@0.13 --save
 $ npm install bookshelf --save
 
 # Then add one of the following:


### PR DESCRIPTION
follow-up to #1590 

this will not break the installation of bookshelf after the release of knex 0.13.1