### PR TITLE
Add tests for withSchema option

### DIFF
--- a/test/integration/helpers/index.js
+++ b/test/integration/helpers/index.js
@@ -7,3 +7,9 @@ exports.formatNumber = function(dialect) {
     postgresql: function(count) { return count.toString() }
   }[dialect];
 }
+
+exports.countModels = function countModels(Model, options) {
+  return function() {
+    return Model.forge().count(options);
+  }
+}

--- a/test/integration/helpers/inserts.js
+++ b/test/integration/helpers/inserts.js
@@ -268,11 +268,13 @@ module.exports = function(bookshelf) {
     ])
 
   ]).then(function() {
-    if (knex.client.dialect === 'postgresql') {
-      return knex.raw('SELECT setval(\'backup_types_id_seq\', (SELECT MAX(id) from "backup_types"));')
-    }
-  }, function(e) {
+    if (knex.client.dialect !== 'postgresql') return;
+
+    return Promise.all([
+      knex('authors').withSchema('test').insert([{name: 'Ryan Coogler'}]),
+      knex.raw('SELECT setval(\'backup_types_id_seq\', (SELECT MAX(id) from "backup_types"));')
+    ]);
+  }).catch(function(e) {
     console.log(e.stack);
   });
-
 };

--- a/test/integration/helpers/migration.js
+++ b/test/integration/helpers/migration.js
@@ -6,7 +6,7 @@ var drops = [
   'photos', 'users_roles', 'info', 'Customer', 'Settings', 'hostnames',
   'instances', 'uuid_test', 'parsed_users', 'tokens', 'thumbnails', 'lefts',
   'rights', 'lefts_rights', 'organization', 'locales', 'translations',
-  'backups', 'backup_types', 'test.authors'
+  'backups', 'backup_types'
 ];
 
 module.exports = function(Bookshelf) {
@@ -14,10 +14,6 @@ module.exports = function(Bookshelf) {
   var isPostgreSQL = Bookshelf.knex.client.dialect === 'postgresql';
 
   return Promise.all(drops.map(function(tableName) {
-    if (isPostgreSQL && tableName.split('.').length > 1) {
-      const tableIdentifier = tableName.split('.');
-      return knex.schema.withSchema(tableIdentifier[0]).dropTableIfExists(tableIdentifier[1])
-    }
     return knex.schema.dropTableIfExists(tableName);
   })).then(function() {
     if (isPostgreSQL) return Bookshelf.knex.raw('DROP SCHEMA IF EXISTS "test" CASCADE');

--- a/test/integration/helpers/migration.js
+++ b/test/integration/helpers/migration.js
@@ -1,4 +1,3 @@
-var _ = require('lodash')
 var Promise = global.testPromise;
 
 var drops = [
@@ -7,19 +6,33 @@ var drops = [
   'photos', 'users_roles', 'info', 'Customer', 'Settings', 'hostnames',
   'instances', 'uuid_test', 'parsed_users', 'tokens', 'thumbnails', 'lefts',
   'rights', 'lefts_rights', 'organization', 'locales', 'translations',
-  'backups', 'backup_types'
+  'backups', 'backup_types', 'test.authors'
 ];
 
 module.exports = function(Bookshelf) {
+  var knex = Bookshelf.knex;
+  var isPostgreSQL = Bookshelf.knex.client.dialect === 'postgresql';
 
-  var schema = Bookshelf.knex.schema;
+  return Promise.all(drops.map(function(tableName) {
+    if (isPostgreSQL && tableName.split('.').length > 1) {
+      const tableIdentifier = tableName.split('.');
+      return knex.schema.withSchema(tableIdentifier[0]).dropTableIfExists(tableIdentifier[1])
+    }
+    return knex.schema.dropTableIfExists(tableName);
+  })).then(function() {
+    if (isPostgreSQL) return Bookshelf.knex.raw('DROP SCHEMA IF EXISTS "test" CASCADE');
+  }).then(function() {
+    if (isPostgreSQL) return knex.schema.createSchema('test');
+  }).then(function() {
+    if (!isPostgreSQL) return;
 
-  return Promise.all(_.map(drops, function(val) {
-    return schema.dropTableIfExists(val);
-  }))
+    return knex.schema.withSchema('test').createTable('authors', function(table) {
+      table.increments('id');
+      table.string('name');
+    });
+  })
   .then(function() {
-
-    return schema.createTable('sites', function(table) {
+    return knex.schema.createTable('sites', function(table) {
       table.increments('id');
       table.string('name');
     })
@@ -180,5 +193,4 @@ module.exports = function(Bookshelf) {
       table.integer('backup_type_id');
     })
   });
-
 };

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -85,6 +85,10 @@ module.exports = function(Bookshelf) {
     hasTimestamps: true
   });
 
+  var TestAuthor = Bookshelf.Model.extend({
+    tableName: 'authors'
+  })
+
   // Author of a blog post.
   var Author = Bookshelf.Model.extend({
     tableName: 'authors',
@@ -398,6 +402,7 @@ module.exports = function(Bookshelf) {
       SiteParsed: SiteParsed,
       SiteMeta: SiteMeta,
       Admin: Admin,
+      TestAuthor: TestAuthor,
       Author: Author,
       AuthorParsed: AuthorParsed,
       Backup: Backup,

--- a/test/unit/sql/sync.js
+++ b/test/unit/sql/sync.js
@@ -43,6 +43,21 @@ module.exports = function() {
       };
     };
 
+    it('accepts a withSchema option', function() {
+      var testSchema = 'test';
+      var setSchema = sinon.spy();
+      var mockModel = {
+        query: function() {
+          return {withSchema: setSchema}
+        },
+        resetQuery: function() {}
+      }
+
+      new Sync(mockModel, {withSchema: testSchema});
+
+      setSchema.should.have.been.calledWith(testSchema);
+    })
+
     describe('prefixFields', function() {
       it('should prefix all keys of the passed in object with the tablename', function() {
         var sync = new Sync(stubModel());

--- a/test/unit/sql/sync.js
+++ b/test/unit/sql/sync.js
@@ -1,18 +1,13 @@
 var _ = require('lodash');
-var path     = require('path');
+var path = require('path');
 var basePath = process.cwd();
 
 module.exports = function() {
   var Sync = require(path.resolve(basePath + '/lib/sync'));
 
   describe('Sync', function() {
-
-    var stubSync = function(idAttribute) {
+    var stubModel = function(idAttribute) {
       var qd = [];
-      var stubQuery = function() {
-        qd.push(_.toArray(arguments));
-        return this;
-      };
 
       return {
         idAttribute: idAttribute || 'id',
@@ -25,7 +20,7 @@ module.exports = function() {
         isNew: function() {
           return true
         },
-        queryData: qd, 
+        queryData: qd,
         operation: null,
         query: function() { return this._query },
         _query: {
@@ -50,7 +45,7 @@ module.exports = function() {
 
     describe('prefixFields', function() {
       it('should prefix all keys of the passed in object with the tablename', function() {
-        var sync = new Sync(stubSync());
+        var sync = new Sync(stubModel());
         var attributes = {
           'some': 'column',
           'another': 'column'
@@ -67,7 +62,7 @@ module.exports = function() {
           'Some': 'column',
           'Another': 'column'
         };
-        var sync = new Sync(_.extend(stubSync(), {
+        var sync = new Sync(_.extend(stubModel(), {
           format: function(attrs) {
             var data = {};
             for (var key in attrs) {
@@ -78,7 +73,7 @@ module.exports = function() {
         }));
 
         sync.select = function() {
-          expect(this.syncing.queryData[0].where).to.eql({ 
+          expect(this.syncing.queryData[0].where).to.eql({
             "testtable.some": "column",
             "testtable.another": "column"
           });
@@ -89,7 +84,7 @@ module.exports = function() {
 
       it('should format attributes for updates, including id attribute', function(done) {
         var snakeCase = _.snakeCase;
-        var stubModelInstance = _.extend(stubSync('idAttribute'), {
+        var stubModelInstance = _.extend(stubModel('idAttribute'), {
           format: function(attrs) {
             var data = {};
             for (var key in attrs) {
@@ -98,23 +93,15 @@ module.exports = function() {
             return data;
           }
         });
-
         var updateFields = {
           someColumn: 'updated',
           otherColumn: 'updated'
         };
 
         stubModelInstance._query.update = function(attrs) {
-            expect(stubModelInstance.getWhereParts()).to.eql([
-              { id_attribute: 'pk' }
-            ]);
-
-            expect(attrs).to.eql({
-              'some_column': 'updated',
-              'other_column': 'updated'
-            });
-
-            done()
+          expect(stubModelInstance.getWhereParts()).to.eql([{id_attribute: 'pk'}]);
+          expect(attrs).to.eql({'some_column': 'updated', 'other_column': 'updated'});
+          done()
         }
 
         var sync = new Sync(stubModelInstance);
@@ -123,8 +110,7 @@ module.exports = function() {
 
       it('should format id attribute for deletes', function(done) {
         var snakeCase = _.snakeCase;
-
-        var stubModelInstance = _.extend(stubSync('idAttribute'), {
+        var stubModelInstance = _.extend(stubModel('idAttribute'), {
           idAttribute: 'idAttribute',
           format: function(attrs) {
             var data = {};
@@ -134,25 +120,20 @@ module.exports = function() {
             return data;
           }
         })
-        
-        stubModelInstance._query.del = function() {
-            expect(stubModelInstance.getWhereParts()).to.eql([
-              { id_attribute: 'pk' }
-            ]);
 
-            done()
+        stubModelInstance._query.del = function() {
+          expect(stubModelInstance.getWhereParts()).to.eql([{id_attribute: 'pk'}]);
+          done()
         }
-        
+
         var sync = new Sync(stubModelInstance);
         sync.del()
-        
       });
-
     });
 
     describe('update', function() {
       it('doesn\'t try to update the primary key if it hasn\'t changed', function() {
-        var sync = new Sync(stubSync());
+        var sync = new Sync(stubModel());
         _.extend(sync.query, {
           update: function(attrs) {
             expect(attrs).to.not.have.property('id');
@@ -166,7 +147,7 @@ module.exports = function() {
       });
 
       it('will update the primary key if it has changed', function() {
-        var sync = new Sync(stubSync());
+        var sync = new Sync(stubModel());
         _.extend(sync.query, {
           update: function(attrs) {
             expect(attrs).to.have.property('id');


### PR DESCRIPTION
* Previous PRs: #1638

## Introduction

This adds some simple tests that were absent from the previous PR.

## Current PR Issues

There is no documentation for this new feature.

## Alternatives considered

Proper schema support within models, so that users don't have to pass `withSchema: 'my_schema'` option with every database access, but that would go against making the models database agnostic which is the current long-term plan. This schema configuration will probably be added to the data mapper interface once that's implemented.