### PR TITLE
Fix doc for model.has return values

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -319,7 +319,7 @@ ModelBase.prototype.escape = function(key) {
  * @description
  * Returns `true` if the attribute contains a value that is not null or undefined.
  * @param {string} attribute The attribute to check.
- * @returns {bool} True if `attribute` is set, otherwise null.
+ * @returns {bool} True if `attribute` is set, otherwise `false`.
  */
 ModelBase.prototype.has = function(attr) {
   return this.get(attr) != null;


### PR DESCRIPTION
# Fix doc for model.has return values

* Related Issues: none
* Previous PRs: none

## Introduction

`model.has(attribute)` returns `true` when the attribute is set. If the attribute is not set, the function returns `false`. The doc incorrectly states that the falsy returned value is `null`.

![otherwisenull](https://user-images.githubusercontent.com/8163408/34281788-e8732872-e675-11e7-8c4d-4401e379903f.png)

## Motivation

It is generally considered best practice in JavaScript to use === instead of == when comparing values to ensure that automatic type conversion doesn't cause unintended consequences. While using `model.has(attribute)`, I was looked specifically for the function to return `null` (per docs) if the attribute was not set:

```javascript
// if deleted_on attribute is not set
if (model.has('deleted_on') === null) {
  // set it
  model.set('deleted_on', moment(MAX_DATE).format('Y-MM-DD HH:mm:ss'));
}
```

As a result of the documentation error, I never get into the if-statement's body, because `model.has(attribute)` never returns `null`. It always returns a boolean value as a result of https://github.com/bookshelf/bookshelf/blob/fd10651d745552ccdb75b76cf9ec8a4a233b38cb/src/base/model.js#L325

## Proposed solution

My solution is to update the documentation to reflect the current state of the source code. `model.has(attribute)` always returns a boolean, which is correctly documented by this PR.

## Current PR Issues

None.

## Alternatives considered

I also considered adding to the description statement (below), but found that the change to the `Returns` section was sufficient.
https://github.com/bookshelf/bookshelf/blob/fd10651d745552ccdb75b76cf9ec8a4a233b38cb/src/base/model.js#L319-L320

If the function returns `true` when an attribute is set, users quickly infer that it will return `false` if the attribute is not set. The documentation doesn't need to repeat this information twice, once in the `Returns` section, which this PR changes, and once in the description.