### PR TITLE
Make require: true the default for deleting models

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -1159,7 +1159,8 @@ const BookshelfModel = ModelBase.extend({
    * @param {Object=}      options                  Hash of options.
    * @param {Transaction=} options.transacting      Optionally run the query in a transaction.
    * @param {bool} [options.require=true]
-   *   Throw a {@link Model.NoRowsDeletedError} if no records are affected by destroy.
+   *   Throw a {@link Model.NoRowsDeletedError} if no records are affected by destroy. This is
+   *   the default behavior as of version 0.13.0.
    *
    * @example
    *

--- a/src/model.js
+++ b/src/model.js
@@ -1199,7 +1199,7 @@ const BookshelfModel = ModelBase.extend({
     }).then(function() {
       return sync.del();
   }).then(function(affectedRows) {
-      if (options.require && affectedRows === 0) {
+      if (options.require !== false && affectedRows === 0) {
         throw new this.constructor.NoRowsDeletedError('No Rows Deleted');
       }
       this.clear();

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -772,9 +772,17 @@ module.exports = function(bookshelf) {
         return m.destroy();
       });
 
-      it('will throw an error when trying to destroy a non-existent object with {require: true}', function() {
-        return new Site({id: 1337}).destroy({require: true}).catch(function(err) {
-          assert(err instanceof bookshelf.NoRowsDeletedError)
+      it('will throw an error when trying to destroy a non-existent object', function() {
+        return new Site({id: 1337}).destroy().then(function() {
+          throw new Error('Should not have succeeded');
+        }).catch(function(error) {
+          assert(error instanceof bookshelf.NoRowsDeletedError);
+        })
+      });
+
+      it('will not throw an error when trying to destroy a non-existent object with {require: false}', function() {
+        return new Site({id: 1337}).destroy({require: false}).then(function(site) {
+          assert(site instanceof Site);
         })
       });
 


### PR DESCRIPTION
* Related Issues: #1593

## Introduction

Change `Model.destroy()` so that the `require: true` option is the default.

## Motivation

This makes `.destroy()` behave the same way as `save()` and also matches what the documentation already says. 

## Current PR Issues

This is a breaking change so it must be clearly marked as such and there should be some kind of document to help users with the transition to this new behavior.

## Alternatives considered

Not addressing this issue right now, but that would just be delaying the inevitable. It's better to do it in a `0.x` release where some breakage is expected.
