### PR TITLE
Update docs for saved event to be consistent with 'updated' and 'created'

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -1080,7 +1080,7 @@ const BookshelfModel = ModelBase.extend({
          *
          * @event Model#saved
          * @param {Model}  model    The model firing the event.
-         * @param {Object} resp     The database response.
+         * @param {Object} attrs    Model firing the event.
          * @param {Object} options  Options object passed to {@link Model#save save}.
          * @returns {Promise}
          */


### PR DESCRIPTION
All three event listeners are called with the same arguments, so its just confusing to make the saved parameter have a different name in the docs