### PR TITLE
Rg update chai

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "bookshelf-jsdoc-theme": "^0.2.0",
-    "chai": "^3.5.0",
+    "chai": "4.0.2",
     "eslint": "^4.17.0",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.0",

--- a/test/integration/helpers/index.js
+++ b/test/integration/helpers/index.js
@@ -10,6 +10,9 @@ exports.formatNumber = function(dialect) {
 
 exports.countModels = function countModels(Model, options) {
   return function() {
-    return Model.forge().count(options);
+    return Model.forge().count(options).then(function(count) {
+      if (typeof count === 'string') return parseInt(count);
+      return count;
+    });
   }
 }


### PR DESCRIPTION
## Introduction

Update chai to a more recent version.

## Motivation

David [was showing it as outdated](https://david-dm.org/bookshelf/bookshelf?type=dev) with a red semaphore and everything which made me sad :cry: 

## Proposed solution

Unfortunately we can't update to the more recent version (4.1.2) due to [a bug](https://github.com/chaijs/chai/issues/1104) in that version that causes the wrong error to be reported when an `expect()` fails.

## Current PR Issues

Not the most recent version, but close enough.
