### PR TITLE
Rg collection docs

### DIFF
--- a/lib/base/collection.js
+++ b/lib/base/collection.js
@@ -324,15 +324,26 @@ CollectionBase.prototype.invokeThen = function() {
 };
 
 /**
+ * This iterator is used by the reduceThen method to ietrate over all models in the collection.
+ *
+ * @callback Collection~reduceThenIterator
+ * @param {mixed} acumulator
+ * @param {Model} model The current model being iterated over.
+ * @param {Number} index
+ * @param {Number} length Total number of models being iterated over.
+ */
+
+/**
  * @method
  * @description
- * Run "reduce" over the models in the collection.
- * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce | MDN `Array.prototype.reduce` reference.}
- * @param {Function} iterator
+ * Iterate over all the models in the collection and reduce this array to a single value using the
+ * given iterator function.
+ * @see {@link http://bluebirdjs.com/docs/api/promise.reduce.html | Bluebird `Promise.reduce` reference}.
+ * @param {Collection~reduceThenIterator} iterator
  * @param {mixed} initialValue
  * @param {Object} context Bound to `this` in the `iterator` callback.
- * @returns {Promise<mixed[]>}
- *   Promise resolving to array of results from invocation.
+ * @returns {Promise<mixed>}
+ *   Promise resolving to the single result from the reduction.
  *
  */
 CollectionBase.prototype.reduceThen = function(iterator, initialValue, context) {

--- a/lib/base/collection.js
+++ b/lib/base/collection.js
@@ -81,16 +81,31 @@ const setOptions = {add: true, remove: true, merge: true};
 const addOptions = {add: true, remove: false};
 
 /**
+ * @member {Number}
+ * @default 0
+ * @description
+ *
+ * This is the total number of models in the collection. Note that this may not represent how many
+ * models there are in total in the database.
+ *
+ * @example
+ *
+ * var vanHalen = new bookshelf.Collection([eddie, alex, stone, roth]);
+ * console.log(vanHalen.length) // 4
+ */
+CollectionBase.prototype.length = 0;
+
+/**
  * @method CollectionBase#initialize
  * @description
  * Called by the {@link Collection Collection constructor} when creating a new instance.
  * Override this function to add custom initialization, such as event listeners.
  * Because plugins may override this method in subclasses, make sure to call
- * your super (extended) class.  e.g.
+ * your super (extended) class. e.g.
  *
  *     initialize: function() {
- *         this.constructor.__super__.initialize.apply(this, arguments);
- *         // Your initialization code ...
+ *       this.constructor.__super__.initialize.apply(this, arguments);
+ *       // Your initialization code ...
  *     }
  *
  * @see Collection


### PR DESCRIPTION
* Related Issues: #1805, #1021

## Introduction

Fix a few issues with the Collections documentation.

## Motivation

The linked issues contain all the necessary information.

## Proposed solution

In order to document the iterator function of the `reduceThen` method a new callback doclet was added. This isn't exactly a callback, but it is treated as a type definition which is acceptable.

Fixes #1805, fixes #1021.
