### PR TITLE
Remove unnecessary processor plugin methods

### DIFF
--- a/src/plugins/processor.js
+++ b/src/plugins/processor.js
@@ -1,71 +1,14 @@
+var _ = require('lodash');
+
 /**
  * Attribute Processor Plugin
  *
- * Allows defining custom processor functions that handle transformation of values whenever they are `.set()` on a model. This
- * plugin modifies the {@link Model#set} method so that any defined processor functions get called when a value is set on a
- * model. It also adds some methods to {@link Bookshelf} instances to handle adding and removing processors.
+ * Allows defining custom processor functions that handle transformation of values whenever they are `.set()` on a
+ * model. This plugin modifies the {@link Model#set} method so that any defined processor functions get called when a
+ * value is set on a model.
  */
-
-var _ = require('lodash');
-
 module.exports = function processorPlugin(bookshelf) {
-  var processors = {};
   var proto = bookshelf.Model.prototype;
-
-  /**
-   * @method Bookshelf#addProcessor
-   * @description
-   * Adds a processor to the associated Bookshelf instance. You must specify a name string and the function to add:
-   *
-   *     var bookshelf = Bookshelf(knex);
-   *     bookshelf.plugin('processor');
-   *     bookshelf.addProcessor('trim', function(string) { return string.trim(); });
-   *
-   * @param {string} name The name of the processor to add. This is how the processor will be identified.
-   * @param {function} processor The actual processor function to add.
-   * @return {undefined}
-   */
-  bookshelf.addProcessor = function addProcessor(name, processor) {
-    if (typeof name !== 'string' || name.length === 0) throw new Error('You must specify a processor name string');
-    if (typeof processor !== 'function') throw new Error('You must specify a function to load as processor');
-    processors[name] = processor;
-  }
-
-  /**
-   * @method Bookshelf#removeProcessor
-   * @description
-   * Removes a previously added processor from the associated Bookshelf instance. You must specify a name string. If the name
-   * doesn't match an existing processor nothing will change and no error will be emitted.
-   *
-   *     var bookshelf = Bookshelf(knex);
-   *     bookshelf.plugin('processor');
-   *     bookshelf.removeProcessor('trim');
-   *
-   * @param {string} name The name of the processor to remove. This is the same name string that was used when adding it.
-   * @return {undefined}
-   */
-  bookshelf.removeProcessor = function removeProcessor(name) {
-    if (Array.isArray(name)) {
-      return name.forEach(this.removeProcessor);
-    }
-    delete processors[name];
-  }
-
-  /**
-   * @method Bookshelf#removeAllProcessors
-   * @description
-   * Removes all previously added processors from the associated Bookshelf instance. If there are no processors already then
-   * nothing will change and no error will be emitted.
-   *
-   *     var bookshelf = Bookshelf(knex);
-   *     bookshelf.plugin('processor');
-   *     bookshelf.removeAllProcessors();
-   *
-   * @return {undefined}
-   */
-  bookshelf.removeAllProcessors = function removeAllProcessors() {
-    processors = {};
-  }
 
   bookshelf.Model = bookshelf.Model.extend({
     set: function(key, value, options) {
@@ -77,13 +20,13 @@ module.exports = function processorPlugin(bookshelf) {
       if (this.processors) {
         if (typeof key === 'object') {
           processedKey = _.transform(key, function(result, value, key) {
-            result[key] = self.processAttribute(value, key);
+            result[key] = self.processAttribute(key, value);
           });
 
           return proto.set.call(this, processedKey, value, options);
         }
 
-        value = this.processAttribute(value, key);
+        value = this.processAttribute(key, value);
       }
 
       return proto.set.call(this, key, value, options);
@@ -92,28 +35,29 @@ module.exports = function processorPlugin(bookshelf) {
     /**
      * @method Model#processAttribute
      * @memberof Model
+     * @private
      * @description
      * Tries to process an attribute using the associated processor or just returning the value as it is if there are no
-     * processors defined for the attribute being transformed. This method is used internally by the Processor Plugin and there
-     * is usually no reason to use it directly.
+     * processors defined for the attribute being transformed. This method is used internally by the Processor Plugin
+     * and there is usually no reason to use it directly.
      *
-     *     var bookshelf = Bookshelf(knex);
+     *     var bookshelf = Bookshelf(knex)
      *     var MyModel = bookshelf.Model.extend({
      *       tableName: 'my_models',
      *       processors: {
-     *         name: 'trim'
+     *         name: function(value) { return value.trim() }
      *       }
-     *     });
+     *     })
      *
-     *     bookshelf.plugin('processor');
-     *     var processedValue = new MyModel().processAttribute('something   ', 'name');
+     *     bookshelf.plugin('processor')
+     *     var processedValue = new MyModel().processAttribute('something   ', 'name')
      *     // processedValue === 'something'
      *
      * @param {mixed} value The value that is to be transformed.
      * @param {string} key The attribute name key.
      * @return {mixed} The transformed value.
      */
-    processAttribute: function(value, key) {
+    processAttribute: function processAttribute(key, value) {
       var processes;
 
       if (this.processors && this.processors[key]) processes = this.processors[key];
@@ -121,20 +65,20 @@ module.exports = function processorPlugin(bookshelf) {
       if (!Array.isArray(processes)) processes = [processes];
 
       processes.forEach(function(process) {
-        var processor;
-
-        if (typeof process === 'string') {
-          processor = processors[process];
-          if (!processor) throw new Error('Unknown processor `' + process + '`');
-        }
-        else {
-          processor = process;
-        }
-
-        value = processor(value);
+        value = process(value);
       });
 
       return value;
-    }
+    },
+
+    /**
+     * @name Model#processors
+     * @type {(Boolean|Object)}
+     * @description
+     * An object mapping attribute names to one or more processor functions to apply to that attribute. By default the
+     * value of this property is `false` to indicate that this model doesn't have any processors set.
+     * @default false
+    */
+    processors: false
   });
 };

--- a/test/integration/plugins/processor.js
+++ b/test/integration/plugins/processor.js
@@ -15,124 +15,9 @@ module.exports = function(bookshelf) {
       User = require('../helpers/objects')(bookshelf).Models.User
     })
 
-    beforeEach(function() {
-      bookshelf.removeAllProcessors()
-    })
-
-    it('adds a Bookshelf#addProcessor() method', function() {
-      expect(bookshelf).to.respondTo('addProcessor');
-    })
-
-    it('adds a Model#processAttribute() method', function() {
-      expect(new User()).to.respondTo('processAttribute');
-    })
-
-    it('adds a Bookshelf#removeProcessor() method', function() {
-      expect(bookshelf).to.respondTo('removeProcessor');
-    })
-
-    it('adds a Model#removeAllProcessors() method', function() {
-      expect(bookshelf).to.respondTo('removeAllProcessors');
-    })
-
-    describe('Bookshelf#addProcessor()', function() {
-      it('adds a custom processor to a Bookshelf instance', function() {
-        var OtherUser = User.extend({
-          processors: {
-            username: 'lowercase'
-          }
-        });
-
-        function setUsername() {
-          new OtherUser().set('username', 'test');
-        }
-
-        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
-
-        expect(setUsername).to.not.throw();
-      })
-
-      it('throws an error if the first argument is not a string', function() {
-        function badAdd() {
-          bookshelf.addProcessor(['name']);
-        }
-
-        expect(badAdd).to.throw();
-      })
-
-      it('throws an error if the first argument is an empty string', function() {
-        function badAdd() {
-          bookshelf.addProcessor('');
-        }
-
-        expect(badAdd).to.throw();
-      })
-
-      it('throws an error if the second argument is not a function', function() {
-        function badAdd() {
-          bookshelf.addProcessor('name', 'this ain\'t right');
-        }
-
-        expect(badAdd).to.throw();
-      })
-    })
-
-    describe('Bookshelf#removeProcessor()', function() {
-      it('can remove an already added processor', function() {
-        var OtherUser = User.extend({
-          processors: {
-            username: 'lowercase'
-          }
-        });
-
-        function setUsername() {
-          new OtherUser().set('username', 'test');
-        }
-
-        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
-        expect(setUsername).to.not.throw();
-
-        bookshelf.removeProcessor('lowercase');
-        expect(setUsername).to.throw();
-      })
-
-      it('can remove a list of already added processors', function() {
-        var OtherUser = User.extend({
-          processors: {
-            username: 'lowercase'
-          }
-        });
-
-        function setUsername() {
-          new OtherUser().set('username', 'test');
-        }
-
-        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
-        expect(setUsername).to.not.throw();
-
-        bookshelf.removeProcessor(['lowercase']);
-        expect(setUsername).to.throw();
-      })
-    })
-
-    describe('Bookshelf#removeAllProcessors()', function() {
-      it('can remove all processors at once', function() {
-        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
-        bookshelf.addProcessor('trim', trimProcessor);
-
-        var OtherUser = User.extend({
-          processors: {
-            username: ['lowercase', 'trim']
-          }
-        });
-
-        function setUsername() {
-          new OtherUser().set('username', 'test');
-        }
-
-        expect(setUsername).to.not.throw();
-        bookshelf.removeAllProcessors();
-        expect(setUsername).to.throw();
+    describe('Model#processors', function() {
+      it('is false by default', function() {
+        expect(new User().processors).to.be.false;
       })
     })
 
@@ -152,11 +37,9 @@ module.exports = function(bookshelf) {
       })
 
       it('processes the set attribute with the correct processor', function() {
-        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
-
         var OtherUser = User.extend({
           processors: {
-            username: 'lowercase'
+            username: lowerCaseProcessor
           }
         });
         var otherUser = new OtherUser().set('username', 'TesT');
@@ -165,11 +48,9 @@ module.exports = function(bookshelf) {
       })
 
       it('can accept an object with attributes to process', function() {
-        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
-
         var OtherUser = User.extend({
           processors: {
-            username: 'lowercase'
+            username: lowerCaseProcessor
           }
         });
         var otherUser = new OtherUser().set({username: 'TesT'});
@@ -178,12 +59,9 @@ module.exports = function(bookshelf) {
       })
 
       it('can process an attribute with multiple processors', function() {
-        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
-        bookshelf.addProcessor('trim', trimProcessor);
-
         var OtherUser = User.extend({
           processors: {
-            username: ['lowercase', 'trim']
+            username: [lowerCaseProcessor, trimProcessor]
           }
         });
         var otherUser = new OtherUser().set('username', 'TesT   ');
@@ -192,12 +70,9 @@ module.exports = function(bookshelf) {
       })
 
       it('doesn\'t do any processing if no processors are specified', function() {
-        bookshelf.addProcessor('lowercase', lowerCaseProcessor);
-        bookshelf.addProcessor('trim', trimProcessor);
-
         var OtherUser = User.extend({
           processors: {
-            bogus: ['lowercase']
+            bogus: [lowerCaseProcessor]
           }
         });
         var otherUser = new OtherUser().set('username', 'TesT');
@@ -205,7 +80,7 @@ module.exports = function(bookshelf) {
         expect(otherUser.get('username')).to.match(/TesT/);
       })
 
-      it('can use a custom processor function', function() {
+      it('can use an anonymous processor function', function() {
         var OtherUser = User.extend({
           processors: {
             username: function(string) {


### PR DESCRIPTION
* Previous PRs: #1741

## Introduction

Remove unnecessary methods from processor plugin.

## Motivation

These methods don't add anything of value and only duplicate functionality that can easily be achieved by simpler methods, like having a module with processors in the project and just including it when necessary in model files.

This follows the new guidelines for the project of not having duplicated functionality to improve clarity of usage.

This plugin hasn't made it to a public release yet, so now's the time to do this change before people start using it and removing methods would cause more problems.
