### PR TITLE
Improve forge() performance

### DIFF
--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -65,7 +65,9 @@ function Bookshelf(knex) {
      *   Convert attributes by {@linkcode Model#parse parse} before being
      *   {@linkcode Model#set set} on the `model`.
      */
-    forge,
+    forge: function(attributes, options) {
+      return new this(attributes, options)
+    },
 
     /**
      * @method Model.collection
@@ -160,7 +162,9 @@ function Bookshelf(knex) {
      *   // collection models should now be saved...
      * });
      */
-     forge
+     forge: function(models, options) {
+         return new this(models, options)
+     }
 
 
   });
@@ -273,13 +277,6 @@ function Bookshelf(knex) {
    * A reference to the {@link http://knexjs.org Knex.js} instance being used by Bookshelf.
    */
   bookshelf.knex = knex;
-
-  // The `forge` function properly instantiates a new Model or Collection
-  // without needing the `new` operator... to make object creation cleaner
-  // and more chainable.
-  function forge() {
-    return new this(...arguments);
-  }
 
   function builderFn(tableNameOrBuilder) {
     let builder = null;


### PR DESCRIPTION

# Improve forge() performance

## Introduction

Babel currently compiles `forge` to convert the `arguments` object to an array. This has well-documented performance problems.

## Motivation

`forge` is one of the most commonly used methods in our codebase. I decided to do some profiling on it using the `--prof` flag and saw that it is not being optimized by V8. After poking around a little, I discovered that Babel compiles forge into the following:

```javascript
function forge() {
  return new (Function.prototype.bind.apply(this,
 [null].concat(Array.prototype.slice.call(arguments))))();
}
```

Using `Array#slice` on `arguments` is explicitly listed [here](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments) as an optimization killer. You can check out some benchmarks on it on [Node.js Foundation's blog](https://medium.com/the-node-js-collection/get-ready-a-new-v8-is-coming-node-js-performance-is-changing-46a63d6da4de), under the header "LEAKING AND ARRAYIFYING ARGUMENTS".

## Proposed solution

The proposed solution avoids using the `arguments` object altogether and defines `forge` inline for both `Model#forge` and `Collection#forge` with their documented parameters. I benchmarked the change using the following small script, ran in a toy project:

```javascript
'use strict'

var knex = require('knex')({
  client: 'sqlite3',
  connection: {
    filename: "./mydb.sqlite"
  }
})

var bookshelf = require('bookshelf')(knex)

var User = bookshelf.Model.extend({
  tableName: 'users'
})

console.time('test')
for (let i = 0; i < 100000; i++) {
  User.forge({
    test1: 'test1',
    test2: 'test2',
    test3: 'test3'
  })
}
console.timeEnd('test')
```

The change improves the execution of the script from ~1700 ms to ~700 ms.

## Current PR Issues

This breaks anyone adding more, undocumented parameters to `forge`.

## Alternatives considered

I'm open to any suggestions! After experimenting a little I did not find a solution to allow arbitrary arguments for `forge` without relying on converting `arguments` to an array.
