### PR TITLE
Fix foreign key = 0 not fetching related object

### DIFF
--- a/src/relation.js
+++ b/src/relation.js
@@ -401,7 +401,7 @@ export default RelationBase.extend({
     // Loop over the `parentModels` and attach the grouped sub-models,
     // keeping the `relatedData` on the new related instance.
     _.each(parentModels, (model) => {
-      let groupedKey = null;
+      let groupedKey;
       if (!this.isInverse()) {
         groupedKey = model.get(this.parentIdAttribute);
       } else {
@@ -411,7 +411,7 @@ export default RelationBase.extend({
         const formatted = model.format(_.clone(model.attributes));
         groupedKey = formatted[keyColumn];
       }
-      if (groupedKey !== null) {
+      if (!_.isNil(groupedKey)) {
         const relation = model.relations[relationName] = this.relatedInstance(grouped[groupedKey]);
         relation.relatedData = this;
         if (this.isJoined()) _.extend(relation, pivotHelpers);

--- a/src/relation.js
+++ b/src/relation.js
@@ -401,7 +401,7 @@ export default RelationBase.extend({
     // Loop over the `parentModels` and attach the grouped sub-models,
     // keeping the `relatedData` on the new related instance.
     _.each(parentModels, (model) => {
-      let groupedKey;
+      let groupedKey = null;
       if (!this.isInverse()) {
         groupedKey = model.get(this.parentIdAttribute);
       } else {
@@ -411,7 +411,7 @@ export default RelationBase.extend({
         const formatted = model.format(_.clone(model.attributes));
         groupedKey = formatted[keyColumn];
       }
-      if (groupedKey) {
+      if (groupedKey !== null) {
         const relation = model.relations[relationName] = this.relatedInstance(grouped[groupedKey]);
         relation.relatedData = this;
         if (this.isJoined()) _.extend(relation, pivotHelpers);


### PR DESCRIPTION
# Fix foreign key = 0 not fetching related object

## Introduction

Fixes fetching relations with foreign key = 0.
Currently inside eagerPair-method the foreign keys are just checked for being falsy,
leaving the related instance out of the parent's relations if the FK is 0.

## Motivation

This PR enables fetching relations with value 0 as the foreign key.

## Proposed solution

Compare the `groupedKey`-variable (which stores the foreign key) through lodashes `isNil`-method inside the if-block, instead of just checking for a falsy value. This way 0 is a valid value, but `null` / `undefined` values are not.