### PR TITLE
Fix eager loading of relations when using parse/format

### DIFF
--- a/lib/eager.js
+++ b/lib/eager.js
@@ -91,7 +91,7 @@ class EagerRelation extends EagerBase {
         return new EagerRelation(relatedModels, response, relatedModel).fetch(options).return(response);
       }
     }).tap(() => {
-      return Promise.map(relatedModels, (model) => model.triggerThen('fetched', model, model.attributes, options));
+      return Promise.map(relatedModels, model => model.triggerThen('fetched', model, model.attributes, options));
     });
   }
 

--- a/lib/relation.js
+++ b/lib/relation.js
@@ -403,7 +403,8 @@ const Relation = RelationBase.extend({
     _.each(parentModels, (model) => {
       let groupedKey;
       if (!this.isInverse()) {
-        groupedKey = model.get(this.parentIdAttribute);
+        const parsedKey = Object.keys(model.parse({[this.parentIdAttribute]: null}))[0];
+        groupedKey = model.get(parsedKey);
       } else {
         const keyColumn = this.key(
           this.isThrough() ? 'throughForeignKey': 'foreignKey'

--- a/test/integration/helpers/inserts.js
+++ b/test/integration/helpers/inserts.js
@@ -1,11 +1,9 @@
 var Promise = global.testPromise;
 
 module.exports = function(bookshelf) {
-
   var knex = bookshelf.knex;
 
   return Promise.all([
-
     knex('sites').insert([{
       name: 'knexjs.org'
     }, {
@@ -265,8 +263,11 @@ module.exports = function(bookshelf) {
     knex('backup_types').insert([
       {id: 0, name: 'standard'},
       {id: 1, name: 'enhanced'} // We need to explicitly set the id to 1 otherwise MySQL will get confused
-    ])
+    ]),
 
+    knex('organization').insert({organization_name: 'Test Organization'}),
+
+    knex('members').insert({organization_id: 1}, {organization_id: 2})
   ]).then(function() {
     if (knex.client.dialect !== 'postgresql') return;
 

--- a/test/integration/helpers/migration.js
+++ b/test/integration/helpers/migration.js
@@ -6,7 +6,7 @@ var drops = [
   'photos', 'users_roles', 'info', 'Customer', 'Settings', 'hostnames',
   'instances', 'uuid_test', 'parsed_users', 'tokens', 'thumbnails', 'lefts',
   'rights', 'lefts_rights', 'organization', 'locales', 'translations',
-  'backups', 'backup_types'
+  'backups', 'backup_types', 'members'
 ];
 
 module.exports = function(Bookshelf) {
@@ -171,6 +171,10 @@ module.exports = function(Bookshelf) {
       table.increments('organization_id');
       table.string('organization_name').notNullable();
       table.boolean('organization_is_active').defaultTo(false);
+    })
+    .createTable('members', function(table) {
+      table.increments();
+      table.integer('organization_id').notNullable();
     })
     .createTable('locales', function(table) {
       table.string('isoCode');

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -341,7 +341,6 @@ module.exports = function(Bookshelf) {
 
   var OrgModel = Bookshelf.Model.extend({
     tableName: 'organization',
-    // defaults: { parsedName: '' },
     idAttribute: 'organization_id',
     format: function (fields) {
       var cols = {};
@@ -358,6 +357,10 @@ module.exports = function(Bookshelf) {
       return fields;
     }
   });
+
+  var Member = Bookshelf.Model.extend({
+    tableName: 'members'
+  })
 
   var Translation = Bookshelf.Model.extend({
     tableName: 'translations',
@@ -429,6 +432,7 @@ module.exports = function(Bookshelf) {
       RightModel: RightModel,
       JoinModel: JoinModel,
       OrgModel: OrgModel,
+      Member: Member,
       Locale: Locale,
       Translation: Translation
     }

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -771,14 +771,14 @@ module.exports = function(bookshelf) {
       });
 
       it('Will not break with prefixed id, #583', function() {
-        var acmeOrg = new Models.OrgModel ({name: "ACME, Inc", is_active: true});
+        var acmeOrg = new Models.OrgModel({name: "ACME, Inc", is_active: true});
         var acmeOrg1;
 
         return acmeOrg.save().then(function() {
-          acmeOrg1 = new Models.OrgModel({id: 1})
+          acmeOrg1 = new Models.OrgModel({name: "ACME, Inc"})
           return acmeOrg1.fetch();
         }).then(function() {
-          equal(Number(acmeOrg1.attributes.id), 1);
+          equal(typeof acmeOrg1.get('id'), 'number');
           equal(acmeOrg1.attributes.name, "ACME, Inc");
           equal(acmeOrg1.attributes.organization_id, undefined);
           equal(acmeOrg1.attributes.organization_name, undefined);
@@ -786,7 +786,6 @@ module.exports = function(bookshelf) {
           expect(acmeOrg.attributes.name).to.equal("ACME, Inc");
           // field name needs to be processed through model.parse
           equal(acmeOrg.attributes.organization_id, undefined);
-          expect(Number(acmeOrg.attributes.id)).to.equal(1);
         });
       });
     });

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -44,6 +44,11 @@ module.exports = function(Bookshelf) {
     var JoinModel   = Models.JoinModel;
     var Locale = Models.Locale;
     var Translation = Models.Translation;
+    var Organization = Models.OrgModel.extend({
+      members: function() {
+        return this.hasMany(Models.Member, 'organization_id')
+      }
+    })
 
     describe('Bookshelf Relations', function() {
       describe('Standard Relations - Models', function() {
@@ -240,6 +245,12 @@ module.exports = function(Bookshelf) {
               result.models[0].related('tags').relatedData.parentId.should.eql(1);
           });
         });
+
+        it('when parent model has custom id attribute and a parse method that mutates it', function() {
+          return Organization.forge({id: 1}).fetch({withRelated: ['members']}).then(function(organization) {
+            expect(organization.related('members').length).to.be.above(0);
+          })
+        })
       });
 
       describe('Nested Eager Loading - Models', function() {


### PR DESCRIPTION
* Related Issues: #1502

## Introduction

This fixes eager loading of related models when the parent model had a custom id attribute and a parse/format method that mutated it.

## Motivation

For more info check the linked issue.

## Proposed solution

This just runs the `parentIdAttribute` through that model's `parse` method in order to get the parsed key that is needed for pairing the eager fetched models with their parents.

Fixes #1502.

## Alternatives considered

A better approach would probably be to delay the parsing of model attributes until the very last moment before models are delivered to the user, but that would require a more extensive refactoring of the whole `parse`/`format` functionality that is better suited for a separate task later on.
