### PR TITLE
Remove OracleDB tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ services:
 
 node_js:
   - '4'
+  - '5'
   - '6'
+  - '7'
 #  - '8' Disabled until either we fix the babel compilation error or remove babel
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # .travis.yml
 language: node_js
 dist: xenial
-sudo: required
+sudo: false
 
 cache:
   directories:
@@ -16,12 +16,6 @@ node_js:
   - '6'
 #  - '8' Disabled until either we fix the babel compilation error or remove babel
 
-before_install:
-  - sudo apt-get update
-  - wget https://raw.githubusercontent.com/Vincit/travis-oracledb-xe/master/accept_the_license_agreement_for_oracledb_xe_11g_and_install.sh
-  - bash ./accept_the_license_agreement_for_oracledb_xe_11g_and_install.sh
-  - npm install oracledb
-
 before_script:
   - psql -c 'create database bookshelf_test;' -U postgres
   - mysql -e 'create database bookshelf_test;'
@@ -30,7 +24,7 @@ notifications:
   email: false
 
 env:
-  - KNEX_TEST_TIMEOUT=60000 ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe ORACLE_SID=XE OCI_LIB_DIR=/u01/app/oracle/product/11.2.0/xe/lib LD_LIBRARY_PATH=/u01/app/oracle/product/11.2.0/xe/lib
+  - KNEX_TEST_TIMEOUT=60000
 
 matrix:
   fast_finish: true

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,7 +1,6 @@
 var _        = require('lodash');
 
 module.exports = function(Bookshelf) {
-
   var Knex     = require('knex');
   var config   = require(process.env.BOOKSHELF_TEST || './integration/helpers/config');
   var Promise  = global.testPromise;
@@ -26,16 +25,7 @@ module.exports = function(Bookshelf) {
   var SQLite3 = require('../bookshelf')(sqlite3);
   var Swapped = require('../bookshelf')(Knex({client: 'sqlite3', useNullAsDefault: true}));
   Swapped.knex = sqlite3;
-  var databasesArray = [SQLite3, Swapped, MySQL, PostgreSQL];
-  // Load OracleDB tests only if the module is present in the system
-  try{
-    var oracleDbModuleName = require.resolve('oracledb');
-    var oracledb = require('knex')({client: 'oracledb', connection: config.oracledb});
-    var OracleDB = require('../bookshelf')(oracledb);
-    databasesArray.push(OracleDB);
-  }catch(e){
-    // empty
-  }
+  var databases = [SQLite3, Swapped, MySQL, PostgreSQL];
 
   it('should allow creating a new Bookshelf instance with "new"', function() {
     var bookshelf = new Bookshelf(sqlite3);
@@ -59,12 +49,10 @@ module.exports = function(Bookshelf) {
     });
   });
 
-  _.each(databasesArray, function(bookshelf) {
-
+  _.each(databases, function(bookshelf) {
     var dialect = bookshelf.knex.client.dialect;
 
     describe('Dialect: ' + dialect, function() {
-
       this.dialect = dialect;
 
       before(function() {
@@ -91,8 +79,7 @@ module.exports = function(Bookshelf) {
       require('./integration/plugins/pagination')(bookshelf);
       require('./integration/plugins/processor')(bookshelf);
     });
-
   });
 
-  return databasesArray;
+  return databases;
 };

--- a/test/integration/collection.js
+++ b/test/integration/collection.js
@@ -13,12 +13,7 @@ module.exports = function(bookshelf) {
     var json    = function(model) {
       return JSON.parse(JSON.stringify(model));
     };
-    var formatNumber = {
-      mysql:      _.identity,
-      sqlite3:    _.identity,
-      oracle:     _.identity,
-      postgresql: function(count) { return count.toString() }
-    }[dialect];
+    var formatNumber = require('./helpers').formatNumber(dialect);
     var checkCount = function(actual, expected) {
       expect(actual).to.equal(formatNumber(expected));
     };

--- a/test/integration/helpers/config.js
+++ b/test/integration/helpers/config.js
@@ -1,5 +1,4 @@
 module.exports = {
-
   mysql: {
     database: 'bookshelf_test',
     user: 'root',
@@ -13,14 +12,5 @@ module.exports = {
 
   sqlite3: {
     filename: ':memory:'
-  },
-
-  oracledb: {
-    user          : "travis",
-    password      : "travis",
-    connectString : "localhost/XE",
-    // https://github.com/oracle/node-oracledb/issues/525
-    stmtCacheSize : 0
   }
-
 };

--- a/test/integration/helpers/index.js
+++ b/test/integration/helpers/index.js
@@ -1,0 +1,9 @@
+var _ = require('lodash');
+
+exports.formatNumber = function(dialect) {
+  return {
+    mysql: _.identity,
+    sqlite3: _.identity,
+    postgresql: function(count) { return count.toString() }
+  }[dialect];
+}

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -9,9 +9,7 @@ var deepEqual = require('assert').deepEqual;
 var QueryBuilder = require('knex/lib/query/builder')
 
 module.exports = function(bookshelf) {
-
   describe('Model', function() {
-
     var Models    = require('./helpers/objects')(bookshelf).Models;
 
     var stubSync = {
@@ -23,12 +21,7 @@ module.exports = function(bookshelf) {
     };
 
     var dialect = bookshelf.knex.client.dialect;
-    var formatNumber = {
-      mysql:      _.identity,
-      sqlite3:    _.identity,
-      oracle:     _.identity,
-      postgresql: function(count) { return count.toString() }
-    }[dialect];
+    var formatNumber = require('./helpers').formatNumber(dialect);
     var checkCount = function(actual, expected) {
       expect(actual, formatNumber(expected));
     };

--- a/test/integration/output/Collection.js
+++ b/test/integration/output/Collection.js
@@ -98,39 +98,6 @@ module.exports = {
         name: 'This is a new Title 5!',
         content: 'Lorem ipsum Commodo consectetur eu ea amet laborum nulla eiusmod minim veniam ullamco nostrud sed mollit consectetur veniam mollit Excepteur quis cupidatat.'
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        owner_id: 1,
-        blog_id: 1,
-        name: 'This is a new Title!',
-        content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.'
-      },{
-        id: 2,
-        owner_id: 2,
-        blog_id: 2,
-        name: 'This is a new Title 2!',
-        content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.'
-      },{
-        id: 3,
-        owner_id: 2,
-        blog_id: 1,
-        name: 'This is a new Title 3!',
-        content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
-      },{
-        id: 4,
-        owner_id: 3,
-        blog_id: 3,
-        name: 'This is a new Title 4!',
-        content: 'Lorem ipsum Anim sed eu sint aute.'
-      },{
-        id: 5,
-        owner_id: 4,
-        blog_id: 4,
-        name: 'This is a new Title 5!',
-        content: 'Lorem ipsum Commodo consectetur eu ea amet laborum nulla eiusmod minim veniam ullamco nostrud sed mollit consectetur veniam mollit Excepteur quis cupidatat.'
-      }]
     }
   }
 };

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -17,12 +17,6 @@ module.exports = {
         id: 2,
         name: 'bookshelfjs.org'
       }
-    },
-    oracle: {
-      result: {
-        id: 2,
-        name: 'bookshelfjs.org'
-      }
     }
   },
   'handles hasMany (posts)': {
@@ -70,21 +64,6 @@ module.exports = {
         name: 'This is a new Title 3!',
         content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        owner_id: 1,
-        blog_id: 1,
-        name: 'This is a new Title!',
-        content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.'
-      },{
-        id: 3,
-        owner_id: 2,
-        blog_id: 1,
-        name: 'This is a new Title 3!',
-        content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
-      }]
     }
   },
   'handles hasOne (meta)': {
@@ -103,13 +82,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        site_id: 1,
-        description: 'This is a description for the Knexjs Site'
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         site_id: 1,
@@ -150,17 +122,6 @@ module.exports = {
         _pivot_author_id: 1,
         _pivot_post_id: 1
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        owner_id: 1,
-        blog_id: 1,
-        name: 'This is a new Title!',
-        content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.',
-        _pivot_author_id: 1,
-        _pivot_post_id: 1
-      }]
     }
   },
   'eager loads "hasOne" relationships correctly (site -> meta)': {
@@ -187,17 +148,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        name: 'knexjs.org',
-        meta: {
-          id: 1,
-          site_id: 1,
-          description: 'This is a description for the Knexjs Site'
-        }
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org',
@@ -287,32 +237,6 @@ module.exports = {
           name: 'Alternate Site Blog'
         }]
       }
-    },
-    oracle: {
-      result: {
-        id: 1,
-        name: 'knexjs.org',
-        authors: [{
-          id: 1,
-          site_id: 1,
-          first_name: 'Tim',
-          last_name: 'Griesser'
-        },{
-          id: 2,
-          site_id: 1,
-          first_name: 'Bazooka',
-          last_name: 'Joe'
-        }],
-        blogs: [{
-          id: 1,
-          site_id: 1,
-          name: 'Main Site Blog'
-        },{
-          id: 2,
-          site_id: 1,
-          name: 'Alternate Site Blog'
-        }]
-      }
     }
   },
   'eager loads "belongsTo" relationships correctly (blog -> site)': {
@@ -348,17 +272,6 @@ module.exports = {
           name: 'bookshelfjs.org'
         }
       }
-    },
-    oracle: {
-      result: {
-        id: 3,
-        site_id: 2,
-        name: 'Main Site Blog',
-        site: {
-          id: 2,
-          name: 'bookshelfjs.org'
-        }
-      }
     }
   },
   'does not load "belongsTo" relationship when foreignKey is null (blog -> site) #1299': {
@@ -377,13 +290,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 5,
-        site_id: null,
-        name: 'Orphan Blog Without a Site'
-      }
-    },
-    oracle: {
       result: {
         id: 5,
         site_id: null,
@@ -466,31 +372,6 @@ module.exports = {
           _pivot_tag_id: 3
         }]
       }
-    },
-    oracle: {
-      result: {
-        id: 1,
-        owner_id: 1,
-        blog_id: 1,
-        name: 'This is a new Title!',
-        content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.',
-        tags: [{
-          id: 1,
-          name: 'cool',
-          _pivot_post_id: 1,
-          _pivot_tag_id: 1
-        },{
-          id: 2,
-          name: 'boring',
-          _pivot_post_id: 1,
-          _pivot_tag_id: 2
-        },{
-          id: 3,
-          name: 'exciting',
-          _pivot_post_id: 1,
-          _pivot_tag_id: 3
-        }]
-      }
     }
   },
   'Attaches an empty related model or collection if the `EagerRelation` comes back blank': {
@@ -517,17 +398,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 3,
-        name: 'backbonejs.org',
-        meta: {
-
-        },
-        blogs: [],
-        authors: []
-      }
-    },
-    oracle: {
       result: {
         id: 3,
         name: 'backbonejs.org',
@@ -571,21 +441,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        name: 'knexjs.org',
-        authors: [{
-          id: 1,
-          site_id: 1,
-          first_name: 'Tim'
-        },{
-          id: 2,
-          site_id: 1,
-          first_name: 'Bazooka'
-        }]
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org',
@@ -653,31 +508,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        id: 1,
-        name: 'knexjs.org',
-        meta: {
-          id: 1,
-          site_id: 1,
-          description: 'This is a description for the Knexjs Site'
-        }
-      },{
-        id: 2,
-        name: 'bookshelfjs.org',
-        meta: {
-          id: 2,
-          site_id: 2,
-          description: 'This is a description for the Bookshelfjs Site'
-        }
-      },{
-        id: 3,
-        name: 'backbonejs.org',
-        meta: {
-
-        }
-      }]
-    },
-    oracle: {
       result: [{
         id: 1,
         name: 'knexjs.org',
@@ -820,45 +650,6 @@ module.exports = {
         site_id: null,
         name: 'Orphan Blog Without a Site'
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        site_id: 1,
-        name: 'Main Site Blog',
-        site: {
-          id: 1,
-          name: 'knexjs.org'
-        }
-      },{
-        id: 2,
-        site_id: 1,
-        name: 'Alternate Site Blog',
-        site: {
-          id: 1,
-          name: 'knexjs.org'
-        }
-      },{
-        id: 3,
-        site_id: 2,
-        name: 'Main Site Blog',
-        site: {
-          id: 2,
-          name: 'bookshelfjs.org'
-        }
-      },{
-        id: 4,
-        site_id: 2,
-        name: 'Alternate Site Blog',
-        site: {
-          id: 2,
-          name: 'bookshelfjs.org'
-        }
-      },{
-        id: 5,
-        site_id: null,
-        name: 'Orphan Blog Without a Site'
-      }]
     }
   },
   'eager loads "hasMany" models correctly (site -> blogs)': {
@@ -893,21 +684,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        name: 'knexjs.org',
-        blogs: [{
-          id: 1,
-          site_id: 1,
-          name: 'Main Site Blog'
-        },{
-          id: 2,
-          site_id: 1,
-          name: 'Alternate Site Blog'
-        }]
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org',
@@ -989,38 +765,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        id: 1,
-        owner_id: 1,
-        blog_id: 1,
-        name: 'This is a new Title!',
-        content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.',
-        tags: [{
-          id: 1,
-          name: 'cool',
-          _pivot_post_id: 1,
-          _pivot_tag_id: 1
-        },{
-          id: 2,
-          name: 'boring',
-          _pivot_post_id: 1,
-          _pivot_tag_id: 2
-        },{
-          id: 3,
-          name: 'exciting',
-          _pivot_post_id: 1,
-          _pivot_tag_id: 3
-        }]
-      },{
-        id: 3,
-        owner_id: 2,
-        blog_id: 1,
-        name: 'This is a new Title 3!',
-        content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.',
-        tags: []
-      }]
-    },
-    oracle: {
       result: [{
         id: 1,
         owner_id: 1,
@@ -1164,43 +908,6 @@ module.exports = {
           }]
         }]
       }
-    },
-    oracle: {
-      result: {
-        id: 1,
-        name: 'knexjs.org',
-        authors: [{
-          id: 1,
-          site_id: 1,
-          first_name: 'Tim',
-          last_name: 'Griesser',
-          ownPosts: [{
-            id: 1,
-            owner_id: 1,
-            blog_id: 1,
-            name: 'This is a new Title!',
-            content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.'
-          }]
-        },{
-          id: 2,
-          site_id: 1,
-          first_name: 'Bazooka',
-          last_name: 'Joe',
-          ownPosts: [{
-            id: 2,
-            owner_id: 2,
-            blog_id: 2,
-            name: 'This is a new Title 2!',
-            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.'
-          },{
-            id: 3,
-            owner_id: 2,
-            blog_id: 1,
-            name: 'This is a new Title 3!',
-            content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
-          }]
-        }]
-      }
     }
   },
   'eager loads "hasMany" -> "belongsToMany" (site -> authors.posts)': {
@@ -1291,49 +998,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        name: 'knexjs.org',
-        authors: [{
-          id: 1,
-          site_id: 1,
-          first_name: 'Tim',
-          last_name: 'Griesser',
-          posts: [{
-            id: 1,
-            owner_id: 1,
-            blog_id: 1,
-            name: 'This is a new Title!',
-            content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.',
-            _pivot_author_id: 1,
-            _pivot_post_id: 1
-          }]
-        },{
-          id: 2,
-          site_id: 1,
-          first_name: 'Bazooka',
-          last_name: 'Joe',
-          posts: [{
-            id: 1,
-            owner_id: 1,
-            blog_id: 1,
-            name: 'This is a new Title!',
-            content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.',
-            _pivot_author_id: 2,
-            _pivot_post_id: 1
-          },{
-            id: 2,
-            owner_id: 2,
-            blog_id: 2,
-            name: 'This is a new Title 2!',
-            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.',
-            _pivot_author_id: 2,
-            _pivot_post_id: 2
-          }]
-        }]
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org',
@@ -1527,80 +1191,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        name: 'knexjs.org',
-        authors: [{
-          id: 1,
-          site_id: 1,
-          first_name: 'Tim',
-          last_name: 'Griesser',
-          ownPosts: [{
-            id: 1,
-            owner_id: 1,
-            blog_id: 1,
-            name: 'This is a new Title!',
-            content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.'
-          }],
-          site: {
-            id: 1,
-            name: 'knexjs.org'
-          }
-        },{
-          id: 2,
-          site_id: 1,
-          first_name: 'Bazooka',
-          last_name: 'Joe',
-          ownPosts: [{
-            id: 2,
-            owner_id: 2,
-            blog_id: 2,
-            name: 'This is a new Title 2!',
-            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.'
-          },{
-            id: 3,
-            owner_id: 2,
-            blog_id: 1,
-            name: 'This is a new Title 3!',
-            content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
-          }],
-          site: {
-            id: 1,
-            name: 'knexjs.org'
-          }
-        }],
-        blogs: [{
-          id: 1,
-          site_id: 1,
-          name: 'Main Site Blog',
-          posts: [{
-            id: 1,
-            owner_id: 1,
-            blog_id: 1,
-            name: 'This is a new Title!',
-            content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.'
-          },{
-            id: 3,
-            owner_id: 2,
-            blog_id: 1,
-            name: 'This is a new Title 3!',
-            content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
-          }]
-        },{
-          id: 2,
-          site_id: 1,
-          name: 'Alternate Site Blog',
-          posts: [{
-            id: 2,
-            owner_id: 2,
-            blog_id: 2,
-            name: 'This is a new Title 2!',
-            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.'
-          }]
-        }]
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org',
@@ -1882,75 +1472,6 @@ module.exports = {
         name: 'backbonejs.org',
         authors: []
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        name: 'knexjs.org',
-        authors: [{
-          id: 1,
-          site_id: 1,
-          first_name: 'Tim',
-          last_name: 'Griesser',
-          ownPosts: [{
-            id: 1,
-            owner_id: 1,
-            blog_id: 1,
-            name: 'This is a new Title!',
-            content: 'Lorem ipsum Labore eu sed sed Excepteur enim laboris deserunt adipisicing dolore culpa aliqua cupidatat proident ea et commodo labore est adipisicing ex amet exercitation est.'
-          }]
-        },{
-          id: 2,
-          site_id: 1,
-          first_name: 'Bazooka',
-          last_name: 'Joe',
-          ownPosts: [{
-            id: 2,
-            owner_id: 2,
-            blog_id: 2,
-            name: 'This is a new Title 2!',
-            content: 'Lorem ipsum Veniam ex amet occaecat dolore in pariatur minim est exercitation deserunt Excepteur enim officia occaecat in exercitation aute et ad esse ex in in dolore amet consequat quis sed mollit et id incididunt sint dolore velit officia dolor dolore laboris dolor Duis ea ex quis deserunt anim nisi qui culpa laboris nostrud Duis anim deserunt esse laboris nulla qui in dolor voluptate aute reprehenderit amet ut et non voluptate elit irure mollit dolor consectetur nisi adipisicing commodo et mollit dolore incididunt cupidatat nulla ut irure deserunt non officia laboris fugiat ut pariatur ut non aliqua eiusmod dolor et nostrud minim elit occaecat commodo consectetur cillum elit laboris mollit dolore amet id qui eiusmod nulla elit eiusmod est ad aliqua aute enim ut aliquip ex in Ut nisi sint exercitation est mollit veniam cupidatat adipisicing occaecat dolor irure in aute aliqua ullamco.'
-          },{
-            id: 3,
-            owner_id: 2,
-            blog_id: 1,
-            name: 'This is a new Title 3!',
-            content: 'Lorem ipsum Reprehenderit esse esse consectetur aliquip magna.'
-          }]
-        }]
-      },{
-        id: 2,
-        name: 'bookshelfjs.org',
-        authors: [{
-          id: 3,
-          site_id: 2,
-          first_name: 'Charlie',
-          last_name: 'Brown',
-          ownPosts: [{
-            id: 4,
-            owner_id: 3,
-            blog_id: 3,
-            name: 'This is a new Title 4!',
-            content: 'Lorem ipsum Anim sed eu sint aute.'
-          }]
-        },{
-          id: 4,
-          site_id: 2,
-          first_name: 'Ron',
-          last_name: 'Burgundy',
-          ownPosts: [{
-            id: 5,
-            owner_id: 4,
-            blog_id: 4,
-            name: 'This is a new Title 5!',
-            content: 'Lorem ipsum Commodo consectetur eu ea amet laborum nulla eiusmod minim veniam ullamco nostrud sed mollit consectetur veniam mollit Excepteur quis cupidatat.'
-          }]
-        }]
-      },{
-        id: 3,
-        name: 'backbonejs.org',
-        authors: []
-      }]
     }
   },
   'eager loads relations on a populated model (site -> blogs, authors.site)': {
@@ -1967,12 +1488,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        name: 'knexjs.org'
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org'
@@ -2015,18 +1530,6 @@ module.exports = {
         id: 3,
         name: 'backbonejs.org'
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        name: 'knexjs.org'
-      },{
-        id: 2,
-        name: 'bookshelfjs.org'
-      },{
-        id: 3,
-        name: 'backbonejs.org'
-      }]
     }
   },
   'works with many-to-many (user -> roles)': {
@@ -2047,14 +1550,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        rid: 4,
-        name: 'admin',
-        _pivot_uid: 1,
-        _pivot_rid: 4
-      }]
-    },
-    oracle: {
       result: [{
         rid: 4,
         name: 'admin',
@@ -2099,18 +1594,6 @@ module.exports = {
           _pivot_rid: 4
         }]
       }
-    },
-    oracle: {
-      result: {
-        uid: 1,
-        username: 'root',
-        roles: [{
-          rid: 4,
-          name: 'admin',
-          _pivot_uid: 1,
-          _pivot_rid: 4
-        }]
-      }
     }
   },
   'handles morphOne (photo)': {
@@ -2133,15 +1616,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 1,
-        imageable_type: 'profile_pic'
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         url: 'https://www.google.com/images/srpr/logo4w.png',
@@ -2196,21 +1670,6 @@ module.exports = {
         imageable_id: 1,
         imageable_type: 'sites'
       }]
-    },
-    oracle: {
-      result: [{
-        id: 3,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 1,
-        imageable_type: 'sites'
-      },{
-        id: 4,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 1,
-        imageable_type: 'sites'
-      }]
     }
   },
   'handles morphTo with custom morphValue (imageable "authors")': {
@@ -2237,14 +1696,6 @@ module.exports = {
         first_name: 'Tim',
         last_name: 'Griesser'
       }
-    },
-    oracle: {
-      result: {
-        id: 1,
-        site_id: 1,
-        first_name: 'Tim',
-        last_name: 'Griesser'
-      }
     }
   },
   'handles morphTo (imageble "authors", PhotoParsed)': {
@@ -2265,14 +1716,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id_parsed: 1,
-        site_id_parsed: 1,
-        first_name_parsed: 'Tim',
-        last_name_parsed: 'Griesser'
-      }
-    },
-    oracle: {
       result: {
         id_parsed: 1,
         site_id_parsed: 1,
@@ -2308,15 +1751,6 @@ module.exports = {
         url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
         caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.'
       }
-    },
-    oracle: {
-      result: {
-        imageable_id_parsed: 1,
-        imageable_type_parsed: 'profile_pic',
-        id_parsed: 1,
-        url_parsed: 'https://www.google.com/images/srpr/logo4w.png',
-        caption_parsed: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.'
-      }
     }
   },
   'handles morphTo (imageable "sites")': {
@@ -2333,12 +1767,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        name: 'knexjs.org'
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org'
@@ -2425,45 +1853,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        id: 1,
-        name: 'knexjs.org',
-        photos: [{
-          id: 3,
-          url: 'https://www.google.com/images/srpr/logo4w.png',
-          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-          imageable_id: 1,
-          imageable_type: 'sites'
-        },{
-          id: 4,
-          url: 'https://www.google.com/images/srpr/logo4w.png',
-          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-          imageable_id: 1,
-          imageable_type: 'sites'
-        }]
-      },{
-        id: 2,
-        name: 'bookshelfjs.org',
-        photos: [{
-          id: 5,
-          url: 'https://www.google.com/images/srpr/logo4w.png',
-          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-          imageable_id: 2,
-          imageable_type: 'sites'
-        },{
-          id: 6,
-          url: 'https://www.google.com/images/srpr/logo4w.png',
-          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-          imageable_id: 2,
-          imageable_type: 'sites'
-        }]
-      },{
-        id: 3,
-        name: 'backbonejs.org',
-        photos: []
-      }]
-    },
-    oracle: {
       result: [{
         id: 1,
         name: 'knexjs.org',
@@ -2657,82 +2046,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        id: 1,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 1,
-        imageable_type: 'profile_pic',
-        imageable: {
-          id: 1,
-          site_id: 1,
-          first_name: 'Tim',
-          last_name: 'Griesser'
-        }
-      },{
-        id: 2,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 2,
-        imageable_type: 'profile_pic',
-        imageable: {
-          id: 2,
-          site_id: 1,
-          first_name: 'Bazooka',
-          last_name: 'Joe'
-        }
-      },{
-        id: 3,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 1,
-        imageable_type: 'sites',
-        imageable: {
-          id: 1,
-          name: 'knexjs.org'
-        }
-      },{
-        id: 4,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 1,
-        imageable_type: 'sites',
-        imageable: {
-          id: 1,
-          name: 'knexjs.org'
-        }
-      },{
-        id: 5,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 2,
-        imageable_type: 'sites',
-        imageable: {
-          id: 2,
-          name: 'bookshelfjs.org'
-        }
-      },{
-        id: 6,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 2,
-        imageable_type: 'sites',
-        imageable: {
-          id: 2,
-          name: 'bookshelfjs.org'
-        }
-      },{
-        id: 7,
-        url: 'http://image.dev',
-        caption: 'this is a test image',
-        imageable_id: 10,
-        imageable_type: 'sites',
-        imageable: {
-
-        }
-      }]
-    },
-    oracle: {
       result: [{
         id: 1,
         url: 'https://www.google.com/images/srpr/logo4w.png',
@@ -3169,126 +2482,6 @@ module.exports = {
 
         }
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 1,
-        imageable_type: 'profile_pic',
-        imageable: {
-          id: 1,
-          site_id: 1,
-          first_name: 'Tim',
-          last_name: 'Griesser'
-        }
-      },{
-        id: 2,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 2,
-        imageable_type: 'profile_pic',
-        imageable: {
-          id: 2,
-          site_id: 1,
-          first_name: 'Bazooka',
-          last_name: 'Joe'
-        }
-      },{
-        id: 3,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 1,
-        imageable_type: 'sites',
-        imageable: {
-          id: 1,
-          name: 'knexjs.org',
-          authors: [{
-            id: 1,
-            site_id: 1,
-            first_name: 'Tim',
-            last_name: 'Griesser'
-          },{
-            id: 2,
-            site_id: 1,
-            first_name: 'Bazooka',
-            last_name: 'Joe'
-          }]
-        }
-      },{
-        id: 4,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 1,
-        imageable_type: 'sites',
-        imageable: {
-          id: 1,
-          name: 'knexjs.org',
-          authors: [{
-            id: 1,
-            site_id: 1,
-            first_name: 'Tim',
-            last_name: 'Griesser'
-          },{
-            id: 2,
-            site_id: 1,
-            first_name: 'Bazooka',
-            last_name: 'Joe'
-          }]
-        }
-      },{
-        id: 5,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 2,
-        imageable_type: 'sites',
-        imageable: {
-          id: 2,
-          name: 'bookshelfjs.org',
-          authors: [{
-            id: 3,
-            site_id: 2,
-            first_name: 'Charlie',
-            last_name: 'Brown'
-          },{
-            id: 4,
-            site_id: 2,
-            first_name: 'Ron',
-            last_name: 'Burgundy'
-          }]
-        }
-      },{
-        id: 6,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 2,
-        imageable_type: 'sites',
-        imageable: {
-          id: 2,
-          name: 'bookshelfjs.org',
-          authors: [{
-            id: 3,
-            site_id: 2,
-            first_name: 'Charlie',
-            last_name: 'Brown'
-          },{
-            id: 4,
-            site_id: 2,
-            first_name: 'Ron',
-            last_name: 'Burgundy'
-          }]
-        }
-      },{
-        id: 7,
-        url: 'http://image.dev',
-        caption: 'this is a test image',
-        imageable_id: 10,
-        imageable_type: 'sites',
-        imageable: {
-
-        }
-      }]
     }
   },
   'handles morphOne with custom columnNames (thumbnail)': {
@@ -3311,15 +2504,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 1,
-        ImageableType: 'authors'
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         url: 'https://www.google.com/images/srpr/logo4w.png',
@@ -3374,21 +2558,6 @@ module.exports = {
         ImageableId: 1,
         ImageableType: 'sites'
       }]
-    },
-    oracle: {
-      result: [{
-        id: 3,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 1,
-        ImageableType: 'sites'
-      },{
-        id: 4,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 1,
-        ImageableType: 'sites'
-      }]
     }
   },
   'handles morphTo with custom columnNames (imageable "authors")': {
@@ -3415,14 +2584,6 @@ module.exports = {
         first_name: 'Tim',
         last_name: 'Griesser'
       }
-    },
-    oracle: {
-      result: {
-        id: 1,
-        site_id: 1,
-        first_name: 'Tim',
-        last_name: 'Griesser'
-      }
     }
   },
   'handles morphTo with custom columnNames (imageable "sites")': {
@@ -3439,12 +2600,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        name: 'knexjs.org'
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         name: 'knexjs.org'
@@ -3531,45 +2686,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        id: 1,
-        name: 'knexjs.org',
-        thumbnails: [{
-          id: 3,
-          url: 'https://www.google.com/images/srpr/logo4w.png',
-          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-          ImageableId: 1,
-          ImageableType: 'sites'
-        },{
-          id: 4,
-          url: 'https://www.google.com/images/srpr/logo4w.png',
-          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-          ImageableId: 1,
-          ImageableType: 'sites'
-        }]
-      },{
-        id: 2,
-        name: 'bookshelfjs.org',
-        thumbnails: [{
-          id: 5,
-          url: 'https://www.google.com/images/srpr/logo4w.png',
-          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-          ImageableId: 2,
-          ImageableType: 'sites'
-        },{
-          id: 6,
-          url: 'https://www.google.com/images/srpr/logo4w.png',
-          caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-          ImageableId: 2,
-          ImageableType: 'sites'
-        }]
-      },{
-        id: 3,
-        name: 'backbonejs.org',
-        thumbnails: []
-      }]
-    },
-    oracle: {
       result: [{
         id: 1,
         name: 'knexjs.org',
@@ -3763,82 +2879,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        id: 1,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 1,
-        ImageableType: 'authors',
-        imageable: {
-          id: 1,
-          site_id: 1,
-          first_name: 'Tim',
-          last_name: 'Griesser'
-        }
-      },{
-        id: 2,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 2,
-        ImageableType: 'authors',
-        imageable: {
-          id: 2,
-          site_id: 1,
-          first_name: 'Bazooka',
-          last_name: 'Joe'
-        }
-      },{
-        id: 3,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 1,
-        ImageableType: 'sites',
-        imageable: {
-          id: 1,
-          name: 'knexjs.org'
-        }
-      },{
-        id: 4,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 1,
-        ImageableType: 'sites',
-        imageable: {
-          id: 1,
-          name: 'knexjs.org'
-        }
-      },{
-        id: 5,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 2,
-        ImageableType: 'sites',
-        imageable: {
-          id: 2,
-          name: 'bookshelfjs.org'
-        }
-      },{
-        id: 6,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 2,
-        ImageableType: 'sites',
-        imageable: {
-          id: 2,
-          name: 'bookshelfjs.org'
-        }
-      },{
-        id: 7,
-        url: 'http://image.dev',
-        caption: 'this is a test image',
-        ImageableId: 10,
-        ImageableType: 'sites',
-        imageable: {
-
-        }
-      }]
-    },
-    oracle: {
       result: [{
         id: 1,
         url: 'https://www.google.com/images/srpr/logo4w.png',
@@ -4275,126 +3315,6 @@ module.exports = {
 
         }
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 1,
-        ImageableType: 'authors',
-        imageable: {
-          id: 1,
-          site_id: 1,
-          first_name: 'Tim',
-          last_name: 'Griesser'
-        }
-      },{
-        id: 2,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 2,
-        ImageableType: 'authors',
-        imageable: {
-          id: 2,
-          site_id: 1,
-          first_name: 'Bazooka',
-          last_name: 'Joe'
-        }
-      },{
-        id: 3,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 1,
-        ImageableType: 'sites',
-        imageable: {
-          id: 1,
-          name: 'knexjs.org',
-          authors: [{
-            id: 1,
-            site_id: 1,
-            first_name: 'Tim',
-            last_name: 'Griesser'
-          },{
-            id: 2,
-            site_id: 1,
-            first_name: 'Bazooka',
-            last_name: 'Joe'
-          }]
-        }
-      },{
-        id: 4,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 1,
-        ImageableType: 'sites',
-        imageable: {
-          id: 1,
-          name: 'knexjs.org',
-          authors: [{
-            id: 1,
-            site_id: 1,
-            first_name: 'Tim',
-            last_name: 'Griesser'
-          },{
-            id: 2,
-            site_id: 1,
-            first_name: 'Bazooka',
-            last_name: 'Joe'
-          }]
-        }
-      },{
-        id: 5,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 2,
-        ImageableType: 'sites',
-        imageable: {
-          id: 2,
-          name: 'bookshelfjs.org',
-          authors: [{
-            id: 3,
-            site_id: 2,
-            first_name: 'Charlie',
-            last_name: 'Brown'
-          },{
-            id: 4,
-            site_id: 2,
-            first_name: 'Ron',
-            last_name: 'Burgundy'
-          }]
-        }
-      },{
-        id: 6,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        ImageableId: 2,
-        ImageableType: 'sites',
-        imageable: {
-          id: 2,
-          name: 'bookshelfjs.org',
-          authors: [{
-            id: 3,
-            site_id: 2,
-            first_name: 'Charlie',
-            last_name: 'Brown'
-          },{
-            id: 4,
-            site_id: 2,
-            first_name: 'Ron',
-            last_name: 'Burgundy'
-          }]
-        }
-      },{
-        id: 7,
-        url: 'http://image.dev',
-        caption: 'this is a test image',
-        ImageableId: 10,
-        ImageableType: 'sites',
-        imageable: {
-
-        }
-      }]
     }
   },
   'handles hasMany `through`': {
@@ -4421,17 +3341,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        id: 1,
-        post_id: 1,
-        name: '(blank)',
-        email: 'test@example.com',
-        comment: 'this is neat.',
-        _pivot_id: 1,
-        _pivot_blog_id: 1
-      }]
-    },
-    oracle: {
       result: [{
         id: 1,
         post_id: 1,
@@ -4487,27 +3396,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        id: 1,
-        site_id: 1,
-        name: 'Main Site Blog',
-        comments: [{
-          id: 1,
-          post_id: 1,
-          name: '(blank)',
-          email: 'test@example.com',
-          comment: 'this is neat.',
-          _pivot_id: 1,
-          _pivot_blog_id: 1
-        }]
-      },{
-        id: 2,
-        site_id: 1,
-        name: 'Alternate Site Blog',
-        comments: []
-      }]
-    },
-    oracle: {
       result: [{
         id: 1,
         site_id: 1,
@@ -4592,27 +3480,6 @@ module.exports = {
         name: 'Alternate Site Blog',
         comments: []
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        site_id: 1,
-        name: 'Main Site Blog',
-        comments: [{
-          id: 1,
-          post_id: 1,
-          name: '(blank)',
-          email: 'test@example.com',
-          comment: 'this is neat.',
-          _pivot_id: 1,
-          _pivot_blog_id: 1
-        }]
-      },{
-        id: 2,
-        site_id: 1,
-        name: 'Alternate Site Blog',
-        comments: []
-      }]
     }
   },
   'handles hasOne `through`': {
@@ -4635,15 +3502,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        meta_id: 1,
-        other_description: 'This is an info block for hasOne -> through test',
-        _pivot_id: 1,
-        _pivot_site_id: 1
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         meta_id: 1,
@@ -4701,29 +3559,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        id: 1,
-        name: 'knexjs.org',
-        info: {
-          id: 1,
-          meta_id: 1,
-          other_description: 'This is an info block for hasOne -> through test',
-          _pivot_id: 1,
-          _pivot_site_id: 1
-        }
-      },{
-        id: 2,
-        name: 'bookshelfjs.org',
-        info: {
-          id: 2,
-          meta_id: 2,
-          other_description: 'This is an info block for an eager hasOne -> through test',
-          _pivot_id: 2,
-          _pivot_site_id: 2
-        }
-      }]
-    },
-    oracle: {
       result: [{
         id: 1,
         name: 'knexjs.org',
@@ -4936,69 +3771,6 @@ module.exports = {
         last_name: null,
         blogs: []
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        site_id: 1,
-        first_name: 'Tim',
-        last_name: 'Griesser',
-        blogs: [{
-          id: 1,
-          site_id: 1,
-          name: 'Main Site Blog',
-          _pivot_owner_id: 1,
-          _pivot_blog_id: 1
-        }]
-      },{
-        id: 2,
-        site_id: 1,
-        first_name: 'Bazooka',
-        last_name: 'Joe',
-        blogs: [{
-          id: 1,
-          site_id: 1,
-          name: 'Main Site Blog',
-          _pivot_owner_id: 2,
-          _pivot_blog_id: 1
-        },{
-          id: 2,
-          site_id: 1,
-          name: 'Alternate Site Blog',
-          _pivot_owner_id: 2,
-          _pivot_blog_id: 2
-        }]
-      },{
-        id: 3,
-        site_id: 2,
-        first_name: 'Charlie',
-        last_name: 'Brown',
-        blogs: [{
-          id: 3,
-          site_id: 2,
-          name: 'Main Site Blog',
-          _pivot_owner_id: 3,
-          _pivot_blog_id: 3
-        }]
-      },{
-        id: 4,
-        site_id: 2,
-        first_name: 'Ron',
-        last_name: 'Burgundy',
-        blogs: [{
-          id: 4,
-          site_id: 2,
-          name: 'Alternate Site Blog',
-          _pivot_owner_id: 4,
-          _pivot_blog_id: 4
-        }]
-      },{
-        id: 5,
-        site_id: 99,
-        first_name: 'Anonymous',
-        last_name: null,
-        blogs: []
-      }]
     }
   },
   'eager loads belongsTo `through`': {
@@ -5049,22 +3821,6 @@ module.exports = {
           _pivot_blog_id: 1
         }
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        post_id: 1,
-        name: '(blank)',
-        email: 'test@example.com',
-        comment: 'this is neat.',
-        blog:
-        { id: 1,
-          site_id: 1,
-          name: 'Main Site Blog',
-          _pivot_id: 1,
-          _pivot_blog_id: 1
-        }
-      }]
     }
   },
   '#65 - should eager load correctly for models': {
@@ -5091,17 +3847,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        hostname: 'google.com',
-        instance_id: 3,
-        route: null,
-        instance: {
-          id: 3,
-          name: 'search engine'
-        }
-      }
-    },
-    oracle: {
       result: {
         hostname: 'google.com',
         instance_id: 3,
@@ -5153,25 +3898,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        hostname: 'google.com',
-        instance_id: 3,
-        route: null,
-        instance: {
-          id: 3,
-          name: 'search engine'
-        }
-      },{
-        hostname: 'apple.com',
-        instance_id: 10,
-        route: null,
-        instance: {
-          id: 10,
-          name: 'computers'
-        }
-      }]
-    },
-    oracle: {
       result: [{
         hostname: 'google.com',
         instance_id: 3,
@@ -5479,102 +4205,6 @@ module.exports = {
 
         }
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 1,
-        imageable_type: 'profile_pic',
-        imageableParsed: {
-          id_parsed: 1,
-          site_id_parsed: 1,
-          first_name_parsed: 'Tim',
-          last_name_parsed: 'Griesser'
-        }
-      },{
-        id: 2,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 2,
-        imageable_type: 'profile_pic',
-        imageableParsed: {
-          id_parsed: 2,
-          site_id_parsed: 1,
-          first_name_parsed: 'Bazooka',
-          last_name_parsed: 'Joe'
-        }
-      },{
-        id: 3,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 1,
-        imageable_type: 'sites',
-        imageableParsed: {
-          id_parsed: 1,
-          name_parsed: 'knexjs.org',
-          meta: {
-            id: 1,
-            site_id: 1,
-            description: 'This is a description for the Knexjs Site'
-          }
-        }
-      },{
-        id: 4,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 1,
-        imageable_type: 'sites',
-        imageableParsed: {
-          id_parsed: 1,
-          name_parsed: 'knexjs.org',
-          meta: {
-            id: 1,
-            site_id: 1,
-            description: 'This is a description for the Knexjs Site'
-          }
-        }
-      },{
-        id: 5,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 2,
-        imageable_type: 'sites',
-        imageableParsed: {
-          id_parsed: 2,
-          name_parsed: 'bookshelfjs.org',
-          meta: {
-            id: 2,
-            site_id: 2,
-            description: 'This is a description for the Bookshelfjs Site'
-          }
-        }
-      },{
-        id: 6,
-        url: 'https://www.google.com/images/srpr/logo4w.png',
-        caption: 'Lorem ipsum Quis Ut eu nostrud ea sint aute non aliqua ut ullamco cupidatat exercitation nisi nisi.',
-        imageable_id: 2,
-        imageable_type: 'sites',
-        imageableParsed: {
-          id_parsed: 2,
-          name_parsed: 'bookshelfjs.org',
-          meta: {
-            id: 2,
-            site_id: 2,
-            description: 'This is a description for the Bookshelfjs Site'
-          }
-        }
-      },{
-        id: 7,
-        url: 'http://image.dev',
-        caption: 'this is a test image',
-        imageable_id: 10,
-        imageable_type: 'sites',
-        imageableParsed: {
-
-        }
-      }]
     }
   },
   "works with hasOne relation (locale -> translation)": {
@@ -5591,12 +4221,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        code: 'pt',
-        customer: 'Customer1'
-      }
-    },
-    oracle: {
       result: {
         code: 'pt',
         customer: 'Customer1'
@@ -5630,15 +4254,6 @@ module.exports = {
           customer: 'Customer1'
         }
       }
-    },
-    oracle: {
-      result: {
-        isoCode: 'pt',
-        translation: {
-          code: 'pt',
-          customer: 'Customer1'
-        }
-      }
     }
   },
   "works with hasMany relation (locale -> translations)": {
@@ -5661,15 +4276,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        code: 'en',
-        customer: 'Customer1'
-      }, {
-        code: 'en',
-        customer: 'Customer2'
-      }]
-    },
-    oracle: {
       result: [{
         code: 'en',
         customer: 'Customer1'
@@ -5715,18 +4321,6 @@ module.exports = {
           customer: 'Customer2'
         }]
       }
-    },
-    oracle: {
-      result: {
-        isoCode: 'en',
-        translations: [{
-          code: 'en',
-          customer: 'Customer1'
-        }, {
-          code: 'en',
-          customer: 'Customer2'
-        }]
-      }
     }
   },
   "works with belongsTo relation (translation -> locale)": {
@@ -5741,11 +4335,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        isoCode: 'pt'
-      }
-    },
-    oracle: {
       result: {
         isoCode: 'pt'
       }
@@ -5771,15 +4360,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        code: 'pt',
-        customer: 'Customer1',
-        locale: {
-          isoCode: 'pt'
-        }
-      }
-    },
-    oracle: {
       result: {
         code: 'pt',
         customer: 'Customer1',
@@ -5817,19 +4397,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        id: 1,
-        name: 'Customer1',
-        _pivot_code: 'en',
-        _pivot_customer: 'Customer1'
-      }, {
-        id: 2,
-        name: 'Customer2',
-        _pivot_code: 'en',
-        _pivot_customer: 'Customer2'
-      }]
-    },
-    oracle: {
       result: [{
         id: 1,
         name: 'Customer1',
@@ -5891,22 +4458,6 @@ module.exports = {
           _pivot_customer: 'Customer2'
         }]
       }
-    },
-    oracle: {
-      result: {
-        isoCode: 'en',
-        customers: [{
-          id: 1,
-          name: 'Customer1',
-          _pivot_code: 'en',
-          _pivot_customer: 'Customer1'
-        }, {
-          id: 2,
-          name: 'Customer2',
-          _pivot_code: 'en',
-          _pivot_customer: 'Customer2'
-        }]
-      }
     }
   },
   "works with hasOne `through` relation (customer -> locale)": {
@@ -5925,13 +4476,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        isoCode: 'en',
-        _pivot_code: 'en',
-        _pivot_customer: 'Customer2'
-      }
-    },
-    oracle: {
       result: {
         isoCode: 'en',
         _pivot_code: 'en',
@@ -5972,17 +4516,6 @@ module.exports = {
           _pivot_customer: 'Customer2'
         }
       }
-    },
-    oracle: {
-      result: {
-        id: 2,
-        name: 'Customer2',
-        locale: {
-          isoCode: 'en',
-          _pivot_code: 'en',
-          _pivot_customer: 'Customer2'
-        }
-      }
     }
   },
   "works with hasMany `through` relation (customer -> locales)": {
@@ -6009,17 +4542,6 @@ module.exports = {
       }]
     },
     sqlite3: {
-      result: [{
-        isoCode: 'en',
-        _pivot_code: 'en',
-        _pivot_customer: 'Customer1'
-      }, {
-        isoCode: 'pt',
-        _pivot_code: 'pt',
-        _pivot_customer: 'Customer1'
-      }]
-    },
-    oracle: {
       result: [{
         isoCode: 'en',
         _pivot_code: 'en',
@@ -6076,21 +4598,6 @@ module.exports = {
           _pivot_customer: 'Customer1'
         }]
       }
-    },
-    oracle: {
-      result: {
-        id: 1,
-        name: 'Customer1',
-        locales: [{
-          isoCode: 'en',
-          _pivot_code: 'en',
-          _pivot_customer: 'Customer1'
-        }, {
-          isoCode: 'pt',
-          _pivot_code: 'pt',
-          _pivot_customer: 'Customer1'
-        }]
-      }
     }
   },
   "works with belongsTo `through` relation (locale -> customer)": {
@@ -6111,14 +4618,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        id: 1,
-        name: 'Customer1',
-        _pivot_code: 'pt',
-        _pivot_customer: 'Customer1'
-      }
-    },
-    oracle: {
       result: {
         id: 1,
         name: 'Customer1',
@@ -6151,17 +4650,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        isoCode: 'pt',
-        customer: {
-          id: 1,
-          name: 'Customer1',
-          _pivot_code: 'pt',
-          _pivot_customer: 'Customer1'
-        }
-      }
-    },
-    oracle: {
       result: {
         isoCode: 'pt',
         customer: {
@@ -6212,19 +4700,6 @@ module.exports = {
         _pivot_code: 'en',
         _pivot_customer: 'Customer2'
       }]
-    },
-    oracle: {
-      result: [{
-        id: 1,
-        name: 'Customer1',
-        _pivot_code: 'en',
-        _pivot_customer: 'Customer1'
-      }, {
-        id: 2,
-        name: 'Customer2',
-        _pivot_code: 'en',
-        _pivot_customer: 'Customer2'
-      }]
     }
   },
   "works with eager belongsToMany `through` relation (locale -> customers)": {
@@ -6261,22 +4736,6 @@ module.exports = {
       }
     },
     sqlite3: {
-      result: {
-        isoCode: 'en',
-        customersThrough: [{
-          id: 1,
-          name: 'Customer1',
-          _pivot_code: 'en',
-          _pivot_customer: 'Customer1'
-        }, {
-          id: 2,
-          name: 'Customer2',
-          _pivot_code: 'en',
-          _pivot_customer: 'Customer2'
-        }]
-      }
-    },
-    oracle: {
       result: {
         isoCode: 'en',
         customersThrough: [{


### PR DESCRIPTION
* Related Issues: #1713, #1661, #1660, #1605
* Previous PRs: #1609, #1528

## Introduction

Remove all OracleDB related tests and associated code.

## Motivation

The tests for OracleDB are an endless cause of problems and build errors that have nothing to do with Bookshelf. To make matters worse, the entire test suite must run on the slower `sudo: required` Travis infrastructure which usually entails very long wait times before the build even starts (it can take hours), as well as taking double the time to run the test suite itself due to the extra OracleDB installation steps.

This change is also in line with the ideas expressed in #1600 and #1661 of removing all database adapter tests and leave that concern to the query builder being used (Knex). Since Knex already tests against several databases, including OracleDB, there shouldn't be any reason to duplicate those tests in Bookshelf.

## Proposed solution

This change simply removes all OracleDB tests, which shouldn't be a problem anyway, since we don't have any database specific code. Since removing tests for all other databases is going to require more work, it's best to start with the database that is easier to remove and that is causing more problems.

Removing OracleDB tests already made the TravisCI build much faster which is valuable in terms of development and quality of life for the developers.

## Current PR Issues

Doesn't remove all database adapter tests.

## Alternatives considered

Finding a maintainer for OracleDB support within Bookshelf, but that would be short lived anyway, since the plan is to move away from tests with actual databases and instead test the behavior of Bookshelf alone.

Separating OracleDB tests into a separate build matrix that is allowed to fail, but that would require a little bit of work to adapt the test suite, and again is against the objectives already mentioned.
