### PR TITLE
Fix documentation of some events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # .travis.yml
 language: node_js
-dist: trusty
+dist: xenial
 sudo: required
 
 cache:
@@ -30,13 +30,7 @@ notifications:
   email: false
 
 env:
-  - CXX=g++-4.8 KNEX_TEST_TIMEOUT=60000 ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe ORACLE_SID=XE OCI_LIB_DIR=/u01/app/oracle/product/11.2.0/xe/lib LD_LIBRARY_PATH=/u01/app/oracle/product/11.2.0/xe/lib
+  - KNEX_TEST_TIMEOUT=60000 ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe ORACLE_SID=XE OCI_LIB_DIR=/u01/app/oracle/product/11.2.0/xe/lib LD_LIBRARY_PATH=/u01/app/oracle/product/11.2.0/xe/lib
 
 matrix:
   fast_finish: true
-
-addons:
-  apt:
-    packages:
-    - g++-4.8
-    - gcc-4.8

--- a/src/model.js
+++ b/src/model.js
@@ -1171,7 +1171,8 @@ const BookshelfModel = ModelBase.extend({
    *
    * @throws {Model.NoRowsDeletedError}
    *
-   * @returns {Promise<Model>} A promise resolving to the destroyed and thus "empty" model.
+   * @returns {Promise<Model>} A promise resolving to the destroyed and thus
+   *                           empty model, i.e. all attributes are `undefined`.
    */
   destroy: Promise.method(function(options) {
     options = options ? _.clone(options) : {};

--- a/src/model.js
+++ b/src/model.js
@@ -1022,9 +1022,10 @@ const BookshelfModel = ModelBase.extend({
        *   Attributes that will be inserted or updated.
        *
        *   **Note**: There's currently a bug that leads to attrs only
-       *   containing attributes that were passed as argument to `.save()`. You
-       *   can work around this by accessing `model.changed` which does contain
-       *   all the attributes that will be inserted or updated.
+       *   containing attributes that were passed as argument to
+       *   {@link Model#save save}. You can work around this by accessing
+       *   `model.changed` which does contain all the attributes that will be
+       *   inserted or updated.
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
        */
@@ -1042,9 +1043,10 @@ const BookshelfModel = ModelBase.extend({
        *   Attributes that will be inserted.
        *
        *   **Note**: There's currently a bug that leads to attrs only
-       *   containing attributes that were passed as argument to `.save()`. You
-       *   can work around this by accessing `model.changed` which does contain
-       *   all the attributes that will be inserted.
+       *   containing attributes that were passed as argument to
+       *   {@link Model#save save}. You can work around this by accessing
+       *   `model.changed` which does contain all the attributes that will be
+       *   inserted.
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
        */
@@ -1064,9 +1066,10 @@ const BookshelfModel = ModelBase.extend({
        *   Attributes that will be updated.
        *
        *   **Note**: There's currently a bug that leads to attrs only
-       *   containing attributes that were passed as argument to `.save()`. You
-       *   can work around this by accessing `model.changed` which does contain
-       *   all the attributes that will be updated.
+       *   containing attributes that were passed as argument to
+       *   {@link Model#save save}. You can work around this by accessing
+       *   `model.changed` which does contain all the attributes that will be
+       *   updated.
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
        */

--- a/src/model.js
+++ b/src/model.js
@@ -1188,7 +1188,7 @@ const BookshelfModel = ModelBase.extend({
        *
        * @event Model#destroying
        * @param {Model}  model    The model firing the event.
-       * @param {Object} options  Options object passed to {@link Model#save save}.
+       * @param {Object} options  Options object passed to {@link Model#destroy destroy}.
        * @returns {Promise}
        */
       return this.triggerThen('destroying', this, options);

--- a/src/model.js
+++ b/src/model.js
@@ -1018,7 +1018,13 @@ const BookshelfModel = ModelBase.extend({
        * @param {Model} model
        *   The model firing the event. Its attributes are already changed but
        *   not commited to the database yet.
-       * @param {Object} attrs    Attributes that will be inserted or updated.
+       * @param {Object} attrs
+       *   Attributes that will be inserted or updated.
+       *
+       *   **Note**: There's currently a bug that leads to attrs only
+       *   containing attributes that were passed as argument to `.save()`. You
+       *   can work around this by accessing `model.changed` which does contain
+       *   all the attributes that will be inserted or updated.
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
        */
@@ -1032,7 +1038,13 @@ const BookshelfModel = ModelBase.extend({
        *
        * @event Model#creating
        * @param {Model}  model    The model firing the event.
-       * @param {Object} attrs    Attributes that will be inserted.
+       * @param {Object} attrs
+       *   Attributes that will be inserted.
+       *
+       *   **Note**: There's currently a bug that leads to attrs only
+       *   containing attributes that were passed as argument to `.save()`. You
+       *   can work around this by accessing `model.changed` which does contain
+       *   all the attributes that will be inserted.
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
        */
@@ -1048,7 +1060,13 @@ const BookshelfModel = ModelBase.extend({
        * @param {Model}  model
        *   The model firing the event. Its attributes are already changed but
        *   not commited to the database yet.
-       * @param {Object} attrs    Attributes that will be updated.
+       * @param {Object} attrs
+       *   Attributes that will be updated.
+       *
+       *   **Note**: There's currently a bug that leads to attrs only
+       *   containing attributes that were passed as argument to `.save()`. You
+       *   can work around this by accessing `model.changed` which does contain
+       *   all the attributes that will be updated.
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
        */
@@ -1058,7 +1076,6 @@ const BookshelfModel = ModelBase.extend({
         return sync[options.method](method === 'update' && options.patch ? attrs : this.attributes);
       })
       .then(function(resp) {
-
         // After a successful database save, the id is updated if the model was created
         if (method === 'insert' && this.id == null) {
           const updatedCols = {};
@@ -1083,9 +1100,12 @@ const BookshelfModel = ModelBase.extend({
          * Fired after an `insert` or `update` query.
          *
          * @event Model#saved
-         * @param {Model}  model    The model firing the event.
-         * @param {Object} attrs    The model's attributes after calling `toJSON()` on it.
-         * @param {Object} options  Options object passed to {@link Model#save save}.
+         * @param {Model} model The model firing the event.
+         * @param {(Array|Number)} response
+         *   A list containing the id of the newly created model in case of an
+         *   `insert` or a number representing the affected rows in the case of
+         *   an `update` query.
+         * @param {Object} options Options object passed to {@link Model#save save}.
          * @returns {Promise}
          */
 
@@ -1096,7 +1116,7 @@ const BookshelfModel = ModelBase.extend({
          *
          * @event Model#created
          * @param {Model}  model    The model firing the event.
-         * @param {Object} attrs    The model's attributes after calling `toJSON()` on it.
+         * @param {Array}  newId    A list containing the id of the newly created model.
          * @param {Object} options  Options object passed to {@link Model#save save}.
          * @returns {Promise}
          */
@@ -1107,9 +1127,9 @@ const BookshelfModel = ModelBase.extend({
          * Fired after an `update` query.
          *
          * @event Model#updated
-         * @param {Model}  model    The model firing the event.
-         * @param {Object} attrs    The model's attributes after calling `toJSON()` on it.
-         * @param {Object} options  Options object passed to {@link Model#save save}.
+         * @param {Model} model The model firing the event.
+         * @param {Number} affectedRows Number of rows affected by the update.
+         * @param {Object} options Options object passed to {@link Model#save save}.
          * @returns {Promise}
          */
         return this.triggerThen((method === 'insert' ? 'created saved' : 'updated saved'), this, resp, options);
@@ -1174,8 +1194,8 @@ const BookshelfModel = ModelBase.extend({
       return this.triggerThen('destroying', this, options);
     }).then(function() {
       return sync.del();
-    }).then(function(resp) {
-      if (options.require && resp === 0) {
+  }).then(function(affectedRows) {
+      if (options.require && affectedRows === 0) {
         throw new this.constructor.NoRowsDeletedError('No Rows Deleted');
       }
       this.clear();
@@ -1187,12 +1207,12 @@ const BookshelfModel = ModelBase.extend({
        * handler for async behaviour.
        *
        * @event Model#destroyed
-       * @param {Model}  model    The model firing the event.
-       * @param {Object} attrs    Model firing the event.
-       * @param {Object} options  Options object passed to {@link Model#destroy destroy}.
+       * @param {Model}  model The model firing the event.
+       * @param {Object} affectedRows Number of affected rows.
+       * @param {Object} options Options object passed to {@link Model#destroy destroy}.
        * @returns {Promise}
        */
-      return this.triggerThen('destroyed', this, resp, options);
+      return this.triggerThen('destroyed', this, affectedRows, options);
     }).then(this._reset);
   }),
 

--- a/src/model.js
+++ b/src/model.js
@@ -1015,7 +1015,9 @@ const BookshelfModel = ModelBase.extend({
        * exception from the handler will cancel the save.
        *
        * @event Model#saving
-       * @param {Model}  model    The model firing the event.
+       * @param {Model} model
+       *   The model firing the event. Its attributes are already changed but
+       *   not commited to the database yet.
        * @param {Object} attrs    Attributes that will be inserted or updated.
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
@@ -1043,7 +1045,9 @@ const BookshelfModel = ModelBase.extend({
        * exception from the handler will cancel the save operation.
        *
        * @event Model#updating
-       * @param {Model}  model    The model firing the event.
+       * @param {Model}  model
+       *   The model firing the event. Its attributes are already changed but
+       *   not commited to the database yet.
        * @param {Object} attrs    Attributes that will be updated.
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
@@ -1080,7 +1084,7 @@ const BookshelfModel = ModelBase.extend({
          *
          * @event Model#saved
          * @param {Model}  model    The model firing the event.
-         * @param {Object} resp     The database response.
+         * @param {Object} attrs    The model's attributes after calling `toJSON()` on it.
          * @param {Object} options  Options object passed to {@link Model#save save}.
          * @returns {Promise}
          */
@@ -1092,7 +1096,7 @@ const BookshelfModel = ModelBase.extend({
          *
          * @event Model#created
          * @param {Model}  model    The model firing the event.
-         * @param {Object} attrs    Model firing the event.
+         * @param {Object} attrs    The model's attributes after calling `toJSON()` on it.
          * @param {Object} options  Options object passed to {@link Model#save save}.
          * @returns {Promise}
          */
@@ -1104,7 +1108,7 @@ const BookshelfModel = ModelBase.extend({
          *
          * @event Model#updated
          * @param {Model}  model    The model firing the event.
-         * @param {Object} attrs    Model firing the event.
+         * @param {Object} attrs    The model's attributes after calling `toJSON()` on it.
          * @param {Object} options  Options object passed to {@link Model#save save}.
          * @returns {Promise}
          */


### PR DESCRIPTION
* Related Issues: #1015
* Previous PRs: #1657 

## Introduction

Documentation for the second argument (called `attrs` up until now) of some events is completely wrong. This fixes it but those second arguments should be revised anyway to discuss if they make sense in their current form.

This change builds on the previous PR linked above, but goes a bit further so that linked PR is no longer needed.

Fixes #1015, closes #1657.

## Current PR Issues

Doesn't fix the issue of useless return values for some of these arguments.
