### PR TITLE
Update contributing document and issue templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,52 +1,58 @@
-## How to contribute to Bookshelf.js
+# How to contribute to Bookshelf.js
 
 * Before sending a pull request for a feature or bug fix, be sure to have
 [tests](https://github.com/bookshelf/bookshelf/tree/master/test).
-
 * Use the same coding style as the rest of the
 [codebase](https://github.com/bookshelf/bookshelf/blob/master/src/bookshelf.js).
-
-* Use the [issue](https://github.com/bookshelf/bookshelf/blob/master/ISSUE-TEMPLATE.js) or [pull request](https://github.com/bookshelf/bookshelf/blob/master/PR-TEMPLATE.js) templates when creating your entry, this will help clarify the scope of your proposal or the subject of your issue.
-
-* Make changes in the /src directory, running "npm run dev" which will kick off
-transpilation from ES6 in the background.
-
+* Use the [issue](https://github.com/bookshelf/bookshelf/blob/master/ISSUE-TEMPLATE.js) or
+[pull request](https://github.com/bookshelf/bookshelf/blob/master/PR-TEMPLATE.js) templates when creating your entry,
+this will help clarify the scope of your proposal or the subject of your issue.
+* Make changes in the `/src` directory, running `npm run dev` which will kick off transpilation from ES6 in the
+background.
 * All pull requests should be made to the `master` branch.
 
-### Development Environment Setup
+## Development Environment Setup
 
-You'll need to have `git` installed obviously. Begin by forking the [main
- repository](https://github.com/bookshelf/bookshelf) and then getting the code from your forked copy:
+You'll need to have `git` installed obviously. Begin by forking the
+[main repository](https://github.com/bookshelf/bookshelf) and then getting the code from your forked copy:
 
 ```sh
-$ git clone git@github.com:yourusername/bookshelf.git
+git clone git@github.com:yourusername/bookshelf.git
 ```
 
 Afterwards go to the bookshelf directory that was just created and install the dependencies:
 
 ```sh
-$ npm install
+npm install
 ```
 
 At this point the only thing missing are the databases that will be used for running some of the tests of the automated
 test suite.
 
-There are three options for setting up this part. The first one is to use docker containers for the database servers, alternatively you can provide configuration options of the database
-servers and lastly is to use a config file in case you already have your servers configured and don't want to change
-any of their config files.
+There are three options for setting up this part:
 
-### Docker
+* The first one is to use docker containers for the database servers. This is explained below.
+* Alternatively you can provide configuration options of the database servers and set them up manually. This is also
+explained further down.
+* Last option is to use a config file in case you already have your servers configured and don't want to change any of
+their configurations.
 
-You can install [Docker](https://docs.docker.com/engine/installation/#supported-platforms) easily on any Operating System.
-After picking the correct operating system installer (via package manager or download) one just need to:
+### Using Docker Containers
 
-`docker-compose up`
+You can install [Docker](https://docs.docker.com/engine/installation/#supported-platforms) easily on any Operating
+System. After picking the correct operating system installer (via package manager or download) just run the
+following command on the root of your cloned Bookshelf repository:
 
-**Note:** admin privileges are needed, act according to your chosen Operating System.
+```sh
+docker-compose up
+```
 
-### Database Servers
+**Note:** admin privileges are needed, so you should act according to your chosen Operating System.
 
-The two sections below deal with setting up the database servers needed for running tests.
+### Manual Database Servers Setup
+
+The two sections below deal with manually setting up the database servers needed for running tests. If you prefer an
+easier alternative you can use Docker containers instead, as explained in the previous section.
 
 #### MySQL
 
@@ -54,7 +60,7 @@ You can install [MySQL](https://www.mysql.com/) easily on most linux distros by 
 this should do it:
 
 ```sh
-$ sudo apt-get install mysql-server mysql-client
+sudo apt-get install mysql-server mysql-client
 ```
 
 On OSX you can download a disk image directly from the [MySQL Downloads page](http://dev.mysql.com/downloads/mysql/), or
@@ -68,7 +74,7 @@ problems connecting as the root user with some graphical clients like `phpMyAdmi
 without needing a password use the following command:
 
 ```sh
-$ mysql -u root
+mysql -u root
 ```
 
 If you see an error like:
@@ -81,7 +87,7 @@ that means you can't login as root without a password. If you do know the root u
 password like this:
 
 ```sh
-$ mysql -u root -p
+mysql -u root -p
 ```
 
 and enter the password when asked. Then just set an empty password for root like so:
@@ -92,13 +98,16 @@ UPDATE user SET authentication_string = "" WHERE User = "root";
 FLUSH PRIVILEGES;
 QUIT;
 ```
+
 If you see an error like:
 
 ```sh
 ERROR 1054 (42S22): Unknown column 'authentication_string' in 'field list'
 ```
-It's because you are using an MySQL version older than 5.7. The `authentication_string` column has replaced the `password` column
-in this newer version. If you are using an older version just use `password` instead of `authentication_string` in the example above.
+
+It's because you are using an MySQL version older than 5.7. The `authentication_string` column has replaced the
+`password` column in this newer version. If you are using an older version just use `password` instead of
+`authentication_string` in the example above.
 
 Note that you'll probably need to set the password to `NULL` instead of an empty string in MySQL versions 5.5 and older.
 The above example should work with versions 5.7 and newer.
@@ -115,7 +124,7 @@ You can install [PostgreSQL](http://www.postgresql.org/) easily on most linux di
 With Ubuntu this should do it:
 
 ```sh
-$ sudo apt-get install postgresql postgresql-client
+sudo apt-get install postgresql postgresql-client
 ```
 
 On OSX the easiest way is probably by using [PosgresApp](http://postgresapp.com/). It should also be available to
@@ -138,7 +147,7 @@ access on clients connecting locally. Do not use this setting in a production en
 
 After editing the `pg_hba.conf` file you'll need to restart the PostgreSQL server for the changes to take effect.
 
-### Configuration File
+### Using a Configuration File
 
 If you don't want to go to the trouble of performing the changes explained in the previous two sections you can instead
 use a config file that tells the test suite about your database setup.
@@ -198,7 +207,7 @@ above for further instructions.
 Once you have done that, you can run the tests:
 
 ```sh
-$ npm test
+npm test
 ```
 
 Always make sure all the tests are passing before sending a pull request.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,26 +1,24 @@
-# Issue name
-
 * Related Issues: _#IssueNumber if necessary_
 
 ## Introduction
 
-A short description of what the features or the bugs are. Try to keep it simple and within a
-single-paragraph.
+_A short description of what the features or the bugs are. Try to keep it simple and within a single-paragraph._
 
 ## Issue Description
 
-Describe the bug found or the feature that you are proposing.
+_Describe the bug found or the feature that you are proposing._
 
-If it's completely new feature explain why this new functionality is necessary, and propose some advice for the development (or just open a Pull Request if you have already started to work on the feature on your own).
+_If it's completely new feature explain why this new functionality is necessary, and propose some advice for the
+development, or just open a Pull Request if you have already started to work on the feature on your own._
 
 ## Steps to reproduce issue
 
-If the bug is complex to describe, show how developers can reproduce it (using code snippet, database data, etc...) and describe its drawbacks.
+_If the bug is complex to describe, show how developers can reproduce it using code snippet, database data, etc..._
 
 ## Expected behaviour
 
-Explain what is the expected behaviour of a program while using the code related to this issue.
+_What is the behaviour that you were expecting after following the steps outlined above?_
 
 ## Actual behaviour
 
-Explain what is the actual behaviour of a program and what are the actual errors while running the affected code.
+_What behaviour did you get instead?_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,32 +1,26 @@
-# PR name
-
 * Related Issues: _#IssueNumber if necessary_
 * Previous PRs: _#PRNumber if this PR is a follow-up_
 
 ## Introduction
 
-A short description of what the feature or the bug-fix is. Try to keep it to a
-single-paragraph "elevator pitch" so the reader understands what
-problem this proposal is addressing.
+_A short description of what the feature or the bug-fix is. Try to keep it to a single paragraph "elevator pitch" style
+so the reader easily understands what problem this proposal is addressing._
 
 ## Motivation
 
-Describe the problems that this proposal seeks to address. If the
-problem is that some common pattern is currently hard to express, show
-how one can currently get a similar effect and describe its
-drawbacks. If it's completely new functionality that cannot be
-emulated, motivate why this new functionality is necessary.
+_Describe the problems that this proposal seeks to address and why it's important. If it's completely new functionality
+explain why this new functionality is necessary._
 
 ## Proposed solution
 
-Describe your solution to the problem. Provide examples and describe
-how they work. Show why your solution is better than current
-workarounds: is it cleaner, safer, or more efficient?
+_Describe your solution to the problem. If possible provide examples and describe how they work. Show why your solution
+is better than what's currently available: is it cleaner, safer, or more efficient?_
 
 ## Current PR Issues
 
-If present describe some issues in the Pull Request, in order to help others in the full development of the PR.
+_Are there any known issues in this Pull Request? This will help others understand if more work will be needed._
 
 ## Alternatives considered
 
-Describe alternative approaches to addressing the same problem, and why you chose this approach instead.
+_Describe any alternative approaches to addressing the same problem that you have thought about, and why you chose this
+approach instead._


### PR DESCRIPTION
* Related Issues: #1661

## Introduction

Update the contributing document to make it easier to read (hopefully). Also updates the issues templates to make them more helpful.

Closes #1661.

## Motivation

The first header in the issue templates was unnecessary and duplicated the **Title** that is already available in the GitHub issue tracker. Some parts were also a bit confusing and their purpose was unclear. Finally the tips for the different sections are sometimes left intact by users, which makes it harder to tell at first glance that the user hasn't filled in these sections.

On the contributing document the `$` was removed from the command line examples since it wasn't very obvious that it represented the command prompt and it could potentially lead someone to believe they needed to type in that character.

## Proposed solution

In the issue templates simply remove the duplicated Name, add italic font format to the tips sections so they stand out more if left intact and reword or remove text that is not clear.

In the contributing doc the changes are mainly reformatting so that it's easier to read.

## Current PR Issues

Maybe it would be interesting to also add a section explaining that the user is supposed to remove the pre-written text on the issue templates and that it's ok to remove sections that don't make sense or for which they don't have anything to say.

  