### PR TITLE
Fix many-to-many tutorial code

### DIFF
--- a/tutorials/many-to-many.md
+++ b/tutorials/many-to-many.md
@@ -32,8 +32,8 @@ exports.up = function(knex, Promise) {
 };
 
 exports.down = function(knex, Promise) {
-  return knex.schema.dropTable('books')
+  return knex.schema.dropTable('authors_books')
     .dropTable('authors')
-    .dropTable('authors_books');
+    .dropTable('books');
 };
 ```

--- a/tutorials/many-to-many.md
+++ b/tutorials/many-to-many.md
@@ -26,8 +26,8 @@ exports.up = function(knex, Promise) {
     table.increments('id').primary();
     table.string('name');
   }).createTable('authors_books', function(table) {
-    table.integer('author_id').references('authors.id');
-    table.integer('book_id').references('books.id');
+    table.integer('author_id').unsigned().references('authors.id');
+    table.integer('book_id').unsigned().references('books.id');
   });
 };
 


### PR DESCRIPTION
## Introduction

When I try to implement code from this tutorial, I keep getting this error message:
```
$ knex migrate:latest

Knex:warning - migration file "20180824170607_initial_tables.js" failed
Knex:warning - migration failed with error: alter table `authors_books` add constraint `authors_books_author_id_foreign` foreign key (`author_id`) references `authors` (`id`) - ER_CANNOT_ADD_FOREIGN: Cannot add foreign key constraint
```
AND
```
$ knex migrate:rollback

Knex:warning - migration file "20180824170607_initial_tables.js" failed
Knex:warning - migration failed with error: drop table `books` - ER_ROW_IS_REFERENCED: Cannot delete or update a parent row: a foreign key constraint fails
```
## Motivation

To make the tutorial code running as expected.

## Proposed solution

- to fix ER_CANNOT_ADD_FOREIGN: Cannot add foreign key constraint:-
Refer to this https://github.com/tgriesser/knex/issues/245#issuecomment-234702769
- to fix ER_ROW_IS_REFERENCED: Cannot delete or update a parent row: a foreign key constraint fails:-
Reorder table drop

## Current PR Issues

None

## Alternatives considered

None