### PR TITLE
Add note on needing the Pagination plugin to use fetchPage()

### DIFF
--- a/src/plugins/pagination.js
+++ b/src/plugins/pagination.js
@@ -32,6 +32,10 @@ const DEFAULT_PAGE = 1;
 module.exports = function paginationPlugin (bookshelf) {
   const Model = bookshelf.Model;
   /**
+   * In order to use this function, you must have the {@link
+   * https://github.com/bookshelf/bookshelf/wiki/Plugin:-Pagination Pagination}
+   * plugin installed.
+   *
    * @method Model#fetchPage
    * @belongsTo Model
    *


### PR DESCRIPTION
* Related Issues: #1358
* Previous PRs: #1801 

## Introduction

This adds a note on needing the Pagination plugin to use the `fetchPage()` function. 

This pull request is a followup to #1801 asking me to open a new PR into the master branch.

## Motivation

I needed to paginate the results of a query for a project I was doing. So I did a Ctrl-F through the main Bookshelf docs page and the first result was a link on the sidebar to the main documentation section for the `fetchPage` function. I thought "cool, this is exactly what I need" and tried it out in my code. But it didn't work. I just got the `fetchPage is not a function` error. So I did some googling around and found issue #1358. That issue yielded the solution that a plugin was needed. I tried that out and it worked. 

Admittedly the docs page does mention in several places that the plugin is needed. But, I think adding this note onto the function documentation would be useful. 

## Proposed solution

Add a note to the method documentation. 