### PR TITLE
Clean up automatic timestamps feature

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -1,8 +1,8 @@
 // Base Model
 // ---------------
 import _, { assign, identity, mapKeys, mapValues, clone } from 'lodash';
+import {deprecate} from '../helpers';
 import inherits from 'inherits';
-
 import Events from './events';
 import {PIVOT_PREFIX, DEFAULT_TIMESTAMP_KEYS} from '../constants';
 
@@ -157,17 +157,43 @@ ModelBase.prototype.defaults = null;
  * @default false
  * @description
  *
- * Sets the current date/time on the timestamps columns `created_at` and
- * `updated_at` for a given method. The 'update' method will only update
- * `updated_at`. To override the default column names, assign an array
- * to {@link Model#hasTimestamps hasTimestamps}.  The first element will
- * be the created column name and the second will be the updated
- * column name.
- * You can pass values for the timestamps columns as parameter in the
- * {@link Model#save save} method. This will prevent the automatic
- * update of the timestamps columns values during the {@link Model#save save} method,
- * while the final columns values will be the values you have specified.
+ * Automatically sets the current date and time on the timestamp attributes
+ * `created_at` and `updated_at` based on the type of save method. The *update*
+ * method will only update `updated_at`, while the *insert* method will set
+ * both values.
  *
+ * To override the default attribute names, assign an array to this property.
+ * The first element will be the *created* column name and the second will be
+ * the *updated* one. If any of these elements is set to `null` that particular
+ * timestamp attribute will not be used in the model. For example, to
+ * automatically update only the `created_at` attribute set this property to
+ * `['created_at', null]`.
+ *
+ * You can override the timestamp attribute values of a model and those values
+ * will be used instead of the automatic ones when saving.
+ *
+ * @example
+ *
+ * var MyModel = bookshelf.Model.extend({
+ *   hasTimestamps: true,
+ *   tableName: 'my_table'
+ * })
+ *
+ * var myModel = MyModel.forge({name: 'blah'}).save().then(function(savedModel) {
+ *   // {
+ *   //   name: 'blah',
+ *   //   created_at: 'Sun Mar 25 2018 15:07:11 GMT+0100 (WEST)',
+ *   //   updated_at: 'Sun Mar 25 2018 15:07:11 GMT+0100 (WEST)'
+ *   // }
+ * })
+ *
+ * myModel.save({created_at: new Date(2015, 5, 2)}).then(function(updatedModel) {
+ *   // {
+ *   //   name: 'blah',
+ *   //   created_at: 'Tue Jun 02 2015 00:00:00 GMT+0100 (WEST)',
+ *   //   updated_at: 'Sun Mar 25 2018 15:07:11 GMT+0100 (WEST)'
+ *   // }
+ * })
  */
 ModelBase.prototype.hasTimestamps = false;
 
@@ -592,22 +618,21 @@ ModelBase.prototype.getTimestampKeys = function() {
 /**
  * @method
  * @description
- * Sets the timestamp attributes on the model, if {@link Model#hasTimestamps
- * hasTimestamps} is set to `true` or an array. Check if the model {@link
- * Model#isNew isNew} or if `{method: 'insert'}` is provided as an option and
- * set the `created_at` and `updated_at` attributes to the current date if it
- * is being inserted, and just the `updated_at` attribute if it's being updated.
- * This method may be overriden to use different column names or types for the
- * timestamps.
+ * Automatically sets the timestamp attributes on the model, if
+ * {@link Model#hasTimestamps hasTimestamps} is set to `true` or an array. It
+ * checks if the model is new and sets the `created_at` and `updated_at`
+ * attributes (or any other custom attribute names you have set) to the current
+ * date. If the model is not new and is just being updated then only the
+ * `updated_at` attribute gets automatically updated.
+ *
+ * If the model contains any user defined `created_at` or `updated_at` values,
+ * there won't be any automatic updated of these attributes and the user
+ * supplied values will be used instead.
  *
  * @param {Object=} options
  * @param {string} [options.method]
- *   Either `'insert'` or `'update'`. Specify what kind of save the attribute
+ *   Either `'insert'` or `'update'` to specify what kind of save the attribute
  *   update is for.
- * @param {string} [options.date]
- *   Either a Date object or ms since the epoch. Specify what date is used for
- *   the timestamps updated.
- *
  * @returns {Object} A hash of timestamp attributes that were set.
  */
 ModelBase.prototype.timestamp = function(options) {
@@ -619,6 +644,8 @@ ModelBase.prototype.timestamp = function(options) {
   const [createdAtKey, updatedAtKey] = this.getTimestampKeys();
   const isNewModel = method === 'insert';
   const setUpdatedAt = updatedAtKey && this.hasChanged(updatedAtKey)
+
+  if (options && options.date) deprecate('options.date', 'the model\'s timestamp attributes to set these values')
 
   if (isNewModel && !setUpdatedAt || this.hasChanged() && !setUpdatedAt) {
     attributes[updatedAtKey] = now;

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -616,19 +616,19 @@ ModelBase.prototype.timestamp = function(options) {
   const now          = (options || {}).date ? new Date(options.date) : new Date();
   const attributes   = {};
   const method       = this.saveMethod(options);
-  const canEditUpdatedAtKey = (options || {}).editUpdatedAt!= undefined ? options.editUpdatedAt : true;
-  const canEditCreatedAtKey = (options || {}).editCreatedAt!= undefined ? options.editCreatedAt : true;
-  const [ createdAtKey, updatedAtKey ] = this.getTimestampKeys();
+  const [createdAtKey, updatedAtKey] = this.getTimestampKeys();
+  const isNewModel = method === 'insert';
+  const setUpdatedAt = updatedAtKey && this.hasChanged(updatedAtKey)
 
-  if (updatedAtKey && canEditUpdatedAtKey) {
+  if (isNewModel && !setUpdatedAt || this.hasChanged() && !setUpdatedAt) {
     attributes[updatedAtKey] = now;
   }
 
-  if (createdAtKey && method === 'insert' && canEditCreatedAtKey) {
+  if (createdAtKey && isNewModel && !this.hasChanged(createdAtKey)) {
     attributes[createdAtKey] = now;
   }
 
-  this.set(attributes, options);
+  this.set(attributes, _.extend(options, {silent: true}));
 
   return attributes;
 };

--- a/src/model.js
+++ b/src/model.js
@@ -989,20 +989,10 @@ const BookshelfModel = ModelBase.extend({
       // timestamps, as `timestamp` calls `set` internally.
       this.set(attrs, {silent: true});
 
-      const [ createdAtKey, updatedAtKey ] = this.getTimestampKeys();
-
       // Now set timestamps if appropriate. Extend `attrs` so that the
       // timestamps will be provided for a patch operation.
       if (this.hasTimestamps) {
-        //If some of the new attributes are value for update_at or created_at columns disable the possibility for the timestamp function to update the columns
-        const editUpdatedAt = attrs[updatedAtKey] ? false : true;
-        const editCreatedAt = attrs[createdAtKey] ? false : true;
-        const additionalOptions = {
-          silent: true,
-          editUpdatedAt : editUpdatedAt ,
-          editCreatedAt : editCreatedAt
-        }
-        _.extend(attrs, this.timestamp(_.extend(options, additionalOptions)));
+        _.extend(attrs, this.timestamp(options));
       }
 
       // If there are any save constraints, set them on the model.

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1045,8 +1045,7 @@ module.exports = function(bookshelf) {
         it('will set the created_at timestamp to the user supplied value', function() {
           var admin = new Models.Admin();
           var oldCreatedAt;
-          var newCreatedAt = new Date();
-          newCreatedAt.setMinutes(newCreatedAt.getMinutes() + 1);
+          var newCreatedAt = new Date(1999, 1, 1);
 
           return admin.save().then(function(savedAdmin) {
             oldCreatedAt = savedAdmin.get('created_at');

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1064,7 +1064,7 @@ module.exports = function(bookshelf) {
           m = new (bookshelf.Model.extend({hasTimestamps: true}))();
         })
 
-        it('sets created_at when {method: "insert"} is passed as option', function() {
+        it('sets created_at and updated_at when {method: "insert"} is passed as option', function() {
           m.sync = function() {
             expect(this.get('created_at')).to.be.a('date');
             expect(this.get('updated_at')).to.be.a('date');

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1133,36 +1133,6 @@ module.exports = function(bookshelf) {
       })
     });
 
-    describe('timestamp', function() {
-      it('will set the `updated_at` attribute to a date, and the `created_at` for new entries', function() {
-        var newModel      = new bookshelf.Model({}, {hasTimestamps: true});
-        var existingModel = new bookshelf.Model({id: 1}, {hasTimestamps: true});
-        newModel.timestamp();
-        existingModel.timestamp();
-
-        expect(newModel.get('created_at')).to.be.an.instanceOf(Date);
-        expect(newModel.get('updated_at')).to.be.an.instanceOf(Date);
-        expect(existingModel.get('created_at')).to.not.exist;
-        expect(existingModel.get('updated_at')).to.be.an.instanceOf(Date);
-      });
-
-      it('will set the `created_at` when inserting new entries', function() {
-        var model = new bookshelf.Model({id: 1}, {hasTimestamps: true});
-        model.timestamp({method: 'insert'});
-
-        expect(model.get('created_at')).to.be.an.instanceOf(Date);
-        expect(model.get('updated_at')).to.be.an.instanceOf(Date);
-      });
-
-      it('will not set timestamps on a model without `setTimestamps` set to true', function () {
-        var model = new bookshelf.Model();
-        model.timestamp();
-
-        expect(model.get('created_at')).to.not.exist;
-        expect(model.get('updated_at')).to.not.exist;
-      });
-    });
-
     describe('defaults', function() {
       it('assigns defaults on save, rather than initialize', function() {
         var Item = bookshelf.Model.extend({defaults: {item: 'test', json: {key1: 'defaultValue1', key2: 'defaultValue2'}}});

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -958,172 +958,169 @@ module.exports = function(bookshelf) {
         });
       });
 
-      it('will set the created_at and updated_at columns if true', function() {
-        var m = new (bookshelf.Model.extend({hasTimestamps: true}))();
-        m.sync = function() {
-          equal(this.get('item'), 'test');
-          equal(_.isDate(this.get('created_at')), true);
-          equal(_.isDate(this.get('updated_at')), true);
-          return stubSync;
-        };
+      describe('On update', function() {
+        it('does not set created_at when {method: "update"} is passed as option to save', function() {
+          var m = new bookshelf.Model(null, {hasTimestamps: true});
+          m.sync = function() {
+            expect(this.get('created_at')).to.be.undefined;
+            expect(this.get('updated_at')).to.be.a('date');
+            return stubSync;
+          };
 
-        return m.save({item: 'test'});
-      });
+          return m.save({item: 'test'}, {method: 'update'});
+        });
 
-      it('will set the created_at and updated_at columns to provided time', function() {
-        var dateInThePast = new Date(1999, 1, 1);
-        var m = new (bookshelf.Model.extend({hasTimestamps: true}))();
-        m.sync = function() {
-          equal(this.get('item'), 'test');
-          equal(this.get('created_at').toISOString(), dateInThePast.toISOString());
-          equal(this.get('updated_at').toISOString(), dateInThePast.toISOString());
-          return stubSync;
-        };
+        it('will update the updated_at timestamp if user doesn\'t set a value for it', function() {
+          var admin = new Models.Admin();
+          var originalDate;
 
-        return m.save({item: 'test'}, { date: dateInThePast });
-      });
+          return admin.save().then(function(savedAdmin) {
+            originalDate = savedAdmin.get('updated_at');
 
-      it('only sets the updated_at for existing models', function() {
-        var m1 = new (bookshelf.Model.extend({hasTimestamps: true}))();
-        m1.sync = function() {
-          equal(this.get('item'), 'test');
-          equal(_.isDate(this.get('updated_at')), true);
-          return stubSync;
-        };
+            return Promise.delay(100).then(function() {
+              return savedAdmin.save('username', 'pablo');
+            });
+          }).then(function(updatedAdmin) {
+            expect(updatedAdmin.get('updated_at')).to.not.be.eql(originalDate);
+          });
+        });
 
-        return m1.save({item: 'test'});
-      });
+        it('will not update the updated_at timestamp if the model hasn\'t changed', function() {
+          var admin = new Models.Admin();
+          var originalDate;
 
-      it('allows passing hasTimestamps in the options hash', function() {
+          return admin.save().then(function(savedAdmin) {
+            originalDate = savedAdmin.get('updated_at');
+
+            return Promise.delay(100).then(function() {
+              return savedAdmin.save();
+            });
+          }).then(function(updatedAdmin) {
+            expect(updatedAdmin.get('updated_at')).to.be.eql(originalDate);
+          });
+        });
+
+        it('will set the updated_at timestamp to the user supplied value', function() {
+          var admin = new Models.Admin();
+          var oldUpdatedAt;
+          var newUpdatedAt = new Date();
+          newUpdatedAt.setMinutes(newUpdatedAt.getMinutes() + 1);
+
+          return admin.save().then(function(savedAdmin) {
+            oldUpdatedAt = savedAdmin.get('updated_at');
+            return savedAdmin.save('updated_at', newUpdatedAt);
+          }).then(function(updatedAdmin) {
+            expect(updatedAdmin.get('updated_at')).to.be.eql(newUpdatedAt);
+            expect(updatedAdmin.get('updated_at')).to.not.be.eql(oldUpdatedAt);
+          });
+        });
+
+        it('will not change the existing created_at timestamp if user doesn\'t set a value for it', function() {
+          var model = new Models.Admin();
+          var createdAt;
+
+          return model.save().then(function(savedAdmin) {
+            createdAt = savedAdmin.get('created_at');
+            return savedAdmin.save('username', 'pablo');
+          }).then(function(updatedAdmin) {
+            expect(updatedAdmin.get('created_at')).to.be.eql(createdAt);
+          });
+        });
+
+        it('will set the created_at timestamp to the user supplied value', function() {
+          var admin = new Models.Admin();
+          var oldCreatedAt;
+          var newCreatedAt = new Date();
+          newCreatedAt.setMinutes(newCreatedAt.getMinutes() + 1);
+
+          return admin.save().then(function(savedAdmin) {
+            oldCreatedAt = savedAdmin.get('created_at');
+            return admin.save('created_at', newCreatedAt);
+          }).then(function(updatedAdmin) {
+            expect(updatedAdmin.get('created_at')).to.be.eql(newCreatedAt);
+            expect(updatedAdmin.get('created_at')).to.be.not.eql(oldCreatedAt);
+          });
+        });
+      })
+
+      describe('On insert', function() {
+        it('sets created_at when {method: "insert"} is passed as option', function() {
+          var m = new bookshelf.Model(null, {hasTimestamps: true});
+          m.sync = function() {
+            expect(this.get('created_at')).to.be.a('date');
+            expect(this.get('updated_at')).to.be.a('date');
+            return stubSync;
+          };
+
+          return m.save({id: 1, item: 'test'}, {method: 'insert'});
+        });
+
+        it('will set the created_at and updated_at columns if true', function() {
+          var m = new (bookshelf.Model.extend({hasTimestamps: true}))();
+          m.sync = function() {
+            expect(this.get('created_at')).to.be.a('date');
+            expect(this.get('updated_at')).to.be.a('date');
+            return stubSync;
+          };
+
+          return m.save({item: 'test'});
+        });
+
+        it('will set the timestamps columns to provided time in date option', function() {
+          var dateInThePast = new Date(1999, 1, 1);
+          var m = new (bookshelf.Model.extend({hasTimestamps: true}))();
+          m.sync = function() {
+            equal(this.get('created_at').toISOString(), dateInThePast.toISOString());
+            equal(this.get('updated_at').toISOString(), dateInThePast.toISOString());
+            return stubSync;
+          };
+
+          return m.save({item: 'test'}, {date: dateInThePast});
+        });
+      })
+
+      it('allows passing hasTimestamps in the options hash of model instantiation', function() {
         var m = new bookshelf.Model(null, {hasTimestamps: true});
         m.sync = function() {
-          equal(this.get('item'), 'test');
-          equal(_.isDate(this.get('created_at')), true);
-          equal(_.isDate(this.get('updated_at')), true);
+          expect(this.get('created_at')).to.be.a('date');
+          expect(this.get('updated_at')).to.be.a('date');
           return stubSync;
         };
 
         return m.save({item: 'test'});
       });
 
-      it('allows custom keys for the created at & update at values', function() {
+      it('allows custom keys for the created and updated values', function() {
         var m = new bookshelf.Model(null, {hasTimestamps: ['createdAt', 'updatedAt']});
         m.sync = function() {
-          equal(this.get('item'), 'test');
-          equal(_.isDate(this.get('createdAt')), true);
-          equal(_.isDate(this.get('updatedAt')), true);
+          expect(this.get('createdAt')).to.be.a('date');
+          expect(this.get('updatedAt')).to.be.a('date');
           return stubSync;
         };
 
         return m.save({item: 'test'});
       });
 
-      it('does not set created_at when {method: "update"} is passed', function() {
-        var m = new bookshelf.Model(null, {hasTimestamps: true});
-        m.sync = function() {
-          equal(this.get('item'), 'test');
-          equal(_.isDate(this.get('created_at')), false);
-          equal(_.isDate(this.get('updated_at')), true);
-          return stubSync;
-        };
-
-        return m.save({item: 'test'}, {method: 'update'});
-      });
-
-      it('sets created_at when {method: "insert"} is passed', function() {
-        var m = new bookshelf.Model(null, {hasTimestamps: true});
-        m.sync = function() {
-          equal(this.id, 1);
-          equal(this.get('item'), 'test');
-          equal(_.isDate(this.get('created_at')), true);
-          equal(_.isDate(this.get('updated_at')), true);
-          return stubSync;
-        };
-
-        return m.save({id: 1, item: 'test'}, {method: 'insert'});
-      });
-
-      it('will accept a falsy value as an option for created and ignore it', function() {
+      it('will accept a falsy value as an option for the updated key name to ignore it', function() {
         var m = new bookshelf.Model(null, {hasTimestamps: ['createdAt', null]});
         m.sync = function() {
-          equal(this.get('item'), 'test');
-          equal(_.isDate(this.get('createdAt')), true);
-          equal(_.isDate(this.get('updatedAt')), false);
+          expect(this.get('createdAt')).to.be.a('date');
+          expect(this.get('updatedAt')).to.be.undefined;
           return stubSync;
         };
 
         return m.save({item: 'test'});
       });
 
-      it('will accept a falsy value as an option for updated and ignore it', function() {
+      it('will accept a falsy value as an option for the created key to ignore it', function() {
         var m = new bookshelf.Model(null, {hasTimestamps: [null, 'updatedAt']});
         m.sync = function() {
-          equal(this.get('item'), 'test');
-          equal(_.isDate(this.get('updatedAt')), true);
-          equal(_.isDate(this.get('createdAt')), false);
+          expect(this.get('updatedAt')).to.be.a('date');
+          expect(this.get('createdAt')).to.be.undefined;
           return stubSync;
         };
 
         return m.save({item: 'test'});
-      });
-
-      it('will save a new updated_at timestamp if passed as parameter', function() {
-        var model = new Models.Admin();
-        var oldUpdatedAt = null;
-        var newUpdatedAt = new Date();
-        newUpdatedAt.setMinutes(newUpdatedAt.getMinutes() + 1);
-
-        return model.save().then(function(m) {
-          oldUpdatedAt = m.get('updated_at');
-          return model.save('updated_at',newUpdatedAt);
-        })
-        .then(function(m) {
-          expect(m.get('updated_at')).to.be.eql(newUpdatedAt);
-          expect(m.get('updated_at')).to.be.not.eql(oldUpdatedAt);
-        });
-      });
-
-      it('will save the updated_at timestamp with current time, if updated_at column is not passed as attributed', function() {
-        var model = new Models.Admin();
-        var updatedAt = null;
-
-        return model.save().then(function(m) {
-          updatedAt = m.get('updated_at');
-          return Promise.delay(100).then(function () {
-            return m.save('username', 'pablo');
-          });
-        }).then(function(fin) {
-          expect(fin.get('updated_at')).to.be.not.eql(updatedAt);
-        });
-      });
-
-      it('will save a new created_at timestamp if passed as parameter', function() {
-        var model = new Models.Admin();
-        var oldCreatedAt = null;
-        var newCreatedAt = new Date();
-        newCreatedAt.setMinutes(newCreatedAt.getMinutes() + 1);
-
-        return model.save().then(function(m) {
-          oldCreatedAt = m.get('created_at');
-          return model.save('created_at',newCreatedAt);
-        })
-        .then(function(m) {
-          expect(m.get('created_at')).to.be.eql(newCreatedAt);
-          expect(m.get('created_at')).to.be.not.eql(oldCreatedAt);
-        });
-      });
-
-      it('will save the created_at timestamp with current time, if created_at column is not passed as attribute', function() {
-        var model = new Models.Admin();
-        var createdAt = null
-
-        return model.save().then(function(m) {
-          createdAt = m.get('created_at');
-          return m.save('username','pablo');
-        })
-        .then(function(fin) {
-          expect(fin.get('created_at')).to.be.eql(createdAt);
-        });
       });
 
       it('will not set timestamps on the model if the associated columns are ommitted in fetch', function() {

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1103,17 +1103,6 @@ module.exports = function(bookshelf) {
 
           return m.save({item: 'test', updated_at: userDate});
         })
-
-        it('will set the timestamps columns to provided time in date option', function() {
-          var dateInThePast = new Date(1999, 1, 1);
-          m.sync = function() {
-            equal(this.get('created_at').toISOString(), dateInThePast.toISOString());
-            equal(this.get('updated_at').toISOString(), dateInThePast.toISOString());
-            return stubSync;
-          };
-
-          return m.save({item: 'test'}, {date: dateInThePast});
-        });
       })
 
       it('allows passing hasTimestamps in the options hash of model instantiation', function() {

--- a/test/unit/sql/model.js
+++ b/test/unit/sql/model.js
@@ -8,7 +8,7 @@ var basePath = process.cwd();
 module.exports = function() {
   var Model = require(path.resolve(basePath + '/lib/model'));
 
-  describe('SQL Model', function() {
+  describe('Model', function() {
     describe('#save', function() {
       it('should clone the passed in `options` object', function() {
         var model = new Model();
@@ -29,6 +29,40 @@ module.exports = function() {
         return model.save(null, options).then(function() {
           equal(_.difference(Object.keys(options), ['query']).length, 0);
         });
+      });
+    });
+
+    describe('#timestamp', function() {
+      it('will set the updated_at and the created_at attributes to a new date for new models', function() {
+        var newModel = new Model({}, {hasTimestamps: true});
+        newModel.timestamp();
+
+        expect(newModel.get('created_at')).to.be.an.instanceOf(Date);
+        expect(newModel.get('updated_at')).to.be.an.instanceOf(Date);
+      });
+
+      it('will not set the created_at attribute to a new date for existing models', function() {
+        var existingModel = new Model({id: 1}, {hasTimestamps: true});
+        existingModel.timestamp();
+
+        expect(existingModel.get('created_at')).to.be.undefined;
+        expect(existingModel.get('updated_at')).to.be.an.instanceOf(Date);
+      });
+
+      it('will set the created_at attribute when inserting new models with a predefined id value', function() {
+        var model = new Model({id: 1}, {hasTimestamps: true});
+        model.timestamp({method: 'insert'});
+
+        expect(model.get('created_at')).to.be.an.instanceOf(Date);
+        expect(model.get('updated_at')).to.be.an.instanceOf(Date);
+      });
+
+      it('will not set timestamps on a model if hasTimestamps isn\'t set', function () {
+        var model = new Model();
+        model.timestamp();
+
+        expect(model.get('created_at')).to.not.exist;
+        expect(model.get('updated_at')).to.not.exist;
       });
     });
   });


### PR DESCRIPTION
* Previous PRs: #1710, #1607, #1592, #1583 

## Introduction

This cleans up the previous implementations of the automatic timestamps logic.

It also changes the existing functionality so that saving a model that hasn't changed will not update its `updated_at` attribute as discussed in #1710.

Passing `date` in the options to `save()` is also deprecated.

All the documentation regarding this feature is updated and new examples are added to further explain it.

Closes #1710.

## Motivation

The previous PRs introduced valuable functionality but were overly complicated in their implementations or introduced bugs in the way this feature was expected to work. The current solution behaves like the Rails ActiveRecord's counterpart.

In #1710 the general idea was good, but it introduced a bug that would lead to `created_at` always getting updated with a new value whenever a model was updated, and the bugs around `editCreatedAt` that were mentioned there are not valid anymore since those options are removed.

With PR #1607 it was possible to prevent a model's timestamp attributes from being updated by user values, but this can easily be achieved using other methods, like unsetting the attributes before saving. It also introduced (along with #1583) the ability to update the timestamps with user supplied values, which was good, but the implementation was a bit spread out throughout the code base and too complicated, and in the case of #1583 it introduced a bug that prevented the `updated_at` attribute from being automatically updated in some cases.

The ability to pass a `date` in the options to `save()` that was introduced in #1592 is redundant since the same thing can easily be achieved with existing methods, so it was deprecated.

## Proposed solution

This will prioritize user defined values for the `created_at` and `updated_at` timestamps over any other considerations, so it's always possible to update these values directly.

If no user defined values are provided for these attributes they will be automatically set. If the model is new both of them will be set to the current date. This also works if the model being saved is new but already includes the id attribute, because in this case the `{method: 'insert'}` option is passed to the `save()` call.

If the model is not new only the `updated_at` attribute will be automatically updated.

The `options.date` functionality of `.save()` to set both timestamp attributes with the same value is deprecated and will be removed in the next version. It's already possible to achieve the same effect by setting the timestamp attributes with the wanted values and saving.

## Current PR Issues

Breaks backwards compatibility if users are abusing this feature to only update the `updated_at` attribute of a model without doing any further changes, but the same effect can be easily achieved with:

```js
// Before
myModel.save() // updated_at got updated to the current date

// Now
myModel.save({updated_at: new Date()})
```
