### PR TITLE
Add bookshelf-ez-fetch to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ User.where('id', 1).fetch({withRelated: ['posts.tags']}).then(function(user) {
 * [bookshelf-plugin-mode](https://github.com/popodidi/bookshelf-plugin-mode) - Plugin inspired by [Visibility](https://github.com/tgriesser/bookshelf/wiki/Plugin:-Visibility) plugin, providing functionality to specify different modes with corresponding visible/hidden fields of model.
 * [bookshelf-secure-password](https://github.com/venables/bookshelf-secure-password) - A plugin for easily securing passwords using bcrypt.
 * [bookshelf-default-select](https://github.com/DJAndries/bookshelf-default-select) - Enables default column selection for models. Inspired by [Visibility](https://github.com/tgriesser/bookshelf/wiki/Plugin:-Visibility), but operates on the database level.
+* [bookshelf-ez-fetch](https://github.com/DJAndries/bookshelf-ez-fetch) - Convenient fetching methods which allow for compact filtering, relation selection and error handling.
 
 ## Support
 


### PR DESCRIPTION
# Add bookshelf-ez-fetch to Community Plugins

## Introduction

Adds a link to bookshelf-ez-fetch under the Community Plugins section of the README. This plugin adds simple, compact fetching methods to the model. Features include shortcuts for various comparison operators when filtering, and relational model column selection.

## Motivation

To compact/shorten fetching code