### PR TITLE
Add info in doclet of Model#idAttribute

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -111,6 +111,11 @@ ModelBase.prototype.initialize = function() {};
  * but your database's columns in `snake_case`, for example) this refers to
  * the name returned by parse (`myId`), not the database column (`my_id`).
  *
+ * If the table you're working with does not have an Primary-Key in the form 
+ * of a single column - you'll have to override it with a getter that returns 
+ * null. (overriding with undefined does not cascade the default behavior of 
+ * the value `'id'`.
+ * Such a getter in ES6 would look like `get idAttribute() { return null }`
  */
 ModelBase.prototype.idAttribute = 'id';
 


### PR DESCRIPTION
# Add info in doclet of Model#idAttribute
## Introduction

Some tables have a Primary Key built of more than one column.
Some tables have a Primary Key built of more than one column.
Some people just add an auto-increment key to this table just to satisfy the norm, however, in big production tables it's a bad practice. Having the DB maintain such an index is useful only if it will be used for lookups. But if lookups are only done through the few columns that actually provide a unique set that effectively is the key - this PK is a hurdle that can be removed as part of DB optimization. 



## Motivation
So far, Bookshelf does not have a response for that.
However - I was proposed this solution in the IRC channel, and it seems to work, so I decided to let people know about it by adding it to the docs.

## Proposed solution

Until we support it officially, for example by letting user define his keys in an array of field names - this is the work-around I was recommended in the IRC channel.


## Current PR Issues

none 

## Alternatives considered

none 