### PR TITLE
Add parameterized virtual properties

### DIFF
--- a/src/plugins/virtuals.js
+++ b/src/plugins/virtuals.js
@@ -45,7 +45,7 @@ module.exports = function (Bookshelf) {
       }
       if (!options || options.virtuals !== false) {
         if ((options && options.virtuals === true) || this.outputVirtuals) {
-          attrs = _.extend(attrs, getVirtuals(this));
+          attrs = _.extend(attrs, getVirtuals(this, options && options.virtualParams));
         }
       }
       return attrs;
@@ -148,7 +148,7 @@ module.exports = function (Bookshelf) {
     }
   });
 
-  // Underscore methods that we want to implement on the Model.
+  // Lodash methods that we want to implement on the Model.
   const modelMethods = ['keys', 'values', 'toPairs', 'invert', 'pick', 'omit'];
 
   // Mix in each Lodash method as a proxy to `Model#attributes`.
@@ -166,12 +166,13 @@ module.exports = function (Bookshelf) {
     }
   }
 
-  function getVirtuals(model) {
+  function getVirtuals(model, params) {
     const { virtuals } = model;
     const attrs = {};
     if (virtuals != null) {
       for (const virtualName in virtuals) {
-        attrs[virtualName] = getVirtual(model, virtualName);
+        const paramsForVirtual = typeof(params) === 'object' && params !== null ? params[virtualName] : undefined;
+        attrs[virtualName] = getVirtual(model, virtualName, paramsForVirtual);
       }
     }
     return attrs;

--- a/src/plugins/virtuals.js
+++ b/src/plugins/virtuals.js
@@ -52,17 +52,16 @@ module.exports = function (Bookshelf) {
     },
 
     // Allow virtuals to be fetched like normal properties
-    get: function (attr) {
+    get: function(attr, ...params) {
       const { virtuals } = this;
       if (_.isObject(virtuals) && virtuals[attr]) {
-        return getVirtual(this, attr);
+        return getVirtual(this, attr, ...params);
       }
       return proto.get.apply(this, arguments);
     },
 
     // Allow virtuals to be set like normal properties
     set: function(key, value, options) {
-
       if (key == null) {
         return this;
       }
@@ -159,11 +158,11 @@ module.exports = function (Bookshelf) {
     };
   });
 
-  function getVirtual(model, virtualName) {
+  function getVirtual(model, virtualName, ...params) {
     const { virtuals } = model;
     if (_.isObject(virtuals) && virtuals[virtualName]) {
-      return virtuals[virtualName].get ? virtuals[virtualName].get.call(model)
-        : virtuals[virtualName].call(model);
+      return virtuals[virtualName].get ? virtuals[virtualName].get.call(model, ...params)
+        : virtuals[virtualName].call(model, ...params);
     }
   }
 

--- a/test/integration/plugins/registry.js
+++ b/test/integration/plugins/registry.js
@@ -16,8 +16,8 @@ module.exports = function(Bookshelf) {
 		});
 
 		beforeEach(function () {
-			this._relation.reset();
-			this.morphTo.reset();
+			this._relation.resetHistory();
+			this.morphTo.resetHistory();
 		});
 
 		before(function() {
@@ -182,7 +182,7 @@ module.exports = function(Bookshelf) {
 		});
 
 		describe('bookshelf.resolve', function() {
-			
+
 			it('resolves the path to a model with a custom function', function() {
 				var one = Bookshelf.Model.extend({});
 				var two = Bookshelf.Model.extend({});

--- a/test/integration/plugins/virtuals.js
+++ b/test/integration/plugins/virtuals.js
@@ -364,6 +364,33 @@ module.exports = function(bookshelf) {
 
         deepEqual(json, null);
       });
+
+      it('includes virtuals with parameters', function() {
+        var m = new (bookshelf.Model.extend({
+          virtuals: {
+            fullName: function(param) {
+              return this.get('firstName') + ' ' + param;
+            }
+          }
+        }))({firstName: 'Joe', lastName: 'Shmoe'});
+        var json = m.toJSON({virtualParams: {fullName: 'Danger'}});
+
+        deepEqual(_.keys(json), ['firstName', 'lastName', 'fullName']);
+        equal(json.fullName, 'Joe Danger');
+      });
+
+      it('includes virtuals with array parameters', function() {
+        var m = new (bookshelf.Model.extend({
+          virtuals: {
+            fullName: function(param) {
+              return this.get('firstName') + ' ' + param.join(' ');
+            }
+          }
+        }))({firstName: 'Joe', lastName: 'Shmoe'});
+        var json = m.toJSON({virtualParams: {fullName: ['Danger', 'Mouse', 'Explosion']}});
+
+        equal(json.fullName, 'Joe Danger Mouse Explosion');
+      });
     })
 
     it('works fine with `underscore` methods - #170', function() {


### PR DESCRIPTION
* Previous PRs: #1614, #1474 

## Introduction

This combines the best features of the previous two PRs. It's simple in its changes like #1474, but allows some control of which parameters go to which virtuals when calling `.toJSON()` like #1614.

Also fixes the sinon warnings in the test suite and rearranges the Virtuals Plugin test file to nest some test cases under their respective describe blocks.

## Motivation

No one else seemed interested in changing their PR.

## Proposed solution

This builds on the previous work and works exactly like those two PRs when it comes to the changes done to the model's `.get()` method:

```js
var PersonWithTitle = bookshelf.Model.extend({
  virtuals: {
    fullName: function(name) {
      return this.get('firstName') + ' ' + name
    }
  }
})
var john = new Person({firstName: 'John'})

john.get('fullName', 'Connor') // John Connor
```
However, it adds a new `virtualParams` option to `toJSON()` that allows passing values to specific virtuals. It must be an object with keys corresponding with the virtual name their values are meant for:

```js
john.toJSON({virtualParams: {fullName: 'Connor'}})
john.fullName  // John Connor
```

Closes #1474 and closes #1614.

## Current PR Issues

Can't pass more than one argument to virtuals in `toJSON()`. This is possible when using `.get()` directly though. This was done on purpose to allow passing arrays to virtuals, although the benefit of that is yet to be determined.

Also lacks documentation, but that will be done separately on the Wiki page. In the future Plugin docs should be a part of the main website, but currently the docs for plugins aren't being generated.
