### PR TITLE
Empty hasOne relation should return null instead of {} when serialized

### DIFF
--- a/lib/eager.js
+++ b/lib/eager.js
@@ -72,8 +72,9 @@ class EagerRelation extends EagerBase {
 
   // Handles the eager load for both the `morphTo` and regular cases.
   _eagerLoadHelper(response, relationName, handled, options) {
-    const relatedModels = this.pushModels(relationName, handled, response);
-    const relatedData   = handled.relatedData;
+    const relatedData = handled.relatedData;
+    const isEmptyHasOne = response.length === 0 && relatedData.type === 'hasOne';
+    const relatedModels = isEmptyHasOne ? [] : this.pushModels(relationName, handled, response);
 
     return Promise.try(() => {
       // If there is a response, fetch additional nested eager relations, if any.

--- a/lib/model.js
+++ b/lib/model.js
@@ -106,6 +106,9 @@ const BookshelfModel = ModelBase.extend({
    *   than `Target` model's `id` / `{@link Model#idAttribute idAttribute}`.
    *
    * @returns {Model}
+   *
+   *   The return value will always be a model, even if the relation doesn't exist, but in that
+   *   case the relation will be `null` when {@link Model#serialize serializing} the model.
    */
   hasOne(Target, foreignKey, foreignKeyTarget) {
     return this._relation('hasOne', Target, { foreignKey, foreignKeyTarget }).init(this);
@@ -194,6 +197,9 @@ const BookshelfModel = ModelBase.extend({
    *   than `Target` model's `id` / `{@link Model#idAttribute idAttribute}`.
    *
    * @returns {Model}
+   *
+   *   The return value will always be a model, even if the relation doesn't exist, but in that
+   *   case the relation will be `null` when {@link Model#serialize serializing} the model.
    */
   belongsTo(Target, foreignKey, foreignKeyTarget) {
     return this._relation('belongsTo', Target, { foreignKey, foreignKeyTarget }).init(this);

--- a/lib/relation.js
+++ b/lib/relation.js
@@ -329,9 +329,7 @@ const Relation = RelationBase.extend({
 
   // Fetches all `eagerKeys` from the current relation.
   eagerKeys(response) {
-    const key = this.isInverse() && !this.isThrough()
-      ? this.key('foreignKey')
-      : this.parentIdAttribute;
+    const key = this.isInverse() && !this.isThrough() ? this.key('foreignKey') : this.parentIdAttribute;
     return _.reject(_(response).map(key).uniq().value(), _.isNil);
   },
 

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -379,9 +379,6 @@ module.exports = {
       result: {
         id: 3,
         name: 'backbonejs.org',
-        meta: {
-
-        },
         blogs: [],
         authors: []
       }
@@ -390,9 +387,6 @@ module.exports = {
       result: {
         id: 3,
         name: 'backbonejs.org',
-        meta: {
-
-        },
         authors: [],
         blogs: []
       }
@@ -401,9 +395,6 @@ module.exports = {
       result: {
         id: 3,
         name: 'backbonejs.org',
-        meta: {
-
-        },
         blogs: [],
         authors: []
       }

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -91,6 +91,12 @@ module.exports = function(Bookshelf) {
           }).then(checkTest(this));
         });
 
+        it('does not load "hasOne" relationship when it doesn\'t exist (site -> meta)', function() {
+          return new Site({id: 3}).fetch({withRelated: ['meta']}).then(function(site) {
+            expect(site.toJSON()).to.not.have.property('meta')
+          });
+        });
+
         it('eager loads "hasMany" relationships correctly (site -> authors, blogs)', function() {
           return new Site({id: 1}).fetch({
             withRelated: ['authors', 'blogs']


### PR DESCRIPTION
* Related Issues: #1771, #1299, #753
* Previous PRs: #1563

## Introduction

When fetching a model that has a `hasOne` relation and that relation doesn't exist the relation should be `null` when serializing the model. Currently it's an empty object `{}`. 

## Motivation

This makes the `hasOne` relationship behave like `belongsTo` which also exhibited this same unexpected behavior until it was changed with PR #1563. All other relation types continue working the same way, so a `hasMany` without any records is still an empty array `[]` when serialized.

This should make it easier to determine if a `hasOne` relation exists or not since after serialization you can just write:

```js
if (model.singleRelation) { ... }
```

instead of:

```js
if (model.singleRelation && model.singeRelation.id) { ... }
```

## Proposed solution

This changes the eager pairing code to ensure that the relation creation part is skipped if the response from the `SELECT` query that tries to fetch the related data is empty. The eager pairing would run `pushModels()` which would always create relation data on the parent model, even when there is no data, resulting in the empty object that was present before this change.

This is a behavior similar to the `belongsTo` relation, except that that one can be determined much earlier in the eager loading code chain.

Fixes #1771.

## Current PR Issues

This is a breaking change, but it shouldn't cause too much trouble since any existing conditions, as in the example above, will still continue working. Other use cases that attempt to add or read properties directly from the serialized output will break.