### PR TITLE
Fix inconsistent timestamp values

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -149,6 +149,16 @@ ModelBase.prototype.idAttribute = 'id';
  */
 ModelBase.prototype.hasTimestamps = false;
 
+ModelBase.prototype.formatTimestamps = function formatTimestamps() {
+  if (!this.hasTimestamps) return this;
+
+  this.getTimestampKeys().forEach((key) => {
+    this.set(key, new Date(this.get(key)));
+  });
+
+  return this;
+};
+
 /**
  * @method
  * @description  Get the current value of an attribute from the model.

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -149,6 +149,21 @@ ModelBase.prototype.idAttribute = 'id';
  */
 ModelBase.prototype.hasTimestamps = false;
 
+/**
+ * @method
+ * @private
+ * @description
+ *
+ * Converts the timestamp keys to actual Date objects. This will not run if the
+ * model doesn't have {@link Model#hasTimestamps hasTimestamps} set to either
+ * `true` or an array of key names.
+ * This method is run internally when reading data from the database to ensure
+ * data consistency between the several database implementations.
+ * It returns the model instance that called it, so it allows chaining of other
+ * model methods.
+ *
+ * @returns {Model} The model that called this.
+ */
 ModelBase.prototype.formatTimestamps = function formatTimestamps() {
   if (!this.hasTimestamps) return this;
 
@@ -173,6 +188,7 @@ ModelBase.prototype.get = function(attr) {
 
 /**
  * @method
+ * @private
  * @description
  *
  * Returns the model's {@link Model#idAttribute idAttribute} after applying the
@@ -535,6 +551,18 @@ ModelBase.prototype.saveMethod = function({ method = null, patch = false } = {})
     : method.toLowerCase();
 };
 
+/**
+ * @method
+ * @private
+ * @description
+ *
+ * Returns the automatic timestamp key names set on this model. Note that this
+ * will always return a value even if the model has {@link Model#hasTimestamps
+ * hasTimestamps} set to `false`. In this case and when set to `true` the
+ * return value will be the default names of `created_at` and `updated_at`.
+ *
+ * @returns {Array<string>} The two timestamp key names.
+ */
 ModelBase.prototype.getTimestampKeys = function() {
   return Array.isArray(this.hasTimestamps) ? this.hasTimestamps : DEFAULT_TIMESTAMP_KEYS;
 }
@@ -582,7 +610,6 @@ ModelBase.prototype.timestamp = function(options) {
 
   return attributes;
 };
-
 
 /**
  * @method

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -525,6 +525,10 @@ ModelBase.prototype.saveMethod = function({ method = null, patch = false } = {})
     : method.toLowerCase();
 };
 
+ModelBase.prototype.getTimestampKeys = function() {
+  return Array.isArray(this.hasTimestamps) ? this.hasTimestamps : DEFAULT_TIMESTAMP_KEYS;
+}
+
 /**
  * @method
  * @description
@@ -552,14 +556,9 @@ ModelBase.prototype.timestamp = function(options) {
   const now          = (options || {}).date ? new Date(options.date) : new Date();
   const attributes   = {};
   const method       = this.saveMethod(options);
-  const keys = _.isArray(this.hasTimestamps)
-    ? this.hasTimestamps
-    : DEFAULT_TIMESTAMP_KEYS;
-
   const canEditUpdatedAtKey = (options || {}).editUpdatedAt!= undefined ? options.editUpdatedAt : true;
   const canEditCreatedAtKey = (options || {}).editCreatedAt!= undefined ? options.editCreatedAt : true;
-
-  const [ createdAtKey, updatedAtKey ] = keys;
+  const [ createdAtKey, updatedAtKey ] = this.getTimestampKeys();
 
   if (updatedAtKey && canEditUpdatedAtKey) {
     attributes[updatedAtKey] = now;

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -4,9 +4,7 @@ import _, { assign, identity, mapKeys, mapValues, clone } from 'lodash';
 import inherits from 'inherits';
 
 import Events from './events';
-
-const PIVOT_PREFIX = '_pivot_';
-const DEFAULT_TIMESTAMP_KEYS = ['created_at', 'updated_at'];
+import {PIVOT_PREFIX, DEFAULT_TIMESTAMP_KEYS} from '../constants';
 
 // List of attributes attached directly from the `options` passed to the constructor.
 const modelProps = ['tableName', 'hasTimestamps'];

--- a/src/collection.js
+++ b/src/collection.js
@@ -420,7 +420,10 @@ const BookshelfCollection = CollectionBase.extend({
    */
   _handleResponse: function(response) {
     const { relatedData } = this;
-    this.set(response, {silent: true, parse: true}).invokeMap('_reset');
+
+    this.set(response, {silent: true, parse: true}).invokeMap('formatTimestamps');
+    this.invokeMap('_reset');
+
     if (relatedData && relatedData.isJoined()) {
       relatedData.parsePivot(this.models);
     }

--- a/src/collection.js
+++ b/src/collection.js
@@ -1,10 +1,8 @@
 import { clone, omit, isString, isArray, extend, toArray } from 'lodash';
-
 import Sync from './sync';
 import Helpers from './helpers';
 import EagerRelation from './eager';
 import Errors from './errors';
-
 import CollectionBase from './base/collection';
 import Promise from './base/promise';
 import createError from 'create-error';

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,2 @@
 export const PIVOT_PREFIX = '_pivot_';
+export const DEFAULT_TIMESTAMP_KEYS = ['created_at', 'updated_at'];

--- a/src/model.js
+++ b/src/model.js
@@ -9,8 +9,6 @@ import Errors from './errors';
 import ModelBase from './base/model';
 import Promise from './base/promise';
 
-const DEFAULT_TIMESTAMP_KEYS = ['created_at', 'updated_at'];
-
 /**
  * @class Model
  * @extends ModelBase
@@ -975,13 +973,7 @@ const BookshelfModel = ModelBase.extend({
       // timestamps, as `timestamp` calls `set` internally.
       this.set(attrs, {silent: true});
 
-
-      // Obtain the keys for the timestamp columns
-      const keys = _.isArray(this.hasTimestamps)
-        ? this.hasTimestamps
-        : DEFAULT_TIMESTAMP_KEYS;
-
-      const [ createdAtKey, updatedAtKey ] = keys;
+      const [ createdAtKey, updatedAtKey ] = this.getTimestampKeys();
 
       // Now set timestamps if appropriate. Extend `attrs` so that the
       // timestamps will be provided for a patch operation.
@@ -1392,6 +1384,7 @@ const BookshelfModel = ModelBase.extend({
    */
   _handleResponse(response) {
     const relatedData = this.relatedData;
+
     this.set(this.parse(response[0]), {silent: true})._reset();
     if (relatedData && relatedData.isJoined()) {
       relatedData.parsePivot([this]);

--- a/src/model.js
+++ b/src/model.js
@@ -1385,7 +1385,8 @@ const BookshelfModel = ModelBase.extend({
   _handleResponse(response) {
     const relatedData = this.relatedData;
 
-    this.set(this.parse(response[0]), {silent: true})._reset();
+    this.set(this.parse(response[0]), {silent: true}).formatTimestamps()._reset();
+
     if (relatedData && relatedData.isJoined()) {
       relatedData.parsePivot([this]);
     }

--- a/src/relation.js
+++ b/src/relation.js
@@ -426,8 +426,8 @@ export default RelationBase.extend({
     // Now that related models have been successfully paired, update each with
     // its parsed attributes
     related.map(model => {
-      model.attributes = model.parse(model.attributes)
-      model._reset();
+      model.attributes = model.parse(model.attributes);
+      model.formatTimestamps()._reset();
     });
 
     return related;


### PR DESCRIPTION
* Related Issues: #1068, #572
* Previous PRs: #1546

## Introduction

Ensure date values of automatic timestamps are always returned in a consistent format.

## Motivation

When using SQLite dates are returned as Unix timestamps when fetching data from the database, but when a model is created and saved they are stored as Date objects on the model. This creates inconsistency when dealing with dates between saving and fetching, which leads to users having to deal with this inconsistency themselves. However it should be the ORM's job to deal with these issues and provide a consistent interface for users. See the above related issue for more info.

Fixes #1068.

## Proposed solution

This adds a new method to format the dates whenever a model has the `hasTimestamps` attribute set to `true` or an array of key names. Unlike the previous PR this doesn't wrap existing methods (`parse`) and just calls the new method when needed. The advantage of this approach is that the `parse` method is kept untouched which is a positive thing since it's already complicated and tangled as it is.

## Current PR Issues

Doesn't format other date columns the user might have set on the database, but since Bookshelf doesn't know about the database structure it wouldn't be feasible anyway.

There's also a problem in the way that MySQL handles dates that causes millisecond information to be discarded when saving to the database. This can be fixed but requires a [change in Knex](https://github.com/tgriesser/knex/issues/2524) and there's nothing we can do on our side except for recommending that users use a custom date format in migrations when dealing with MySQL.