### PR TITLE
Make postpublish work regardless of your remotes structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "cover": "npm run lint && istanbul cover _mocha -- --check-leaks -t 10000 -b -R spec test/index.js",
     "test": "npm run build && npm run lint &&  mocha --check-leaks -t 10000 -b test/index.js",
     "jsdoc": "./scripts/jsdoc.sh",
-    "gh-pages": "./scripts/gh-pages.sh",
     "prepublish": "node ./scripts/build.js lib && npm run build",
     "postpublish": "./scripts/postpublish.sh"
   },

--- a/scripts/gh-pages.sh
+++ b/scripts/gh-pages.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -e
 
 # Checkout and update gh-pages branch.
-git checkout -B gh-pages origin/gh-pages
+git checkout -B gh-pages bookshelf-source/gh-pages
 
 # Update to master.
-git pull origin master
+git pull bookshelf-source master
 
 # Regenate documentation.
 npm run jsdoc
@@ -16,4 +16,4 @@ git add --force --all index.html docs
 git commit -m "Update docs"
 
 # Push the update.
-git push origin gh-pages
+git push bookshelf-source gh-pages

--- a/scripts/postpublish.sh
+++ b/scripts/postpublish.sh
@@ -6,10 +6,13 @@ get_property() {
 
 version="$(get_property 'package.json' 'version')"
 
+git remote remove bookshelf-source
+git remote add bookshelf-source git@github.com:bookshelf/bookshelf.git
+
 git commit -am "Release $version"
 git tag $version
 
-git push origin master
-git push origin master --tags
+git push bookshelf-source master
+git push bookshelf-source master --tags
 
-npm run gh-pages
+./scripts/gh-pages


### PR DESCRIPTION
## Changelog
- Removed the npm script `gh-pages`, and run that script directly from the `postpublish.sh` script.
- Always re-create a keyword remote `bookshelf-source` for publishing operations that points to the bookshelf source repo on github. This removes confusion about `origin` (which is a fork on my machine) vs other remotes when doing publishing.