### PR TITLE
Create previousAttributes using a deep clone of attributes

### DIFF
--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -716,7 +716,7 @@ ModelBase.prototype.previousAttributes = function() {
  * @returns {Model} This model.
  */
 ModelBase.prototype._reset = function() {
-  this._previousAttributes = _.clone(this.attributes);
+  this._previousAttributes = _.cloneDeep(this.attributes);
   this.changed = Object.create(null);
   return this;
 };

--- a/test/integration/json.js
+++ b/test/integration/json.js
@@ -52,6 +52,20 @@ module.exports = function(bookshelf) {
         });
     });
 
+    it('can update attributes without affecting _previousAttributes', function() {
+      return Command.forge({id: 0}).fetch()
+        .then(function(command) {
+          const newTarget = {
+            x: 7,
+            y: 13,
+          };
+          const updatedInfo = command.get('info');
+          updatedInfo.target = newTarget;
+          command.set('info', updatedInfo);
+          expect(command.get('info')).to.not.deep.eql(command.previous('info'));
+        });
+    });
+
     it('Trying to fetch a model automatically excludes JSON column', function() {
       return Command.forge({unit_id: 1, type: 'attack', info: {test: 'blah'}}).fetch()
         .then(function(command) {


### PR DESCRIPTION
* Related Issues: #1875

## Introduction

Altered `Model._reset` to use a deep clone so that changes to `Model.attributes` don't affect `Model._previousAttributes`.

## Motivation

Problem is detailed in #1875.

## Proposed solution

Use `_.cloneDeep`. Fixes #1875.

## Current PR Issues

None

## Alternatives considered

None