### PR TITLE
Fix once method not passing correct arguments to callback

### DIFF
--- a/lib/base/events.js
+++ b/lib/base/events.js
@@ -118,7 +118,7 @@ class Events extends EventEmitter {
    *   That callback to invoke only once when the event is fired.
    */
   once(name, callback) {
-    const wrapped = _.once(() => {
+    const wrapped = _.once(function() {
       this.off(name, wrapped);
       return callback.apply(this, arguments);
     });

--- a/test/base/tests/events.js
+++ b/test/base/tests/events.js
@@ -1,34 +1,38 @@
-var assert = require('assert');
-var equal = assert.equal;
 var path = require('path');
-var basePath = process.cwd();
 
 module.exports = function() {
-  var Events = require(path.resolve(basePath + '/lib/base/events'));
+  var Events = require(path.resolve(process.cwd(), 'lib/base/events'));
 
   describe('Events', function() {
     var events;
-    var handlersRun;
 
     beforeEach(function() {
       events = new Events();
-      handlersRun = [];
-      events.on('A', eventHandler('A'));
-      events.on('B', eventHandler('B'));
     });
 
-    function eventHandler(event) {
-      return function() {
-        handlersRun.push(event);
-      }
-    }
-
     describe('#off()', function() {
-      it('should deregister multiple, space-separated events', function() {
+      it('should deregister multiple space-separated events', function() {
+        function eventHandler() {
+          throw new Error('Expected event handler to have not been called');
+        }
+
+        events.on('A', eventHandler);
+        events.on('B', eventHandler);
         events.off('A B');
         events.trigger('A');
-        events.trigger('B');
-        equal(handlersRun.length, 0);
+
+        expect(events._eventsCount).to.equal(0);
+      });
+    });
+
+    describe('#trigger()', function() {
+      it('should pass additional arguments to the listener', function() {
+        events.on('event', function(name, arg1, arg2) {
+          expect(name).to.equal('event');
+          expect(arg1).to.equal(1);
+          expect(arg2).to.equal(2);
+        })
+        events.trigger('event', 1, 2);
       });
     });
   });

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -26,6 +26,78 @@ module.exports = function(bookshelf) {
       expect(actual, formatNumber(expected));
     };
 
+    describe('Events', function() {
+      describe('fetching:collection', function() {
+        it('passes the collection as first argument to the listener', function() {
+          var site = new Models.Site();
+
+          site.on('fetching:collection', function(collection) {
+            expect(collection).to.be.an.instanceof(bookshelf.Collection);
+            expect(collection.model).to.eql(Models.Site);
+          });
+
+          return site.fetchAll();
+        })
+
+        it('passes the column definitions to fetch as second argument to the listener', function() {
+          var site = new Models.Site();
+
+          site.on('fetching:collection', function(collection, columns) {
+            expect(columns).to.be.an.instanceof(Array);
+            expect(columns.length).to.be.above(0);
+          });
+
+          return site.fetchAll();
+        })
+
+        it('passes options as third argument to the listener', function() {
+          var site = new Models.Site();
+
+          site.on('fetching:collection', function(collection, columns, options) {
+            expect(options).to.be.an.instanceof(Object);
+            expect(options).to.have.property('query');
+          });
+
+          return site.fetchAll();
+        })
+      })
+
+      describe('fetched:collection', function() {
+        it('passes the collection as first argument to the listener', function() {
+          var site = new Models.Site();
+
+          site.on('fetched:collection', function(collection) {
+            expect(collection).to.be.an.instanceof(bookshelf.Collection);
+            expect(collection.model).to.eql(Models.Site);
+          });
+
+          return site.fetchAll();
+        })
+
+        it('passes the fetched columns as second argument to the listener', function() {
+          var site = new Models.Site();
+
+          site.on('fetched:collection', function(collection, columns) {
+            expect(columns).to.be.an.instanceof(Array);
+            expect(columns.length).to.be.above(0);
+          });
+
+          return site.fetchAll();
+        })
+
+        it('passes options as third argument to the listener', function() {
+          var site = new Models.Site();
+
+          site.on('fetching:collection', function(collection, columns, options) {
+            expect(options).to.be.an.instanceof(Object);
+            expect(options).to.have.property('query');
+          });
+
+          return site.fetchAll();
+        })
+      })
+    })
+
     describe('extend/constructor/initialize', function() {
       var User = bookshelf.Model.extend({
         idAttribute: 'user_id',

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -590,11 +590,9 @@ module.exports = function(bookshelf) {
           isFetchedTriggered = true;
         });
 
-        site.fetchAll().then(function() {
+        return site.fetchAll().then(function() {
           equal(isFetchingTriggered, true);
           equal(isFetchedTriggered, true);
-        }).catch(function() {
-          equal(true, false);
         });
       });
 


### PR DESCRIPTION
* Previous PRs: #1835

## Introduction

This fixes the `.once` method not passing the correct arguments to its callback. This bug is not present in any released versions and is only found in commits after 2ebd1afc4009aefc9ca9423423f6943c0fc783ff.

## Proposed solution

This bug was introduced in the previous PR due to an incorrect conversion of the previous code. Since fat arrow functions don't have their own `arguments` and the use of the rest operator is not possible on Node 4, the changes meant that the arguments being passed were the wrong ones. 

Also fixes one other test case that wasn't returning a Promise as it should, and adds a new `Event#trigger()` unit test for good measure.
