### PR TITLE
Remove second argument of model destroyed event

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -1212,11 +1212,10 @@ const BookshelfModel = ModelBase.extend({
        *
        * @event Model#destroyed
        * @param {Model}  model The model firing the event.
-       * @param {Object} affectedRows Number of affected rows.
        * @param {Object} options Options object passed to {@link Model#destroy destroy}.
        * @returns {Promise}
        */
-      return this.triggerThen('destroyed', this, affectedRows, options);
+      return this.triggerThen('destroyed', this, options);
     }).then(this._reset);
   }),
 


### PR DESCRIPTION
* Related Issues: #1722
* Previous PRs: #1723

## Introduction

In #1723 it was discovered that the second argument to the `destroyed` event was completely useless, so this just removes it.

## Motivation

There is no point in having that argument as it will always have the same value. See the above linked related issue for more info.

Fixes #1722.

## Current PR Issues

This is a breaking change in case someone is using the current third argument (`options`) for something in this event's handler. This is highly unlikely, so the disruption should be minimal or non-existent.
