### PR TITLE
Make collection iterable using for of loops

### DIFF
--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -601,6 +601,11 @@ CollectionBase.prototype._reset = function() {
   this._byId  = Object.create(null);
 };
 
+// Make collection iterable in for of loops
+CollectionBase.prototype[Symbol.iterator] = function*() {
+  yield * this.models
+}
+
 /**
  * @method CollectionBase#forEach
  * @see http://lodash.com/docs/#forEach

--- a/test/base/tests/collection.js
+++ b/test/base/tests/collection.js
@@ -29,6 +29,15 @@ module.exports = function() {
       equal(collection.tableName(), 'test_table');
     });
 
+    it('should be iterable', function () {
+      var models = []
+      collection = new Collection([{some_id: 1}, {some_id: 2}]);
+      for (var model of collection) {
+        models.push(model)
+      }
+      equal(models.length, collection.length)
+    })
+
     it('should have an idAttribute method, returning the idAttribute of the model', function() {
       equal(collection.idAttribute(), 'some_id');
     });


### PR DESCRIPTION
* Related Issues: #1816, #1525
* Previous PRs: #1817
## Introduction

Make collections iterable using for of loops.
```js
const models = await bookshelf.model('Model').fetchAll()
// previously
for (const model of models.models) {}

// now
for (const model of models) {}
```

## Motivation

It's nice to be able to use default ECMA functionality when they're non-breaking.

## Proposed solution

Define `CollectionBase.prototype[Symbol.iterator]` and yield to `this.models` (which always defaults to an array)

## Current PR Issues

None that I am aware of

## Alternatives considered

None that I am aware of