### PR TITLE
Added test that `parentId` is not undefined when using `fetchAll` with relations

### DIFF
--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -225,6 +225,13 @@ module.exports = function(Bookshelf) {
           return Post.where('blog_id', 1).fetchAll({withRelated: ['tags']})
             .then(checkTest(this));
         });
+
+        it('eager loads "belongsToMany" models correctly and parent is not undefined', function() {
+          return Post.where('blog_id', 1).fetchAll({withRelated: ['tags']})
+            .then(function (result) {
+              result.models[0].related('tags').relatedData.parentId.should.eql(1);
+          });
+        });
       });
 
       describe('Nested Eager Loading - Models', function() {


### PR DESCRIPTION
no issue

- the fix for that was added in https://github.com/bookshelf/bookshelf/pull/1716