### PR TITLE
Add Bookshelf Manager to list of community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ User.where('id', 1).fetch({withRelated: ['posts.tags']}).then(function(user) {
 * [bookshelf-secure-password](https://github.com/venables/bookshelf-secure-password) - A plugin for easily securing passwords using bcrypt.
 * [bookshelf-default-select](https://github.com/DJAndries/bookshelf-default-select) - Enables default column selection for models. Inspired by [Visibility](https://github.com/tgriesser/bookshelf/wiki/Plugin:-Visibility), but operates on the database level.
 * [bookshelf-ez-fetch](https://github.com/DJAndries/bookshelf-ez-fetch) - Convenient fetching methods which allow for compact filtering, relation selection and error handling.
+* [bookshelf-manager](https://github.com/ericclemmons/bookshelf-manager) - Model & Collection manager to make it easy to create & save deep, nested JSON structures from API requests.
 
 ## Support
 


### PR DESCRIPTION
Was suggested I add [bookshelf-manager](https://github.com/ericclemmons/bookshelf-manager) to the list in https://github.com/bookshelf/bookshelf/pull/573

I haven't worked on this plugin in a while so I'm not sure if it needs any work to work with the latest version of Bookshelf, but it has tests if anyone would like to verify.