### PR TITLE
Fix timestamp() setting a key named "null" in some cases

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -647,7 +647,7 @@ ModelBase.prototype.timestamp = function(options) {
 
   if (options && options.date) deprecate('options.date', 'the model\'s timestamp attributes to set these values')
 
-  if (isNewModel && !setUpdatedAt || this.hasChanged() && !setUpdatedAt) {
+  if (updatedAtKey && (isNewModel && !setUpdatedAt || this.hasChanged() && !setUpdatedAt)) {
     attributes[updatedAtKey] = now;
   }
 

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1188,6 +1188,16 @@ module.exports = function(bookshelf) {
         return m.save({item: 'test'});
       });
 
+      it('will not set an attribute named "null" when passing a literal null as a key name', function() {
+        var m = new bookshelf.Model(null, {hasTimestamps: ['createdAt', null]});
+        m.sync = function() {
+          expect(this.get('null')).to.be.undefined;
+          return stubSync;
+        };
+
+        return m.save({item: 'test'});
+      })
+
       it('will accept a falsy value as an option for the created key to ignore it', function() {
         var m = new bookshelf.Model(null, {hasTimestamps: [null, 'updatedAt']});
         m.sync = function() {


### PR DESCRIPTION
* Previous PRs: #1798

## Introduction

The previous PR introduced a bug where a model could end up with a key named "null" if the user specified a custom `hasTimestamps` value that included a literal `null` as the second key name. This would lead to a SQL error complaining about a nonexistent column named "null" or "undefined".  

## Proposed solution

This checks if a `updatedAt` key exists first before attempting any other comparisons. The problem was in [the first condition](https://github.com/bookshelf/bookshelf/blob/3508288b8f22c3f73def3e73e35c2e117321682a/src/base/model.js#L650) that would incorrectly return `true` if the key hadn't been set, even though it should only be checking if it had been set by the user.
