### PR TITLE
Proposal: blocking created_at and updated_at from being updated.

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -487,24 +487,23 @@ ModelBase.prototype.saveMethod = function({ method = null, patch = false } = {})
 ModelBase.prototype.timestamp = function(options) {
   if (!this.hasTimestamps) return {};
 
-  const now          = (options || {}).date ? new Date(options.date) : new Date();
-  const attributes   = {};
-  const method       = this.saveMethod(options);
+  options = options || {};
+
+  const now = options.date ? new Date(options.date) : new Date();
+  const attributes = {};
+  const method = this.saveMethod(options);
   const keys = _.isArray(this.hasTimestamps)
     ? this.hasTimestamps
     : DEFAULT_TIMESTAMP_KEYS;
 
-  const canEditUpdatedAtKey = (options || {}).editUpdatedAt!= undefined ? options.editUpdatedAt : true;
-  const canEditCreatedAtKey = (options || {}).editCreatedAt!= undefined ? options.editCreatedAt : true;
-
   const [ createdAtKey, updatedAtKey ] = keys;
 
-  if (updatedAtKey && canEditUpdatedAtKey) {
-    attributes[updatedAtKey] = now;
+  if (method === 'insert' && !options.editCreatedAt) {
+    attributes[createdAtKey] = now;
   }
 
-  if (createdAtKey && method === 'insert' && canEditCreatedAtKey) {
-    attributes[createdAtKey] = now;
+  if (!options.editUpdatedAt) {
+    attributes[updatedAtKey] = now;
   }
 
   this.set(attributes, options);

--- a/src/model.js
+++ b/src/model.js
@@ -986,13 +986,16 @@ const BookshelfModel = ModelBase.extend({
       // Now set timestamps if appropriate. Extend `attrs` so that the
       // timestamps will be provided for a patch operation.
       if (this.hasTimestamps) {
-        //If some of the new attributes are value for update_at or created_at columns disable the possibility for the timestamp function to update the columns
-        const editUpdatedAt = attrs[updatedAtKey] ? false : true;
-        const editCreatedAt = attrs[createdAtKey] ? false : true;
+        // If some of the new attributes are value for update_at or created_at
+        // columns disable the possibility for the timestamp function to update
+        // the columns
+        const {forceTimestamps = false} = options;
+        const editUpdatedAt = Boolean(attrs[updatedAtKey]) && forceTimestamps;
+        const editCreatedAt = Boolean(attrs[createdAtKey]) && forceTimestamps;
         const additionalOptions = {
           silent: true,
-          editUpdatedAt : editUpdatedAt ,
-          editCreatedAt : editCreatedAt
+          editUpdatedAt: editUpdatedAt,
+          editCreatedAt: editCreatedAt
         }
         _.extend(attrs, this.timestamp(_.extend(options, additionalOptions)));
       }
@@ -1049,67 +1052,67 @@ const BookshelfModel = ModelBase.extend({
        * @returns {Promise}
        */
       return this.triggerThen((method === 'insert' ? 'creating saving' : 'updating saving'), this, attrs, options)
-      .bind(this)
-      .then(function() {
-        return sync[options.method](method === 'update' && options.patch ? attrs : this.attributes);
-      })
-      .then(function(resp) {
+        .bind(this)
+        .then(function() {
+          return sync[options.method](method === 'update' && options.patch ? attrs : this.attributes);
+        })
+        .then(function(resp) {
 
-        // After a successful database save, the id is updated if the model was created
-        if (method === 'insert' && this.id == null) {
-          const updatedCols = {};
-          updatedCols[this.idAttribute] = this.id = resp[0];
-          const updatedAttrs = this.parse(updatedCols);
-          _.assign(this.attributes, updatedAttrs);
-        } else if (method === 'update' && resp === 0) {
-          if (options.require !== false) {
-            throw new this.constructor.NoRowsUpdatedError('No Rows Updated');
+          // After a successful database save, the id is updated if the model was created
+          if (method === 'insert' && this.id == null) {
+            const updatedCols = {};
+            updatedCols[this.idAttribute] = this.id = resp[0];
+            const updatedAttrs = this.parse(updatedCols);
+            _.assign(this.attributes, updatedAttrs);
+          } else if (method === 'update' && resp === 0) {
+            if (options.require !== false) {
+              throw new this.constructor.NoRowsUpdatedError('No Rows Updated');
+            }
           }
-        }
 
-        // In case we need to reference the `previousAttributes` for the this
-        // in the following event handlers.
-        options.previousAttributes = this._previousAttributes;
+          // In case we need to reference the `previousAttributes` for the this
+          // in the following event handlers.
+          options.previousAttributes = this._previousAttributes;
 
-        this._reset();
+          this._reset();
 
-        /**
-         * Saved event.
-         *
-         * Fired after an `insert` or `update` query.
-         *
-         * @event Model#saved
-         * @param {Model}  model    The model firing the event.
-         * @param {Object} resp     The database response.
-         * @param {Object} options  Options object passed to {@link Model#save save}.
-         * @returns {Promise}
-         */
+          /**
+           * Saved event.
+           *
+           * Fired after an `insert` or `update` query.
+           *
+           * @event Model#saved
+           * @param {Model}  model    The model firing the event.
+           * @param {Object} resp     The database response.
+           * @param {Object} options  Options object passed to {@link Model#save save}.
+           * @returns {Promise}
+           */
 
-        /**
-         * Created event.
-         *
-         * Fired after an `insert` query.
-         *
-         * @event Model#created
-         * @param {Model}  model    The model firing the event.
-         * @param {Object} attrs    Model firing the event.
-         * @param {Object} options  Options object passed to {@link Model#save save}.
-         * @returns {Promise}
-         */
+          /**
+           * Created event.
+           *
+           * Fired after an `insert` query.
+           *
+           * @event Model#created
+           * @param {Model}  model    The model firing the event.
+           * @param {Object} attrs    Model firing the event.
+           * @param {Object} options  Options object passed to {@link Model#save save}.
+           * @returns {Promise}
+           */
 
-        /**
-         * Updated event.
-         *
-         * Fired after an `update` query.
-         *
-         * @event Model#updated
-         * @param {Model}  model    The model firing the event.
-         * @param {Object} attrs    Model firing the event.
-         * @param {Object} options  Options object passed to {@link Model#save save}.
-         * @returns {Promise}
-         */
-        return this.triggerThen((method === 'insert' ? 'created saved' : 'updated saved'), this, resp, options);
-      });
+          /**
+           * Updated event.
+           *
+           * Fired after an `update` query.
+           *
+           * @event Model#updated
+           * @param {Model}  model    The model firing the event.
+           * @param {Object} attrs    Model firing the event.
+           * @param {Object} options  Options object passed to {@link Model#save save}.
+           * @returns {Promise}
+           */
+          return this.triggerThen((method === 'insert' ? 'created saved' : 'updated saved'), this, resp, options);
+        });
     })
     .return(this);
   }),

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -827,7 +827,7 @@ module.exports = function(bookshelf) {
           equal(this.get('updated_at').toISOString(), dateInThePast.toISOString());
           return stubSync;
         };
-        return m.save({item: 'test'}, { date: dateInThePast });
+        return m.save({item: 'test'}, {date: dateInThePast});
       });
 
 
@@ -908,18 +908,32 @@ module.exports = function(bookshelf) {
         return m.save({item: 'test'});
       });
 
-      it('will save a new updated_at timestamp if passed as parameter', function() {
+      it('will save a new updated_at timestamp if passed as parameter and force option is present', function() {
         var model = new Models.Admin();
         var oldUpdatedAt = null;
         var newUpdatedAt = new Date();
         newUpdatedAt.setMinutes(newUpdatedAt.getMinutes() + 1);
         return model.save().then(function(m) {
           oldUpdatedAt = m.get('updated_at');
-          return model.save('updated_at',newUpdatedAt);
+          return model.save({updated_at: newUpdatedAt}, {forceTimestamps: true});
         })
         .then(function(m) {
           expect(m.get('updated_at')).to.be.eql(newUpdatedAt);
           expect(m.get('updated_at')).to.be.not.eql(oldUpdatedAt);
+        });
+      });
+
+      it('will not save a new updated_at timestamp if passed as parameter', function() {
+        var model = new Models.Admin();
+        var oldUpdatedAt = null;
+        var newUpdatedAt = new Date();
+        newUpdatedAt.setMinutes(newUpdatedAt.getMinutes() + 1);
+        return model.save().then(function(m) {
+          oldUpdatedAt = m.get('updated_at');
+          return model.save('updated_at', newUpdatedAt);
+        })
+        .then(function(m) {
+          expect(m.get('updated_at')).to.be.not.eql(newUpdatedAt);
         });
       });
 


### PR DESCRIPTION
# Proposal: blocking `created_at` and `updated_at` from being updated.

* Related Issues : No issue in particular but was mentioned a couple times

## Introduction

This prevents model's timestamps columns to be only updated if a `forceTimestamps`
option is set to true. It brings back an old behavior which has made
developers lock on the previous version.

## Motivation

If a payload carries back the created_at or updated_at (or whichever named columns for timestamps chosen) are not updated unless that is the intent, via `forceTimestamps` option is set to `true`.

## Current PR Issues

It kind of breaks current 0.10.4 behavior, which was changed in the current version.
Some indentation was formatted, but only on the changed files.

## Alternatives considered

This is a proposal so, please, give your insights on it.