### PR TITLE
Fix for issue #629

### DIFF
--- a/src/relation.js
+++ b/src/relation.js
@@ -413,7 +413,12 @@ export default RelationBase.extend({
       }
       if (groupedKey) {
         const relation = model.relations[relationName] = this.relatedInstance(grouped[groupedKey]);
-        relation.relatedData = this;
+        if(this.type === 'belongsToMany') {
+          // If type is of "belongsToMany" then the relatedData need to be recreated through the parent model
+          relation.relatedData = model[relationName]().relatedData;
+        } else {
+          relation.relatedData = this;
+        }
         if (this.isJoined()) _.extend(relation, pivotHelpers);
       }
     })


### PR DESCRIPTION
Can't attach belongsToMany relation to models fetched with fetchAll
https://github.com/bookshelf/bookshelf/issues/629

# PR name

* Related Issues: 629
* Previous PRs: N/A

## Introduction

Can't attach "belongsToMany" relation to models fetched with fetchAll. Will run to errors when the parent model access the collections of the child models and tries to detach.

## Motivation

A many to many with a pivot table is pretty common. This bug makes bookshelf useless in this scenario.

## Proposed solution

The current workaround documented in [#629](https://github.com/bookshelf/bookshelf/issues/629) is to load the child models again which is not very database friendly. The simple solution is to have the parent model recreate the the relation related data when pairing the child models with the parent models (note that before the child model fetch, a interim relation object was created and so the parent model couldn't be associated downstream of this process).

Fixes #629.

## Current PR Issues

Not sure.

## Alternatives considered

This seems like it would also affect many to many relationships.
