### PR TITLE
Add more helpful error messages on bad or insufficient morphTo data

### DIFF
--- a/src/eager.js
+++ b/src/eager.js
@@ -45,10 +45,17 @@ export default class EagerRelation extends EagerBase {
       typeColumn = `${morphName}_type`, idColumn = `${morphName}_id`
     ] = columnNames;
 
-    const parentsByType = _.groupBy(this.parent, model => model.get(typeColumn));
-    const TargetByType = _.mapValues(parentsByType, (parents, type) =>
-      Helpers.morphCandidate(relatedData.candidates, type)
-    );
+    const parentsByType = _.groupBy(this.parent, model => {
+      const type = model.get(typeColumn);
+
+      if (!type)
+        throw new Error('The target polymorphic model could not be determined because it\'s missing the type attribute')
+
+      return type
+    });
+    const TargetByType = _.mapValues(parentsByType, (parents, type) => {
+      return Helpers.morphCandidate(relatedData.candidates, type)
+    });
 
     return Promise.all(_.map(parentsByType, (parents, type) => {
       const Target = TargetByType[type];

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -21,13 +21,14 @@ const helpers = {
     return model.set(model.parse(data));
   },
 
-  // Finds the specific `morphTo` table we should be working with, or throws
+  // Finds the specific `morphTo` target Model we should be working with, or throws
   // an error if none is matched.
   morphCandidate: function(candidates, morphValue) {
-    const [Target] = _.find(candidates, ([,tableName]) => tableName === morphValue);
-    if (!Target) {
-      throw new Error('The target polymorphic model was not found');
-    }
+    const [Target] = _.find(candidates, ([,tableName]) => tableName === morphValue) || [];
+
+    if (!Target)
+      throw new Error('The target polymorphic type "' + morphValue + '" is not one of the defined target types');
+
     return Target;
   },
 

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -708,6 +708,27 @@ module.exports = function(Bookshelf) {
             var expectedMessage = 'The target polymorphic model could not be determined because it\'s missing the ' +
                                   'type attribute'
             expect(error.message).to.equal(expectedMessage)
+          }).finally(function() {
+            return Photo.where('imageable_type', null).destroy({require: false})
+          })
+        })
+
+        it('throws an error if the type attribute is not one of the expected types', function() {
+          var badType = 'not the one'
+
+          return Bookshelf.knex('photos').insert({
+            caption: 'a caption',
+            imageable_id: 1,
+            imageable_type: badType
+          }).then(function() {
+            return Photo.fetchAll({withRelated: ['imageable']})
+          }).then(function(photos) {
+            expect(photos).to.be.undefined
+          }).catch(function(error) {
+            var expectedMessage = 'The target polymorphic type "' + badType + '" is not one of the defined target types'
+            expect(error.message).to.equal(expectedMessage)
+          }).finally(function() {
+            return Photo.where('imageable_type', badType).destroy({require: false})
           })
         })
       });

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -698,6 +698,18 @@ module.exports = function(Bookshelf) {
         it('eager loads beyond the morphTo with custom columnNames, where possible', function() {
           return Thumbnail.fetchAll({withRelated: ['imageable.authors']}).tap(checkTest(this));
         });
+
+        it('throws an error if the type attribute is not defined', function() {
+          return Bookshelf.knex('photos').insert({caption: 'a caption', imageable_id: 1}).then(function() {
+            return Photo.fetchAll({withRelated: ['imageable']})
+          }).then(function(photos) {
+            expect(photos).to.be.undefined;
+          }).catch(function(error) {
+            var expectedMessage = 'The target polymorphic model could not be determined because it\'s missing the ' +
+                                  'type attribute'
+            expect(error.message).to.equal(expectedMessage)
+          })
+        })
       });
 
       describe('`through` relations', function() {


### PR DESCRIPTION
* Previous PRs: #656

## Introduction

This adds more descriptive error messages when eager loading morphTo relations with bad or insufficient data.

## Motivation

The current error is only thrown when the defined morph type can't be found in any of the possible target types, but the message is a bit ambiguous because it only says that the target model can't be found.

Additionally the changes proposed in the previous PR would introduce other potential issues. It's also not very clear that having a different behavior for a polymorphic relation when calling `.related()` is a bad thing, as argued in that PR, since polymorphic relations are a bit different from the others.

That PR also didn't include tests and its author was not responding.

## Proposed solution

This adds an earlier check to see if the type attribute is set at all on the model and throws an error if it isn't. This is done before even attempting to find the target model from the defined target types.

The error message in case a valid target is not found is also reworded to make it clearer.

This is a breaking change since the existing error message is different and there is a new error being thrown.

Closes #656.

## Current PR Issues

There is no check to see if the target id is set on the model since `NULL` can be a valid value, although it probably isn't. This check can easily be added in the future if needed.
