### PR TITLE
Increase timeout of the large arrays test

### DIFF
--- a/test/base/tests/collection.js
+++ b/test/base/tests/collection.js
@@ -78,18 +78,15 @@ module.exports = function() {
       });
 
       it('should support large arrays', function() {
-        this.timeout(15000);
+        this.timeout(120000);
 
         var count = 200000;
         var models = [];
-        var i;
 
-        for (i = 0; i < count; ++i) {
-          models.push(new collection.model({
-            some_id: i,
-            name: 'Large-' + i
-          }));
+        for (var i = 0; i < count; ++i) {
+          models.push(new collection.model({some_id: i, name: 'Large-' + i}));
         }
+
         collection.set(models, {add: true, remove: false, merge: false});
 
         equal(collection.get(count - 1).get('name'), 'Large-' + (count - 1));


### PR DESCRIPTION
* Related Issues: #1775, #1773, #1759

## Introduction

This test fails sometimes due to timeout when Travis is particularly slow when running a job. Usually it's just a single job that fails, but that causes the entire build to be marked as failed.

## Motivation

It's not good to have a lot of false build errors.

## Proposed solution

This should help decrease or preferably eliminate the number of false build errors by increasing the failing test timeout to 2 minutes.
