### PR TITLE
Fix typo on parse-and-format tutorial

### DIFF
--- a/tutorials/parse-and-format.md
+++ b/tutorials/parse-and-format.md
@@ -27,7 +27,7 @@ A very common use case for this is converting camelCase attributes to snake_case
         });
       },
       format: function(attributes) {
-        return _.mapKeys(response, function(value, key) {
+        return _.mapKeys(attributes, function(value, key) {
           return _.snakeCase(key);
         });
       }


### PR DESCRIPTION
Unless I am missing something it looks like `response` should be `attributes`

Thanks for this awesome library btw ❤️ 