### PR TITLE
Prepare release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## Change Log
 
+**0.12.1** <small>_Jan 8, 2018_</small> - [Diff](https://github.com/bookshelf/bookshelf/compare/0.12.0...0.12.1)
+
+- Lots of documentation fixes and updates:
+  - Fix incorrect value of second argument to model event handlers: [#1723](https://github.com/bookshelf/bookshelf/pull/1723)
+  - Fix incorrect return value from `.detach()`: [#1720](https://github.com/bookshelf/bookshelf/pull/1720)
+  - Fix incorrect return value from `model.has()`: [#1712](https://github.com/bookshelf/bookshelf/pull/1712)
+  - Fix `fetching:collection` and `fetched:collection` not being generated or visible on the navigation bar: [#1114](https://github.com/bookshelf/bookshelf/pull/1114)
+  - Update contributing document and issue templates: [#1736](https://github.com/bookshelf/bookshelf/pull/1736)
+  - Add more information and links to Parse and Format docs: [#1727](https://github.com/bookshelf/bookshelf/pull/1727)
+  - Add bookshelf-ez-fetch to Community Plugins: [#1708](https://github.com/bookshelf/bookshelf/pull/1708)
+  - Add bookshelf-default-select to Community Plugins: [#1706](https://github.com/bookshelf/bookshelf/pull/1706)
+  - Add information and examples about calling `super()` on model's `initialize()`: [#1529](https://github.com/bookshelf/bookshelf/pull/1529)
+  - Add npm version badge to readme: [f4dd792](https://github.com/bookshelf/bookshelf/commit/f4dd79267ad8267a7073dd5c9f0661f6591ae96f)
+- Fix inability to attach belongsToMany relation to models fetched with `fetchAll()`: [#1716](https://github.com/bookshelf/bookshelf/pull/1716)
+- Fix foreign key = 0 not fetching related object: [#1639](https://github.com/bookshelf/bookshelf/pull/1639)
+- Fix unparsed `previousAttributes` for related models: [#1457](https://github.com/bookshelf/bookshelf/pull/1457)
+- Update some dependencies: [#1734](https://github.com/bookshelf/bookshelf/pull/1734), [#1733](https://github.com/bookshelf/bookshelf/pull/1733), [#1732](https://github.com/bookshelf/bookshelf/pull/1732), [#1728](https://github.com/bookshelf/bookshelf/pull/1728), [#1726](https://github.com/bookshelf/bookshelf/pull/1726)
+
 **0.12.0** <small>_Nov 27, 2017_</small> - [Diff](https://github.com/bookshelf/bookshelf/compare/0.11.1...0.12.0)
 
 - Skip visibility-plugin `hidden` and `visible` attributes [#1699](https://github.com/bookshelf/bookshelf/pull/1699).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A lightweight ORM for PostgreSQL, MySQL, and SQLite3",
   "main": "bookshelf.js",
   "scripts": {


### PR DESCRIPTION
**Changelog:**

- Lots of documentation fixes and updates:
  * Fix incorrect value of second argument to model event handlers: #1723
  * Fix incorrect return value from `.detach()`: #1720
  * Fix incorrect return value from `model.has()`: #1712 
  * Fix `fetching:collection` and `fetched:collection` not being generated or visible on the navigation bar: #1114
  * Update contributing document and issue templates: #1736
  * Add more information and links to Parse and Format docs: #1727 
  * Add bookshelf-ez-fetch to Community Plugins: #1708 
  * Add bookshelf-default-select to Community Plugins: #1706
  * Add information and examples about calling `super()` on model's `initialize()`: #1529 
  * Add npm version badge to readme: f4dd792
- Fix inability to attach belongsToMany relation to models fetched with `fetchAll()`: #1716 
- Fix foreign key = 0 not fetching related object: #1639 
- Fix unparsed `previousAttributes` for related models: #1457
- Update some dependencies: #1734, #1733, #1732, #1728, #1726 

[Full changelog](https://github.com/bookshelf/bookshelf/compare/0.12.0...0.12.1)