### PR TITLE
Fix timestamps after messy 1607 PR

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -504,11 +504,11 @@ ModelBase.prototype.timestamp = function(options) {
 
   const [ createdAtKey, updatedAtKey ] = keys;
 
-  if (updatedAtKey && canEditUpdatedAtKey) {
+  if (updatedAtKey && canEditUpdatedAtKey && this.hasChanged()) {
     attributes[updatedAtKey] = now;
   }
 
-  if (createdAtKey && method === 'insert' && canEditCreatedAtKey) {
+  if (createdAtKey && (method === 'insert' || !this.get(createdAtKey) || canEditCreatedAtKey)) {
     attributes[createdAtKey] = now;
   }
 

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -863,17 +863,6 @@ module.exports = function(bookshelf) {
         return m.save({item: 'test'});
       });
 
-      it('does not set created_at when {method: "update"} is passed', function() {
-        var m = new bookshelf.Model(null, {hasTimestamps: true});
-        m.sync = function() {
-          equal(this.get('item'), 'test');
-          equal(_.isDate(this.get('created_at')), false);
-          equal(_.isDate(this.get('updated_at')), true);
-          return stubSync;
-        };
-        return m.save({item: 'test'}, {method: 'update'});
-      });
-
       it('sets created_at when {method: "insert"} is passed', function() {
         var m = new bookshelf.Model(null, {hasTimestamps: true});
         m.sync = function() {
@@ -975,7 +964,7 @@ module.exports = function(bookshelf) {
         expect(newModel.get('created_at')).to.be.an.instanceOf(Date);
         expect(newModel.get('updated_at')).to.be.an.instanceOf(Date);
 
-        expect(existingModel.get('created_at')).to.not.exist;
+        expect(existingModel.get('created_at')).to.be.an.instanceOf(Date);
         expect(existingModel.get('updated_at')).to.be.an.instanceOf(Date);
       });
 


### PR DESCRIPTION
# Fix mess with timestamps

* Previous PRs: #1607

## Introduction

Previous PR introduced a bug on both created_at and updated_at fields.

## Motivation `created_at`

Currently `created_at` field will fail on two occasions:
1. If the user supplies `canEditCreatedAtKey` as false, for new resources `created_at` would not be set at all, causing error if the field is defined as NOT NULL without default value, in the database.
2. `created_at` only set when the resource `isNew()`, hence `created_at` will never be set for models that do not use database generated primary key but something like uuid that is generated on the client side.

## Proposed solution `created_at`

`created_at` should be editable only if we have the `createdAtKey` and one of the following applies:
1. `method` is insert (for new resources)
2. The value of `createdAtKey` was not yet set. This can happen when not using database generated primary key but for example uuid that generated in the code. Settings the primary key before saving the model, causes `isNew()` to return false, hence `method` will never be `insert`.
3. `canEditCreatedAtKey` is `true`.

## Motivation `updated_at`

Currently `updated_at` is updated every time if we have the `updatedAtKey` and the user supplied `canEditUpdatedAtKey`. However this can cause an issue when trying to save a model that did not change, hence causing the `updated_at` to be updated to the current time. Since the model did not change, I believe we should not change the `updated_at` field as well.

## Proposed solution `updated_at`

Simply add the `&& this.hasChanged()` to update the `updatedAtKey` only when the model actually changes.

## Current PR Issues

No tests