### PR TITLE
Fix incorrect documentation for detach()

### DIFF
--- a/src/relation.js
+++ b/src/relation.js
@@ -540,7 +540,7 @@ const pivotHelpers = {
    * @param {Transaction} options.transacting
    *   Optionally run the query in a transaction.
    * @returns {Promise<Collection>}
-   *   A promise resolving to the updated Collection.
+   *   A promise resolving to the updated Collection where this method was called.
    */
   attach(ids, options) {
     return Promise.try(() =>
@@ -554,9 +554,9 @@ const pivotHelpers = {
 
   /**
    * Detach one or more related objects from their pivot tables. If a model or
-   * id is passed, it attempts to remove the pivot table based on that foreign
-   * key. If no parameters are specified, we assume we will detach all related
-   * associations.
+   * id is passed, it attempts to remove from the pivot table based on that
+   * foreign key. If no parameters are specified, we assume we will detach all
+   * related associations.
    *
    * This method (along with {@link Collection#attach} and {@link
    * Collection#updatePivot}) are mixed in to a {@link Collection} when returned
@@ -570,7 +570,7 @@ const pivotHelpers = {
    * @param {Transaction} options.transacting
    *   Optionally run the query in a transaction.
    * @returns {Promise<undefined>}
-   *   A promise resolving to `undefined`.
+   *   A promise resolving to the updated Collection where this method was called.
    */
   detach(ids, options) {
     return Promise.try(() =>


### PR DESCRIPTION
* Related Issues: #1718

## Introduction

The return value is incorrectly documented as `undefined`. It should be a Collection instead.

Fixes #1718.
