### PR TITLE
Disable Node 8 tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 node_js:
   - '4'
   - '6'
-  - '8'
+#  - '8' Disabled until either we fix the babel compilation error or remove babel
 
 before_install:
   - sudo apt-get update


### PR DESCRIPTION
For some unknown reason Travis is failing on Node 8 tests due to some problem with babel.

## Motivation

To get the CI service to provide any meaningful feedback.

## Proposed solution

This problem doesn't happen locally with the exact same version of Node, so this just disables the tests until they can run on Travis.

## Current PR Issues

Doesn't fix the underlying issue, just hides it.

  