### PR TITLE
Add processor plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
     "no-console": 1,
     "no-const-assign": 2,
     "no-unused-vars": [1, {"vars": "all", "args": "none"}],
-    "no-var": 1,
+    "no-var": 0,
     "prefer-const": 1,
     "no-trailing-spaces": 1
   }

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ User.where('id', 1).fetch({withRelated: ['posts.tags']}).then(function(user) {
 * [Virtuals](https://github.com/bookshelf/bookshelf/wiki/Plugin:-Virtuals): Define virtual properties on your model to compute new values.
 * [Visibility](https://github.com/bookshelf/bookshelf/wiki/Plugin:-Visibility): Specify a whitelist/blacklist of model attributes when serialized toJSON.
 * [Pagination](https://github.com/bookshelf/bookshelf/wiki/Plugin:-Pagination): Adds `fetchPage` methods to use for pagination in place of `fetch` and `fetchAll`.
+* [Processor](https://github.com/bookshelf/bookshelf/wiki/Plugin:-Processor): Allows defining custom processor functions that handle transformation of values whenever they are `.set()` on a model.
 
 ## Community plugins
 

--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -238,9 +238,56 @@ function Bookshelf(knex) {
      * @returns {Promise<mixed>}
      */
 
-    // Provides a nice, tested, standardized way of adding plugins to a
-    // `Bookshelf` instance, injecting the current instance into the plugin,
-    // which should be a module.exports.
+    /**
+     * @method Bookshelf#plugin
+     * @memberOf Bookshelf
+     * @description
+     *
+     * This method provides a nice, tested, standardized way of adding plugins
+     * to a `Bookshelf` instance, injecting the current instance into the
+     * plugin, which should be a `module.exports`.
+     *
+     * You can add a plugin by specifying a string with the name of the plugin
+     * to load. In this case it will try to find a module. It will first check
+     * for a match within the `bookshelf/plugins` directory. If nothing is
+     * found it will pass the string to `require()`, so you can either require
+     * an npm dependency by name or one of your own modules by relative path:
+     *
+     *     bookshelf.plugin('./bookshelf-plugins/my-favourite-plugin');
+     *     bookshelf.plugin('plugin-from-npm');
+     *
+     * There are a few built-in plugins already, along with many independently
+     * developed ones. See [the list of available plugins](#plugins).
+     *
+     * You can also provide an array of strings or functions, which is the same
+     * as calling `bookshelf.plugin()` multiple times. In this case the same
+     * options object will be reused:
+     *
+     *       bookshelf.plugin(['registry', './my-plugins/special-parse-format']);
+     *
+     * Example plugin:
+     *
+     *     // Converts all string values to lower case when setting attributes on a model
+     *     module.exports = function(bookshelf) {
+     *       bookshelf.Model = bookshelf.Model.extend({
+     *         set: function(key, value, options) {
+     *           if (!key) return this;
+     *           if (typeof value === 'string') value = value.toLowerCase();
+     *           return bookshelf.Model.prototype.set.call(this, key, value, options);
+     *         }
+     *       });
+     *     }
+     *
+     * @param {string|array|Function} plugin
+     *    The plugin or plugins to add. If you provide a string it can
+     *    represent a built-in plugin, an npm package or a file somewhere on
+     *    your project. You can also pass a function as argument to add it as a
+     *    plugin. Finally, it's also possible to pass an array of strings or
+     *    functions to add them all at once.
+     * @param {mixed} options
+     *    This can be anything you want and it will be passed directly to the
+     *    plugin as the second argument when loading it.
+     */
     plugin(plugin, options) {
       if (isString(plugin)) {
         try {

--- a/src/plugins/processor.js
+++ b/src/plugins/processor.js
@@ -1,15 +1,49 @@
+/**
+ * Attribute Processor Plugin
+ *
+ * Allows defining custom processor functions that handle transformation of values whenever they are `.set()` on a model. This
+ * plugin modifies the {@link Model#set} method so that any defined processor functions get called when a value is set on a
+ * model. It also adds some methods to {@link Bookshelf} instances to handle adding and removing processors.
+ */
+
 var _ = require('lodash');
 
 module.exports = function processorPlugin(bookshelf) {
   var processors = {};
   var proto = bookshelf.Model.prototype;
 
+  /**
+   * @method Bookshelf#addProcessor
+   * @description
+   * Adds a processor to the associated Bookshelf instance. You must specify a name string and the function to add:
+   *
+   *     var bookshelf = Bookshelf(knex);
+   *     bookshelf.plugin('processor');
+   *     bookshelf.addProcessor('trim', function(string) { return string.trim(); });
+   *
+   * @param {string} name The name of the processor to add. This is how the processor will be identified.
+   * @param {function} processor The actual processor function to add.
+   * @return {undefined}
+   */
   bookshelf.addProcessor = function addProcessor(name, processor) {
     if (typeof name !== 'string' || name.length === 0) throw new Error('You must specify a processor name string');
     if (typeof processor !== 'function') throw new Error('You must specify a function to load as processor');
     processors[name] = processor;
   }
 
+  /**
+   * @method Bookshelf#removeProcessor
+   * @description
+   * Removes a previously added processor from the associated Bookshelf instance. You must specify a name string. If the name
+   * doesn't match an existing processor nothing will change and no error will be emitted.
+   *
+   *     var bookshelf = Bookshelf(knex);
+   *     bookshelf.plugin('processor');
+   *     bookshelf.removeProcessor('trim');
+   *
+   * @param {string} name The name of the processor to remove. This is the same name string that was used when adding it.
+   * @return {undefined}
+   */
   bookshelf.removeProcessor = function removeProcessor(name) {
     if (Array.isArray(name)) {
       return name.forEach(this.removeProcessor);
@@ -17,6 +51,18 @@ module.exports = function processorPlugin(bookshelf) {
     delete processors[name];
   }
 
+  /**
+   * @method Bookshelf#removeAllProcessors
+   * @description
+   * Removes all previously added processors from the associated Bookshelf instance. If there are no processors already then
+   * nothing will change and no error will be emitted.
+   *
+   *     var bookshelf = Bookshelf(knex);
+   *     bookshelf.plugin('processor');
+   *     bookshelf.removeAllProcessors();
+   *
+   * @return {undefined}
+   */
   bookshelf.removeAllProcessors = function removeAllProcessors() {
     processors = {};
   }
@@ -43,6 +89,30 @@ module.exports = function processorPlugin(bookshelf) {
       return proto.set.call(this, key, value, options);
     },
 
+    /**
+     * @method Model#processAttribute
+     * @memberof Model
+     * @description
+     * Tries to process an attribute using the associated processor or just returning the value as it is if there are no
+     * processors defined for the attribute being transformed. This method is used internally by the Processor Plugin and there
+     * is usually no reason to use it directly.
+     *
+     *     var bookshelf = Bookshelf(knex);
+     *     var MyModel = bookshelf.Model.extend({
+     *       tableName: 'my_models',
+     *       processors: {
+     *         name: 'trim'
+     *       }
+     *     });
+     *
+     *     bookshelf.plugin('processor');
+     *     var processedValue = new MyModel().processAttribute('something   ', 'name');
+     *     // processedValue === 'something'
+     *
+     * @param {mixed} value The value that is to be transformed.
+     * @param {string} key The attribute name key.
+     * @return {mixed} The transformed value.
+     */
     processAttribute: function(value, key) {
       var processes;
 

--- a/src/plugins/processor.js
+++ b/src/plugins/processor.js
@@ -1,0 +1,70 @@
+var _ = require('lodash');
+
+module.exports = function processorPlugin(bookshelf) {
+  var processors = {};
+  var proto = bookshelf.Model.prototype;
+
+  bookshelf.addProcessor = function addProcessor(name, processor) {
+    if (typeof name !== 'string' || name.length === 0) throw new Error('You must specify a processor name string');
+    if (typeof processor !== 'function') throw new Error('You must specify a function to load as processor');
+    processors[name] = processor;
+  }
+
+  bookshelf.removeProcessor = function removeProcessor(name) {
+    if (Array.isArray(name)) {
+      return name.forEach(this.removeProcessor);
+    }
+    delete processors[name];
+  }
+
+  bookshelf.removeAllProcessors = function removeAllProcessors() {
+    processors = {};
+  }
+
+  bookshelf.Model = bookshelf.Model.extend({
+    set: function(key, value, options) {
+      var processedKey;
+      var self = this;
+
+      if (!key) return this;
+
+      if (this.processors) {
+        if (typeof key === 'object') {
+          processedKey = _.transform(key, function(result, value, key) {
+            result[key] = self.processAttribute(value, key);
+          });
+
+          return proto.set.call(this, processedKey, value, options);
+        }
+
+        value = this.processAttribute(value, key);
+      }
+
+      return proto.set.call(this, key, value, options);
+    },
+
+    processAttribute: function(value, key) {
+      var processes;
+
+      if (this.processors && this.processors[key]) processes = this.processors[key];
+      if (!processes) return value;
+      if (!Array.isArray(processes)) processes = [processes];
+
+      processes.forEach(function(process) {
+        var processor;
+
+        if (typeof process === 'string') {
+          processor = processors[process];
+          if (!processor) throw new Error('Unknown processor `' + process + '`');
+        }
+        else {
+          processor = process;
+        }
+
+        value = processor(value);
+      });
+
+      return value;
+    }
+  });
+};

--- a/test/integration.js
+++ b/test/integration.js
@@ -89,6 +89,7 @@ module.exports = function(Bookshelf) {
       require('./integration/plugins/visibility')(bookshelf);
       require('./integration/plugins/registry')(bookshelf);
       require('./integration/plugins/pagination')(bookshelf);
+      require('./integration/plugins/processor')(bookshelf);
     });
 
   });

--- a/test/integration/plugins/processor.js
+++ b/test/integration/plugins/processor.js
@@ -1,0 +1,222 @@
+module.exports = function(bookshelf) {
+  describe('Processor Plugin', function () {
+    var User;
+
+    function lowerCaseProcessor(string) {
+      return string.toLowerCase();
+    }
+
+    function trimProcessor(string) {
+      return string.trim();
+    }
+
+    before(function() {
+      bookshelf.plugin('processor');
+      User = require('../helpers/objects')(bookshelf).Models.User
+    })
+
+    beforeEach(function() {
+      bookshelf.removeAllProcessors()
+    })
+
+    it('adds a Bookshelf#addProcessor() method', function() {
+      expect(bookshelf).to.respondTo('addProcessor');
+    })
+
+    it('adds a Model#processAttribute() method', function() {
+      expect(new User()).to.respondTo('processAttribute');
+    })
+
+    it('adds a Bookshelf#removeProcessor() method', function() {
+      expect(bookshelf).to.respondTo('removeProcessor');
+    })
+
+    it('adds a Model#removeAllProcessors() method', function() {
+      expect(bookshelf).to.respondTo('removeAllProcessors');
+    })
+
+    describe('Bookshelf#addProcessor()', function() {
+      it('adds a custom processor to a Bookshelf instance', function() {
+        var OtherUser = User.extend({
+          processors: {
+            username: 'lowercase'
+          }
+        });
+
+        function setUsername() {
+          new OtherUser().set('username', 'test');
+        }
+
+        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
+
+        expect(setUsername).to.not.throw();
+      })
+
+      it('throws an error if the first argument is not a string', function() {
+        function badAdd() {
+          bookshelf.addProcessor(['name']);
+        }
+
+        expect(badAdd).to.throw();
+      })
+
+      it('throws an error if the first argument is an empty string', function() {
+        function badAdd() {
+          bookshelf.addProcessor('');
+        }
+
+        expect(badAdd).to.throw();
+      })
+
+      it('throws an error if the second argument is not a function', function() {
+        function badAdd() {
+          bookshelf.addProcessor('name', 'this ain\'t right');
+        }
+
+        expect(badAdd).to.throw();
+      })
+    })
+
+    describe('Bookshelf#removeProcessor()', function() {
+      it('can remove an already added processor', function() {
+        var OtherUser = User.extend({
+          processors: {
+            username: 'lowercase'
+          }
+        });
+
+        function setUsername() {
+          new OtherUser().set('username', 'test');
+        }
+
+        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
+        expect(setUsername).to.not.throw();
+
+        bookshelf.removeProcessor('lowercase');
+        expect(setUsername).to.throw();
+      })
+
+      it('can remove a list of already added processors', function() {
+        var OtherUser = User.extend({
+          processors: {
+            username: 'lowercase'
+          }
+        });
+
+        function setUsername() {
+          new OtherUser().set('username', 'test');
+        }
+
+        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
+        expect(setUsername).to.not.throw();
+
+        bookshelf.removeProcessor(['lowercase']);
+        expect(setUsername).to.throw();
+      })
+    })
+
+    describe('Bookshelf#removeAllProcessors()', function() {
+      it('can remove all processors at once', function() {
+        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
+        bookshelf.addProcessor('trim', trimProcessor);
+
+        var OtherUser = User.extend({
+          processors: {
+            username: ['lowercase', 'trim']
+          }
+        });
+
+        function setUsername() {
+          new OtherUser().set('username', 'test');
+        }
+
+        expect(setUsername).to.not.throw();
+        bookshelf.removeAllProcessors();
+        expect(setUsername).to.throw();
+      })
+    })
+
+    describe('Model#set()', function() {
+      it('throws an error if the specified processor doesn\'t exist', function() {
+        var OtherUser = User.extend({
+          processors: {
+            username: 'nothingHere'
+          }
+        });
+
+        function setUsername() {
+          new OtherUser().set('username', 'test');
+        }
+
+        expect(setUsername).to.throw();
+      })
+
+      it('processes the set attribute with the correct processor', function() {
+        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
+
+        var OtherUser = User.extend({
+          processors: {
+            username: 'lowercase'
+          }
+        });
+        var otherUser = new OtherUser().set('username', 'TesT');
+
+        expect(otherUser.get('username')).to.match(/test/);
+      })
+
+      it('can accept an object with attributes to process', function() {
+        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
+
+        var OtherUser = User.extend({
+          processors: {
+            username: 'lowercase'
+          }
+        });
+        var otherUser = new OtherUser().set({username: 'TesT'});
+
+        expect(otherUser.get('username')).to.match(/test/);
+      })
+
+      it('can process an attribute with multiple processors', function() {
+        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
+        bookshelf.addProcessor('trim', trimProcessor);
+
+        var OtherUser = User.extend({
+          processors: {
+            username: ['lowercase', 'trim']
+          }
+        });
+        var otherUser = new OtherUser().set('username', 'TesT   ');
+
+        expect(otherUser.get('username')).to.match(/test$/);
+      })
+
+      it('doesn\'t do any processing if no processors are specified', function() {
+        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
+        bookshelf.addProcessor('trim', trimProcessor);
+
+        var OtherUser = User.extend({
+          processors: {
+            bogus: ['lowercase']
+          }
+        });
+        var otherUser = new OtherUser().set('username', 'TesT');
+
+        expect(otherUser.get('username')).to.match(/TesT/);
+      })
+
+      it('can use a custom processor function', function() {
+        var OtherUser = User.extend({
+          processors: {
+            username: function(string) {
+              return string + '_custom';
+            }
+          }
+        });
+        var otherUser = new OtherUser().set('username', 'TesT');
+
+        expect(otherUser.get('username')).to.match(/_custom$/);
+      })
+    })
+  })
+}


### PR DESCRIPTION
* Related Issues: #877, #809
* Previous PRs: #1220, #591

## Introduction

Adds Attributes Processor plugin. It allows defining custom processor functions that handle transformation of attribute values whenever they are `.set()` on a model.

It also adds documentation to the `Bookshelf#plugin()` method which was totally absent.

There is also a new wiki page for this plugin at [Plugin: Processors](/bookshelf/bookshelf/wiki/Plugin:-Processor).

## Motivation

This seems like a worthy addition and was also mentioned as part of #552. Adding it as a plugin for now like was mentioned in issue #877.

## Proposed solution

Mostly based on the code proposed by @rhys-vdw on [this comment](https://github.com/bookshelf/bookshelf/issues/877#issuecomment-132409019). The Cast Plugin proposed in the above linked PR was a bit too specific in terms of naming conventions and didn't support having pre-built processors (or *cast* functions using that plugin's nomenclature) that could be assigned to specific attributes by string name. It was otherwise functionally identical to the code proposed by @rhys-vdw. 

On the other hand, the code proposed by @rhys-vdw implied having some processors already in Bookshelf, but that seemed like an unnecessary inclusion. These processors are probably specific to the user's application and can be converted to standalone npm packages or community plugins if needed with the present solution.

The solution proposed in #1220 may seem different from this at first glance, but it's actually trying to achieve the same thing. The problem with that solution is that it's too complicated since it tries to attach the functionality to the Virtuals plugin which means it had to come up with workarounds for things like the possibility of infinite recursion.

Fixes #809.
Closes #1220.
Closes #591.
Ticks the box for missing documentation of `Bookshelf#plugin` on #800.

## Alternatives considered

Considered merging PR #591, but it was a little bit too specific about casting values, and didn't include as much documentation as the current PR.

## Current PR Issues

There are several ways of adding processors right now. Maybe the `[add|remove]Processor` methods aren't that necessary since it's still possible to reuse code if users just keep them in a separate module and `require()` it as necessary in models. This also implies that the ability to assign attribute processors by string name would become irrelevant as well. One could just do:

```js
// In a model file
var myProcessors = require('./lib/processors') // or require('some-npm-package')
var MyModel = bookshelf.Model.extend({
  tableName: 'stuff'
  processors: {
    username: myProcessors.trim
  }
})
```

This PR also adds a new Wiki page instead of moving the plugin wikis to JSDoc.