### PR TITLE
Fix incorrect output ordering in tests in some cases

### DIFF
--- a/test/integration/helpers/index.js
+++ b/test/integration/helpers/index.js
@@ -16,3 +16,23 @@ exports.countModels = function countModels(Model, options) {
     });
   }
 }
+
+exports.sort = function sort(model) {
+  var sorted = {}
+
+  for (var attribute in model) {
+    sorted[attribute] = this.sortCollection(model[attribute])
+  }
+
+  return sorted
+}
+
+exports.sortCollection = function sortCollection(collection) {
+  if (!Array.isArray(collection)) return collection
+
+  collection.sort(function(model1, model2) {
+    return model1.id - model2.id
+  })
+
+  return collection.map(this.sort, exports)
+}

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -1,12 +1,19 @@
-var Promise   = global.testPromise;
-var equal     = require('assert').equal;
+var Promise = global.testPromise;
+var equal = require('assert').equal;
+var helpers = require('./helpers')
 
 module.exports = function(Bookshelf) {
   describe('Relations', function() {
     var output  = require('./output/Relations');
     var dialect = Bookshelf.knex.client.dialect;
     var json    = function(model) {
-      return JSON.parse(JSON.stringify(model));
+      model = model.toJSON()
+
+      if (Array.isArray(model))  {
+        return helpers.sortCollection(model)
+      }
+
+      return helpers.sort(model)
     };
     var checkTest = function(ctx) {
       return function(resp) {


### PR DESCRIPTION
* Related Issues: #426
* Previous PRs: #1800

## Introduction

This ensures that output from database tests are ordered by model id.

## Motivation

Some tests require that the output is exactly the same as some predefined values. However, the previous PR mentioned above introduced a change that caused output ordering to be changed on PostgreSQL, even though the data is exactly the same.

There shouldn't be any need to check for ordering of results unless that is the intended purpose of a specific test.

## Proposed solution

This just orders models inside collections by id after they are fetched from the database. This application side approach was chosen to avoid changing all the affected tests.
