### PR TITLE
Update .npmignore to exclude non-prod files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,5 +5,9 @@ index.html
 .eslintrc
 .istanbul.yml
 .travis.yml
+.npmignore
+.babelrc
 CNAME
 CONTRIBUTING.md
+src
+scripts


### PR DESCRIPTION
# Update .npmignore to exclude non-prod files
* Related Issues : #1678

## Introduction

See #1678

## Motivation
This should reduce package size in about a half...

## Proposed solution
exclude files not required for production installations using `.gitignore`
(which was present, only did a partial job - probably just was not updated as the project grew 😉)

## Current PR Issues
none

## Alternatives considered
none
