### PR TITLE
Add note on needing the Pagination plugin to use fetchPage()

### DIFF
--- a/docs/bookshelf.js.html
+++ b/docs/bookshelf.js.html
@@ -96,7 +96,7 @@ module.exports = require('./lib/bookshelf').default;
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/docs/src_base_collection.js.html
+++ b/docs/src_base_collection.js.html
@@ -886,7 +886,7 @@ module.exports = CollectionBase;
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/docs/src_base_events.js.html
+++ b/docs/src_base_events.js.html
@@ -215,7 +215,7 @@ export default class Events extends EventEmitter {
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/docs/src_base_model.js.html
+++ b/docs/src_base_model.js.html
@@ -920,7 +920,7 @@ module.exports = ModelBase;
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/docs/src_bookshelf.js.html
+++ b/docs/src_bookshelf.js.html
@@ -459,7 +459,7 @@ export default Bookshelf;
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/docs/src_collection.js.html
+++ b/docs/src_collection.js.html
@@ -546,7 +546,7 @@ export default BookshelfCollection;
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/docs/src_model.js.html
+++ b/docs/src_model.js.html
@@ -1540,7 +1540,7 @@ module.exports = BookshelfModel;
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/docs/src_plugins_case-converter.js.html
+++ b/docs/src_plugins_case-converter.js.html
@@ -134,7 +134,7 @@ module.exports = function caseConverter(bookshelf) {
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/docs/src_plugins_pagination.js.html
+++ b/docs/src_plugins_pagination.js.html
@@ -106,6 +106,8 @@ const DEFAULT_PAGE = 1;
 module.exports = function paginationPlugin (bookshelf) {
   const Model = bookshelf.Model;
   /**
+   * In order to use this function, you must have the {@link https://github.com/bookshelf/bookshelf/wiki/Plugin:-Pagination Pagination} plugin installed.
+   *
    * @method Model#fetchPage
    * @belongsTo Model
    *
@@ -309,7 +311,7 @@ module.exports = function paginationPlugin (bookshelf) {
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/docs/src_plugins_processor.js.html
+++ b/docs/src_plugins_processor.js.html
@@ -172,7 +172,7 @@ module.exports = function processorPlugin(bookshelf) {
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/docs/src_relation.js.html
+++ b/docs/src_relation.js.html
@@ -845,7 +845,7 @@ const pivotHelpers = {
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/docs/src_sync.js.html
+++ b/docs/src_sync.js.html
@@ -315,7 +315,7 @@ module.exports = Sync;
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/index.html
+++ b/index.html
@@ -4518,7 +4518,7 @@ the options to the <code>fetchAll</code> call.</p>
 
           
               
-<div class="method no-description">
+<div class="method has-description">
     
 
         <h4 id="Model-instance-fetchPage" class="item-header">
@@ -4680,6 +4680,10 @@ the options to the <code>fetchAll</code> call.</p>
         
   </div>
 
+  
+    <div class="item-description">
+        <p>In order to use this function, you must have the <a href="https://github.com/bookshelf/bookshelf/wiki/Plugin:-Pagination">Pagination</a> plugin installed.</p>
+    </div>
   
 </div>
 
@@ -9430,7 +9434,7 @@ supplied values will be used instead.</p>
 
 
 <span class="param-desc">
-  <p>Promise<mixed[]>
+  <p>Promise&lt;mixed[]&gt;
   A promise resolving the the resolved return values of any triggered handlers.</p>
 </span>
 
@@ -17785,7 +17789,7 @@ or <code>belongsToMany</code>, &quot;through&quot; an <code>Interim</code> model
 
 
 <span class="param-desc">
-  <p>Promise<mixed[]>
+  <p>Promise&lt;mixed[]&gt;
   A promise resolving the the resolved return values of any triggered handlers.</p>
 </span>
 
@@ -19665,7 +19669,7 @@ callback.</p>
 
 
 <span class="param-desc">
-  <p>Promise<mixed[]>
+  <p>Promise&lt;mixed[]&gt;
   A promise resolving the the resolved return values of any triggered handlers.</p>
 </span>
 
@@ -20163,7 +20167,7 @@ event handlers (for validations, etc).</p>
           <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a>
           
             on
-          March 26th 2018
+          March 28th 2018
         </div>
         <div>
           <a href="https://github.com/aral/fork-me-on-github-retina-ribbons">

--- a/src/plugins/pagination.js
+++ b/src/plugins/pagination.js
@@ -32,6 +32,8 @@ const DEFAULT_PAGE = 1;
 module.exports = function paginationPlugin (bookshelf) {
   const Model = bookshelf.Model;
   /**
+   * In order to use this function, you must have the {@link https://github.com/bookshelf/bookshelf/wiki/Plugin:-Pagination Pagination} plugin installed.
+   *
    * @method Model#fetchPage
    * @belongsTo Model
    *


### PR DESCRIPTION
* Related Issues: #1358

## Introduction

This adds a note on needing the Pagination plugin to use the `fetchPage()` function. 

## Motivation

I needed to paginate the results of a query for a project I was doing. So I did a Ctrl-F through the main Bookshelf docs page and the first result was a link on the sidebar to the main documentation section for the `fetchPage` function. I thought "cool, this is exactly what I need" and tried it out in my code. But it didn't work. I just got the `fetchPage is not a function` error. So I did some googling around and found issue #1358. That issue yielded the solution that a plugin was needed. I tried that out and it worked. 

Admittedly the docs page does mention in several places that the plugin is needed. But, I think adding this note onto the function documentation would be useful. 

## Proposed solution

Add a note to the method documentation. 