### PR TITLE
Add test for issue #629

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,26 +1,8 @@
 {
-  "parser": "babel-eslint",
-  "extends": "eslint:recommended",
-  "env": {
-    "es6": true,
-    "node": true
-  },
   "globals": {
     "describe": true,
     "it": true,
     "expect": true,
     "before": true
-  },
-  "ecmaFeatures": {
-    "destructuring": true,
-    "modules": true
-  },
-  "rules": {
-    "no-console": 1,
-    "no-const-assign": 2,
-    "no-unused-vars": [1, {"vars": "all", "args": "none"}],
-    "no-var": 1,
-    "prefer-const": 1,
-    "no-trailing-spaces": 1
   }
 }

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -510,6 +510,20 @@ module.exports = function(Bookshelf) {
             });
         });
 
+        it('can attach `belongsToMany` relation to models eager loaded with `fetchAll`, #629', function() {
+          return Author.fetchAll({withRelated: ['posts']}).then(function(authors) {
+            return Promise.all([
+              authors.at(0).related('posts').detach(),
+              new Post({id: 1}).fetch()
+            ]);
+          }).then(function(models) {
+            expect(models[0]).to.have.length(0);
+            return models[0].attach(models[1]);
+          }).then(function(posts) {
+            expect(posts).to.have.length(1);
+          });
+        });
+
         it('keeps the pivotal helper methods when cloning a collection having `relatedData` with `type` "belongsToMany", #1197', function() {
           var pivotalProps = ['attach', 'detach', 'updatePivot', 'withPivot', '_processPivot', '_processPlainPivot', '_processModelPivot'];
           var author = new Author({id: 1});


### PR DESCRIPTION
* Related Issues: #629
* Previous PRs: #1716

## Introduction

This adds a test for the previously incorrect behavior of `attach()` on eager loaded belongsToMany relations when the parents were fetched with `fetchAll()`.

## Motivation

The previous PR that fixed the issue didn't include any tests.

## Current PR Issues

None that I'm aware of.
