### PR TITLE
Use a different method to check for Knex on Bookshelf construction

### DIFF
--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -11,7 +11,6 @@ import BookshelfModel from './model';
 import BookshelfCollection from './collection';
 import BookshelfRelation from './relation';
 import Errors from './errors';
-import Knex from 'knex';
 
 /**
  * @class Bookshelf
@@ -33,7 +32,6 @@ function Bookshelf(knex) {
   };
 
   const Model = bookshelf.Model = BookshelfModel.extend({
-
     _builder: builderFn,
 
     // The `Model` constructor is referenced as a property on the `Bookshelf`
@@ -47,7 +45,6 @@ function Bookshelf(knex) {
       }
       return new Relation(type, Target, options);
     }
-
   }, {
 
     /**

--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -25,7 +25,7 @@ import Knex from 'knex';
  * @param {Knex} knex Knex instance.
  */
 function Bookshelf(knex) {
-  if (!knex || !(knex.client instanceof Knex.Client)) {
+  if (!knex || knex.name !== 'knex') {
     throw new Error('Invalid knex instance');
   }
   const bookshelf = {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -12,6 +12,7 @@
     "sinon": true
   },
   "rules": {
+    "no-console": 0,
     "no-var": 0
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -6,17 +6,15 @@ Promise.onPossiblyUnhandledRejection(function (err) {
 });
 
 global.testPromise = Promise;
-var testQueryCache = global.testQueryCache = [];
 var oldIt = it;
 
 it = function() {
-  testQueryCache = [];
   return oldIt.apply(this, arguments);
 };
 
 // http://bluebirdjs.com/docs/api/error-management-configuration.html#global-rejection-events
 process.on("unhandledRejection", function(reason, promise) {
-    console.error(reason);
+  console.error(reason);
 });
 
 var Bookshelf = require('../bookshelf');

--- a/test/index.js
+++ b/test/index.js
@@ -48,8 +48,14 @@ describe('Bookshelf', function () {
     return bookshelf.knex.destroy()
   });
 
-  it('should fail without knex instance', function() {
-    expect(() => Bookshelf()).to.throw(/knex/);
+  describe('Construction', function() {
+    it('should fail without a knex instance', function() {
+      expect(() => Bookshelf()).to.throw(/Invalid knex/);
+    });
+
+    it('should fail if passing a random object', function() {
+      expect(() => Bookshelf({config: 'something', options: ['one', 'two']})).to.throw(/Invalid knex/);
+    })
   });
 });
 


### PR DESCRIPTION
* Previous PRs: #1756

## Introduction

The previous PR was great, but was causing a false positive when using a `npm link` to a development version of Bookshelf from another directory.

Example:

```
# bookshelf source in ~/bookshelf
# test code in ~/my-new-test
# in ~/my-new-test run
npm install ../bookshelf
node test.js
# Error: Invalid knex instance
```

## Motivation

This is mainly a problem for developers working on Bookshelf, and it's not immediately obvious why it's happening. While the previous PR was correct, it didn't foresee this corner case, thus making a bit harder than necessary to work on Bookshelf in the aforementioned case.

## Proposed solution

This just checks to see if the function being passed to the constructor has a name equal to `knex`. It's not the most reliable of methods, but works well enough for the intended purposes where extreme reliability is not very important.