### PR TITLE
New implementation for the setting of timestamps columns values

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -127,7 +127,8 @@ ModelBase.prototype.idAttribute = 'id';
  * column name.
  * You can pass values for the timestamps columns as parameter in the
  * {@link Model#save save} method. This will prevent the automatic
- * updated of the timestamps columns values.
+ * update of the timestamps columns values during the {@link Model#save save} method,
+ * while the final columns values will be the values you have specified.
  *
  */
 ModelBase.prototype.hasTimestamps = false;

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -490,8 +490,8 @@ ModelBase.prototype.timestamp = function(options) {
     ? this.hasTimestamps
     : DEFAULT_TIMESTAMP_KEYS;
 
-  const canEditUpdatedAtKey = (options || {}).editUpdatedAt ? options.editUpdatedAt : true;
-  const canEditCreatedAtKey = (options || {}).editCreatedAt ? options.editCreatedAt : true;
+  const canEditUpdatedAtKey = (options || {}).editUpdatedAt!= undefined ? options.editUpdatedAt : true;
+  const canEditCreatedAtKey = (options || {}).editCreatedAt!= undefined ? options.editCreatedAt : true;
 
   const [ createdAtKey, updatedAtKey ] = keys;
 

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -490,24 +490,24 @@ ModelBase.prototype.timestamp = function(options) {
     ? this.hasTimestamps
     : DEFAULT_TIMESTAMP_KEYS;
 
+  const canEditUpdatedAtKey = (options || {}).editUpdatedAt ? options.editUpdatedAt : true;
+  const canEditCreatedAtKey = (options || {}).editCreatedAt ? options.editCreatedAt : true;
+
   const [ createdAtKey, updatedAtKey ] = keys;
 
-  if (updatedAtKey) {
-    attributes[updatedAtKey] = this.attributes[updatedAtKey]
-      ? new Date(this.attributes[updatedAtKey])
-      : now;
+  if (updatedAtKey && canEditUpdatedAtKey) {
+    attributes[updatedAtKey] = now;
   }
 
-  if (createdAtKey && method === 'insert') {
-    attributes[createdAtKey] = this.attributes[createdAtKey]
-      ? new Date(this.attributes[createdAtKey])
-      : now;
+  if (createdAtKey && method === 'insert' && canEditCreatedAtKey) {
+    attributes[createdAtKey] = now;
   }
 
   this.set(attributes, options);
 
   return attributes;
 };
+
 
 /**
  * @method

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -125,6 +125,9 @@ ModelBase.prototype.idAttribute = 'id';
  * to {@link Model#hasTimestamps hasTimestamps}.  The first element will
  * be the created column name and the second will be the updated
  * column name.
+ * You can pass values for the timestamps columns as parameter in the
+ * {@link Model#save save} method. This will prevent the automatic
+ * updated of the timestamps columns values.
  *
  */
 ModelBase.prototype.hasTimestamps = false;

--- a/src/model.js
+++ b/src/model.js
@@ -9,6 +9,8 @@ import Errors from './errors';
 import ModelBase from './base/model';
 import Promise from './base/promise';
 
+const DEFAULT_TIMESTAMP_KEYS = ['created_at', 'updated_at'];
+
 /**
  * @class Model
  * @extends ModelBase
@@ -949,10 +951,24 @@ const BookshelfModel = ModelBase.extend({
       // timestamps, as `timestamp` calls `set` internally.
       this.set(attrs, {silent: true});
 
+
+      // Obtain the keys for the timestamp columns
+      const keys = _.isArray(this.hasTimestamps)
+        ? this.hasTimestamps
+        : DEFAULT_TIMESTAMP_KEYS;
+
+      const [ createdAtKey, updatedAtKey ] = keys;
+
       // Now set timestamps if appropriate. Extend `attrs` so that the
       // timestamps will be provided for a patch operation.
       if (this.hasTimestamps) {
-        _.extend(attrs, this.timestamp(_.extend(options, {silent: true})));
+        //If some of the new attributes are value for update_at or created_at columns disable the possibility for the timestamp function to update the columns 
+        var additionalOptions = {
+          silent: true,
+          editUpdatedAt : attrs[updatedAtKey] ? false : true,
+          editCreatedAt : attrs[createdAtKey] ? false : true
+        }
+        _.extend(attrs, this.timestamp(_.extend(options, additionalOptions)));
       }
 
       // If there are any save constraints, set them on the model.

--- a/src/model.js
+++ b/src/model.js
@@ -986,10 +986,10 @@ const BookshelfModel = ModelBase.extend({
       // Now set timestamps if appropriate. Extend `attrs` so that the
       // timestamps will be provided for a patch operation.
       if (this.hasTimestamps) {
-        //If some of the new attributes are value for update_at or created_at columns disable the possibility for the timestamp function to update the columns 
-        var editUpdatedAt = attrs[updatedAtKey] ? false : true;
-        var editCreatedAt = attrs[createdAtKey] ? false : true;
-        var additionalOptions = {
+        //If some of the new attributes are value for update_at or created_at columns disable the possibility for the timestamp function to update the columns
+        const editUpdatedAt = attrs[updatedAtKey] ? false : true;
+        const editCreatedAt = attrs[createdAtKey] ? false : true;
+        const additionalOptions = {
           silent: true,
           editUpdatedAt : editUpdatedAt ,
           editCreatedAt : editCreatedAt

--- a/src/model.js
+++ b/src/model.js
@@ -963,10 +963,12 @@ const BookshelfModel = ModelBase.extend({
       // timestamps will be provided for a patch operation.
       if (this.hasTimestamps) {
         //If some of the new attributes are value for update_at or created_at columns disable the possibility for the timestamp function to update the columns 
+        var editUpdatedAt = attrs[updatedAtKey] ? false : true;
+        var editCreatedAt = attrs[createdAtKey] ? false : true;
         var additionalOptions = {
           silent: true,
-          editUpdatedAt : attrs[updatedAtKey] ? false : true,
-          editCreatedAt : attrs[createdAtKey] ? false : true
+          editUpdatedAt : editUpdatedAt ,
+          editCreatedAt : editCreatedAt
         }
         _.extend(attrs, this.timestamp(_.extend(options, additionalOptions)));
       }

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -908,6 +908,33 @@ module.exports = function(bookshelf) {
         return m.save({item: 'test'});
       });
 
+      it('will save a new updated_at timestamp if passed as parameter', function() {
+        var model = new Models.Admin();
+        var oldUpdatedAt = null;
+        var newUpdatedAt = new Date();
+        newUpdatedAt.setMinutes(newUpdatedAt.getMinutes() + 1);
+        return model.save().then(function(m) {
+          oldUpdatedAt = m.get('updated_at');
+          return model.save('updated_at',newUpdatedAt);
+        })
+        .then(function(m) {
+          expect(m.get('updated_at')).to.be.eql(newUpdatedAt);
+          expect(m.get('updated_at')).to.be.not.eql(oldUpdatedAt);
+        });
+      });
+
+      it('will save the updated_at timestamp with current time, if updated_at column is not passed as attributed', function() {
+        var model = new Models.Admin();
+        var updatedAt = null
+        return model.save().then(function(m) {
+          updatedAt = m.get('updated_at');
+          return m.save('username','pablo');
+        })
+        .then(function(fin) {
+          expect(fin.get('updated_at')).to.be.not.eql(updatedAt);
+        });
+      });
+
     });
 
     describe('timestamp', function() {
@@ -939,6 +966,7 @@ module.exports = function(bookshelf) {
         expect(model.get('created_at')).to.not.exist;
         expect(model.get('updated_at')).to.not.exist;
       });
+
     });
 
     describe('defaults', function() {

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -935,6 +935,33 @@ module.exports = function(bookshelf) {
         });
       });
 
+      it('will save a new created_at timestamp if passed as parameter', function() {
+        var model = new Models.Admin();
+        var oldCreatedAt = null;
+        var newCreatedAt = new Date();
+        newCreatedAt.setMinutes(newCreatedAt.getMinutes() + 1);
+        return model.save().then(function(m) {
+          oldCreatedAt = m.get('created_at');
+          return model.save('created_at',newCreatedAt);
+        })
+        .then(function(m) {
+          expect(m.get('created_at')).to.be.eql(newCreatedAt);
+          expect(m.get('created_at')).to.be.not.eql(oldCreatedAt);
+        });
+      });
+
+      it('will save the created_at timestamp with current time, if created_at column is not passed as attributed', function() {
+        var model = new Models.Admin();
+        var createdAt = null
+        return model.save().then(function(m) {
+          createdAt = m.get('created_at');
+          return m.save('username','pablo');
+        })
+        .then(function(fin) {
+          expect(fin.get('created_at')).to.be.not.eql(createdAt);
+        });
+      });
+
     });
 
     describe('timestamp', function() {

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -958,7 +958,7 @@ module.exports = function(bookshelf) {
           return m.save('username','pablo');
         })
         .then(function(fin) {
-          expect(fin.get('created_at')).to.be.not.eql(createdAt);
+          expect(fin.get('created_at')).to.be.eql(createdAt);
         });
       });
 


### PR DESCRIPTION
# New implementation for the setting of timestamps columns values

* Related Issues : #1602 
* Previous PRs: #1583 

## Introduction

With version 0.10.4 is it possible to updated the timestamps columns. This unfortunately breaks the auto-update of the updated_at column.

## Motivation

Few weeks ago the #1583 PR was merged to the codebase, allowing the very useful ability to set the timestamps columns values during an update to a model.

Because of the lack of tests we didn't discover a new bug created, that breaks the auto-update of the updated_at timestamps when a model is updated.

This PR aims to solve this bug introducing two new options for the Model.timestamp method, that are generated automatically in the Model.save function

## Proposed solution

I have realised that the timestamps columns, if entries in the attributes object are passed, are updated at every Model.save call, but they are updated also with the Model.timestamps call, so I wrote this change.

In the src/model.js , inside the Model.save method

```
// Obtain the keys for the timestamp columns
const keys = _.isArray(this.hasTimestamps)
  ? this.hasTimestamps
  : DEFAULT_TIMESTAMP_KEYS;

const [ createdAtKey, updatedAtKey ] = keys;

// Now set timestamps if appropriate. Extend `attrs` so that the
// timestamps will be provided for a patch operation.
if (this.hasTimestamps) {
  //If some of the new attributes are value for update_at or created_at columns disable the possibility for the timestamp function to update the columns 
  var additionalOptions = {
    silent: true,
    editUpdatedAt : attrs[updatedAtKey] ? false : true,
    editCreatedAt : attrs[createdAtKey] ? false : true
  }
  _.extend(attrs, this.timestamp(_.extend(options, additionalOptions)));
}
```

As you can see the function takes the timestamps keys from a constant ( WIP , there are another constant in base/model.js and an edit to one of the two can break the feature, so we need to use only one array between the two files).

If the attributes array passed to the save function contains entries for the timestamps keys, then two bool element of the options object (editUpdatedAt and  editCreatedAt) are set to false ( default value true). 

The options object is then passed to the this.timestamp function

in src/base/model.js

```
const canEditUpdatedAtKey = (options || {}).editUpdatedAt ? options.editUpdatedAt : true;
const canEditCreatedAtKey = (options || {}).editCreatedAt ? options.editCreatedAt : true;

const [ createdAtKey, updatedAtKey ] = keys;

if (updatedAtKey && canEditUpdatedAtKey) {
  attributes[updatedAtKey] = now;
}

if (createdAtKey && method === 'insert' && canEditCreatedAtKey) {
  attributes[createdAtKey] = now;
}

this.set(attributes, options);
```

two constant are set based on the value contained in the options object.
If one const is true then the related column is updated with the same process of the 0.10.3 version of bookshelf.
If one const is false then the related column is NOT updated, and the values of the columns already set with ` this.set(attrs, {silent: true});` in src/model.js

## Current PR Issues

WIP
No tests
No docs


Please someone can verify and review it running a sample app? Also I need some help with the tests..