### PR TITLE
Allow eslint to be updated for all minor versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "babel-preset-es2015": "^6.24.1",
     "bookshelf-jsdoc-theme": "^0.2.0",
     "chai": "^3.5.0",
-    "eslint": "4.17.0",
+    "eslint": "^4.17.0",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.0",
     "knex": "^0.14.0",


### PR DESCRIPTION
* Previous PRs: #1749, #1754, #1764

## Introduction

This change allows `eslint` to be updated automatically whenever there's a new minor release.

Closes #1764.

## Motivation

Tired of constantly having greenkeeper modify `package.json` just because of a new minor release of `eslint`. 
