### PR TITLE
Add bookshelf-default-select to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ User.where('id', 1).fetch({withRelated: ['posts.tags']}).then(function(user) {
 * [bookshelf-advanced-serialization](https://github.com/sequiturs/bookshelf-advanced-serialization) - A more powerful visibility plugin, supporting serializing models and collections according to access permissions, application context, and after ensuring relations have been loaded.
 * [bookshelf-plugin-mode](https://github.com/popodidi/bookshelf-plugin-mode) - Plugin inspired by [Visibility](https://github.com/tgriesser/bookshelf/wiki/Plugin:-Visibility) plugin, providing functionality to specify different modes with corresponding visible/hidden fields of model.
 * [bookshelf-secure-password](https://github.com/venables/bookshelf-secure-password) - A plugin for easily securing passwords using bcrypt.
+* [bookshelf-default-select](https://github.com/DJAndries/bookshelf-default-select) - Enables default column selection for models. Inspired by [Visibility](https://github.com/tgriesser/bookshelf/wiki/Plugin:-Visibility), but operates on the database level.
 
 ## Support
 


### PR DESCRIPTION
## Introduction
Add link to the new bookshelf-default-select plugin, under the Community Plugins section of the README. This plugin allows a default set of columns to be defined within a model (when extending). Any fetches to the model (without the 'columns' option set) will only retrieve the specified columns.

## Motivation
Some tables may contain a large amount of columns. Some of these columns may be non-essential. In order to increase performance, and reduce wasted data, the user may want to select the essential columns whenever they are using the model.
