### PR TITLE
Fix timestamps set with Invalid Date in some cases

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -166,7 +166,7 @@ ModelBase.prototype.formatTimestamps = function formatTimestamps() {
   if (!this.hasTimestamps) return this;
 
   this.getTimestampKeys().forEach((key) => {
-    this.set(key, new Date(this.get(key)));
+    if (this.get(key)) this.set(key, new Date(this.get(key)));
   });
 
   return this;

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1125,6 +1125,12 @@ module.exports = function(bookshelf) {
           expect(fin.get('created_at')).to.be.eql(createdAt);
         });
       });
+
+      it('will not set timestamps on the model if the associated columns are ommitted in fetch', function() {
+        return Models.Admin.forge({id: 1}).fetch({columns: ['id']}).then(function(admin) {
+          expect(admin.get('created_at')).to.be.undefined;
+        })
+      })
     });
 
     describe('timestamp', function() {

--- a/test/integration/plugins/pagination.js
+++ b/test/integration/plugins/pagination.js
@@ -67,6 +67,13 @@ module.exports = function (bookshelf) {
           expect(md.rowCount).to.equal(4);
         })
       })
+
+      it('returns correct values for rowCount and pageCount when hasTimestamps is used', function() {
+        return Models.Admin.fetchPage({page: 1, pageSize: 4}).then(function(admins) {
+          expect(admins.pagination.rowCount).to.be.a('number');
+          expect(admins.pagination.pageCount).to.be.a('number');
+        })
+      })
     })
 
     describe('Model static fetchPage', function () {


### PR DESCRIPTION
* Related Issues: #1795 #1793, #1791
* Previous PRs: #1784 

## Introduction

The previous PR introduced a bug that led to the timestamp attributes sometimes being set with a `Invalid Date` value.

This only happened if a model with `hasTimestamps` set to `true` or an array was being fetched but the associated timestamp columns were omitted in the `fetch` call using the `columns: [ ... ]` option.

Strangely this also affected all calls of `fetchPage` causing `null` or missing values for `rowCount` and `pageCount`. 

## Proposed solution

This just checks if the relevant timestamp attributes return a truthy value before attempting to cast them to a `Date` object.
