### PR TITLE
Add back correct author info

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,12 @@
     "knex": ">=0.6.10 <0.15.0"
   },
   "author": {
-    "name": "Bookshelf",
-    "web": "https://github.com/bookshelf"
+    "name": "Tim Griesser",
+    "url": "https://github.com/tgriesser"
   },
+  "contributors": [
+    {"name": "Ricardo Graça", "url": "https://github.com/ricardograca"}
+  ],
   "license": "MIT",
   "readmeFilename": "README.md",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "url": "https://github.com/tgriesser"
   },
   "contributors": [
+    {"name": "Edward Greve", "url": "https://github.com/anyong"},
+    {"name": "Rhys van der Waerden", "url": "https://github.com/rhys-vdw"},
     {"name": "Ricardo Graça", "url": "https://github.com/ricardograca"}
   ],
   "license": "MIT",


### PR DESCRIPTION
## Introduction

This changes back the author info to Tim Griesser, adding a contributors section as well.

## Motivation

The original author info was removed in 37638ea5545b15a0794898aa3406f8fed9dc032b but Tim Griesser is the original author and most of the current code base was indeed authored by him, so the author info in the package should reflect that.

Additionally all other contributors can and should be acknowledged, and so this change also adds a `contributors` section to `package.json`.

## Proposed solution

For now I only added myself as contributor, but anyone that is interested in appearing in that list should state their intention or open a PR adding themselves in. As long as it's someone that has contributed at least one commit or has helped significantly in any other form. 
