### PR TITLE
OracleDB tests will be loaded and executed only when oracledb is installed

### DIFF
--- a/test/integration.js
+++ b/test/integration.js
@@ -19,14 +19,22 @@ module.exports = function(Bookshelf) {
       }
     }
   });
-  var oracledb = require('knex')({client: 'oracledb', connection: config.oracledb});
 
   var MySQL = require('../bookshelf')(mysql);
   var PostgreSQL = require('../bookshelf')(pg);
   var SQLite3 = require('../bookshelf')(sqlite3);
-  var OracleDB = require('../bookshelf')(oracledb);
   var Swapped = require('../bookshelf')(Knex({client: 'sqlite3'}));
   Swapped.knex = sqlite3;
+  var databasesArray = [MySQL, PostgreSQL, SQLite3, Swapped];
+  // Load OracleDB tests only if the module is present in the system
+  try{
+    var oracleDbModuleName = require.resolve('oracledb');
+    var oracledb = require('knex')({client: 'oracledb', connection: config.oracledb});
+    var OracleDB = require('../bookshelf')(oracledb);
+    databasesArray.push(OracleDB);
+  }catch(e){
+    // empty
+  }
 
   it('should allow creating a new Bookshelf instance with "new"', function() {
     var bookshelf = new Bookshelf(sqlite3);
@@ -50,7 +58,7 @@ module.exports = function(Bookshelf) {
     });
   });
 
-  _.each([MySQL, PostgreSQL, SQLite3, OracleDB, Swapped], function(bookshelf) {
+  _.each(databasesArray, function(bookshelf) {
 
     var dialect = bookshelf.knex.client.dialect;
 


### PR DESCRIPTION
# OracleDB tests will be loaded and executed only when oracledb is installed

* Related Issues : #1605 

## Introduction

OracleDB tests will be loaded and executed only when oracledb is installed, this will prevent the tests to fail locally.

## Motivation

In Contributing.md the docs explain only to how run tests using postgre and mysql, there is no reference for oracledb tests, which are executed  in the Travis tests.

But without the oracledb installed it is impossible to run the tests locally because of an "oracledb not found" error.

This PR will help a lot in resolve all tests errors locally before the publish of the PR. This procedure is necessary to prevent PRs that fails on Travis because the code was not tested.