### PR TITLE
Ability to skip visibility-plugin hiding attributes

### DIFF
--- a/src/plugins/visibility.js
+++ b/src/plugins/visibility.js
@@ -30,8 +30,14 @@ module.exports = function(Bookshelf) {
 
     // Checks the `visible` and then `hidden` properties to see if there are
     // any keys we don't want to show when the object is json-ified.
+    // If a `visibility` option is present and it's set to `false`,
+    // the function won't do anything.
     toJSON: function(options) {
       let json = toJSON.apply(this, arguments);
+
+      // Skip if the `visibility` option is set to false
+      if (options && options.visibility === false) return json;
+
       const visible = (options && options.visible) || this.visible;
       if (visible) {
         json = pick(...[json].concat(visible));

--- a/test/integration/plugins/visibility.js
+++ b/test/integration/plugins/visibility.js
@@ -41,6 +41,12 @@ module.exports = function (bookshelf) {
       deepEqual(m.toJSON({hidden: hidden}), {lastName: 'Shmoe', address: '123 Main St.'});
     });
 
+    it('uses an `options.visibility` argument set to false to ignore the `options.hidden` and `options.visible` attributes', function () {
+      m.visible = ['firstName', 'lastName'];
+      m.hidden = ['lastName'];
+      deepEqual(m.toJSON({visibility: false}), {firstName: 'Joe', lastName: 'Shmoe', address: '123 Main St.'});
+    });
+
     it('uses both an `options.hidden` and `options.visible` argument and if both are set, prioritizing `firstName`', function() {
       var visible = ['firstName', 'lastName'];
       var hidden = ['lastName'];


### PR DESCRIPTION
# Ability to skip visibility-plugin hiding attributes

* Related Issues: #951 

## Introduction

Introduces a new `visibility` attribute that you can pass to `toJSON` in order to ignore the `hidden` and `visible` attributes from the visibility-plugin.

## Proposed solution

With `user.toJSON({ visibility: false })` you can ignore the `hidden` and `visible` attributes.