### PR TITLE
Undeprecate options.date argument to timestamp

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -1,7 +1,6 @@
 // Base Model
 // ---------------
 import _, { assign, identity, mapKeys, mapValues, clone } from 'lodash';
-import {deprecate} from '../helpers';
 import inherits from 'inherits';
 import Events from './events';
 import {PIVOT_PREFIX, DEFAULT_TIMESTAMP_KEYS} from '../constants';
@@ -633,6 +632,9 @@ ModelBase.prototype.getTimestampKeys = function() {
  * @param {string} [options.method]
  *   Either `'insert'` or `'update'` to specify what kind of save the attribute
  *   update is for.
+ * @param {string} [options.date]
+ *   Either a Date object or ms since the epoch. Specify what date is used for
+ *   updateing the timestamps, i.e. if something other than `new Date()` should be used.
  * @returns {Object} A hash of timestamp attributes that were set.
  */
 ModelBase.prototype.timestamp = function(options) {
@@ -644,8 +646,6 @@ ModelBase.prototype.timestamp = function(options) {
   const [createdAtKey, updatedAtKey] = this.getTimestampKeys();
   const isNewModel = method === 'insert';
   const setUpdatedAt = updatedAtKey && this.hasChanged(updatedAtKey)
-
-  if (options && options.date) deprecate('options.date', 'the model\'s timestamp attributes to set these values')
 
   if (isNewModel && !setUpdatedAt || this.hasChanged() && !setUpdatedAt) {
     attributes[updatedAtKey] = now;

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1153,6 +1153,17 @@ module.exports = function(bookshelf) {
 
           return m.save({item: 'test', updated_at: userDate});
         })
+
+        it('will set the timestamps columns to provided time in date option', function() {
+          var dateInThePast = new Date(1999, 1, 1);
+          m.sync = function() {
+            equal(this.get('created_at').toISOString(), dateInThePast.toISOString());
+            equal(this.get('updated_at').toISOString(), dateInThePast.toISOString());
+            return stubSync;
+          };
+
+          return m.save({item: 'test'}, {date: dateInThePast});
+        });
       })
 
       it('allows passing hasTimestamps in the options hash of model instantiation', function() {


### PR DESCRIPTION
* Previous PRs: #1798 

## Introduction

`options.date` has been deprecated in #1798. This PR reverts this.

## Motivation

See discussion at the end of #1798 

## Proposed solution

Revert the deprecation.