### PR TITLE
upgrade: swap chalk→turbocolor; remove extraneous devDep

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const _ = require('lodash');
-const chalk = require('chalk')
+const tc = require('turbocolor')
 
 module.exports = {
   // Sets the constraints necessary during a `model.save` call.
@@ -72,7 +72,7 @@ module.exports = {
   },
 
   warn: function(msg) {
-    console.log(chalk.yellow(msg))
+    console.log(tc.yellow(msg))
   },
 
   deprecate: function(a, b) {

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   ],
   "dependencies": {
     "bluebird": "^3.4.3",
-    "chalk": "^2.3.0",
     "create-error": "~0.3.1",
     "inflection": "^1.5.1",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.10",
+    "turbocolor": "2.3.0"
   },
   "devDependencies": {
     "bookshelf-jsdoc-theme": "^0.2.0",
@@ -37,7 +37,6 @@
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.0",
     "knex": "^0.14.0",
-    "minimist": "^1.1.0",
     "mocha": "^5.0.0",
     "mysql": "^2.15.0",
     "pg": "^7.4.1",


### PR DESCRIPTION
Hi! @ricardograca! 👋 

## Summary

This PR replaces chalk for [turbocolor](https://github.com/jorgebucaran/turbocolor). Turbocolor is a ligther/faster drop-in replacement  for chalk (_10x_~_20x_ **faster** load time & runtime) with no dependencies. This is not a breaking change. 

## Motivation

Improve one dependency for a more performant one and remove an extraneous dependency.

## Proposed solution

Turbocolor has essentially the same API as chalk; it's just lighter (no deps) and faster. See full [benchmarks](https://github.com/jorgebucaran/turbocolor/tree/master/bench).

###### turbocolor/chalk

```
# Load Time
chalk: 15.190ms
turbocolor: 0.777ms

# All Colors
chalk × 8,729 ops/sec
turbocolor × 158,383 ops/sec

# Chained Colors
chalk × 1,838 ops/sec
turbocolor × 39,830 ops/sec

# Nested Colors
chalk × 4,049 ops/sec
turbocolor × 59,833 ops/sec
```

## Current PR Issues

None.

---

Let me know if this looks good to you and if you'd like to accept my contribution :)