### PR TITLE
Only request returning attribute if client supports returning

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -3,7 +3,7 @@
 import _ from 'lodash';
 import Promise from './base/promise';
 
-const supportsReturning = (client) => { return _.includes(['postgresql', 'oracle', 'mssql'], client) }
+const supportsReturning = (client) => _.includes(['postgresql', 'postgres', 'pg', 'oracle', 'mssql'], client)
 
 // Sync is the dispatcher for any database queries,
 // taking the "syncing" `model` or `collection` being queried, along with

--- a/src/sync.js
+++ b/src/sync.js
@@ -3,6 +3,8 @@
 import _ from 'lodash';
 import Promise from './base/promise';
 
+const supportsReturning = (client) => { return ['postgresql', 'oracle', 'mssql'].includes(client) }
+
 // Sync is the dispatcher for any database queries,
 // taking the "syncing" `model` or `collection` being queried, along with
 // a hash of options that are used in the various query methods.
@@ -192,7 +194,8 @@ _.extend(Sync.prototype, {
   // Issues an `insert` command on the query - only used by models.
   insert: Promise.method(function() {
     const syncing = this.syncing;
-    return this.query.insert(syncing.format(_.extend(Object.create(null), syncing.attributes)), syncing.idAttribute);
+    return this.query.insert(syncing.format(_.extend(Object.create(null), syncing.attributes)),
+                             supportsReturning(this.query.client.config.client) ? syncing.idAttribute : null);
   }),
 
   // Issues an `update` command on the query - only used by models.

--- a/src/sync.js
+++ b/src/sync.js
@@ -3,7 +3,7 @@
 import _ from 'lodash';
 import Promise from './base/promise';
 
-const supportsReturning = (client) => { return ['postgresql', 'oracle', 'mssql'].includes(client) }
+const supportsReturning = (client) => { return _.includes(['postgresql', 'oracle', 'mssql'], client) }
 
 // Sync is the dispatcher for any database queries,
 // taking the "syncing" `model` or `collection` being queried, along with


### PR DESCRIPTION
* Related Issues: [tgriesser/knex#1660](https://github.com/tgriesser/knex/issues/1660)
* Previous PRs: [tgriesser/knex#2471](https://github.com/tgriesser/knex/pull/2471)

## Introduction

`knex` 0.14.4 has been updated such that a warning is logged when using the `returning` attribute in a SQL dialect that does not support it. `bookshelf` always requests a `returning` attribute during an `insert`, which causes a flood of unwarranted warning messages whenever sqlite3 is used, and there is no way to tell `bookshelf` not to specify `returning`.

## Motivation

When running my tests, I see warning messages like this flood my logs every time I call an `insert`:

```
console.log node_modules/knex/lib/helpers.js:90
  Knex:warning - .returning() is not supported by sqlite3 and will not have any effect.
console.log node_modules/knex/lib/helpers.js:90
  Knex:warning - .returning() is not supported by sqlite3 and will not have any effect.
console.log node_modules/knex/lib/helpers.js:90
  Knex:warning - .returning() is not supported by sqlite3 and will not have any effect.
```

## Proposed solution

My solution is to check if the current client supports `returning` and request the `idAttribute` if and only if the support is available.

## Current PR Issues

N/A

## Alternatives considered

Also considered updating the client within `knex` to be able to do this logic. However, due to the fact that this change was implemented on the `knex` side, I have to assume that this is intended behavior.
