### PR TITLE
change logic of timestamp "update_time"

### DIFF
--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -642,9 +642,8 @@ ModelBase.prototype.timestamp = function(options) {
   const createdAtKey = timestampKeys[0];
   const updatedAtKey = timestampKeys[1];
   const isNewModel = method === 'insert';
-  const setUpdatedAt = updatedAtKey && this.hasChanged(updatedAtKey)
-
-  if (updatedAtKey && (isNewModel && !setUpdatedAt || this.hasChanged() && !setUpdatedAt)) {
+  
+  if (updatedAtKey && (isNewModel || this.hasChanged())) {
     attributes[updatedAtKey] = now;
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -847,7 +847,7 @@ const BookshelfModel = ModelBase.extend({
    * eager loading.
    *
    * @example
-   * Posts.fetchAll().then(function(collection) {
+   * new Posts().fetch().then(function(collection) {
    *   collection.at(0)
    *   .load(['author', 'content', 'comments.tags'])
    *   .then(function(model) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -145,8 +145,8 @@ const BookshelfModel = ModelBase.extend({
    *
    * @param {string=} foreignKeyTarget
    *
-   *   Column in the `Target` model's table which `foreignKey` references, if other
-   *   than `Target` model's `id` / `{@link Model#idAttribute idAttribute}`.
+   *   Column in this model's table which `foreignKey` references, if other
+   *   than this model's `id` / `{@link Model#idAttribute idAttribute}`.
    *
    * @returns {Collection}
    */

--- a/lib/model.js
+++ b/lib/model.js
@@ -847,7 +847,7 @@ const BookshelfModel = ModelBase.extend({
    * eager loading.
    *
    * @example
-   * new Posts().fetch().then(function(collection) {
+   * Posts.fetchAll().then(function(collection) {
    *   collection.at(0)
    *   .load(['author', 'content', 'comments.tags'])
    *   .then(function(model) {


### PR DESCRIPTION
the current logic seems a hot-fixed of a old bug----by the way, the version on npm 0.13.3 was not up-to-date and will throw error when timestamps:['create_at',null].  

although it does solve the problem when updateAtKey is null by adding the marked code below. The current code seems unnecessarily complex. 

const setUpdatedAt = updatedAtKey && this.hasChanged(updatedAtKey)
 if ( ******updatedAtKey && *******(isNewModel && !setUpdatedAt || this.hasChanged() && !setUpdatedAt)) {
     attributes[updatedAtKey] = now;
}

I suggest to rewrite it this new way. 

Additional discussion: 
1) why check "this.hasChanged(createdAtKey)" when inserting? I don't quite understand. 
2) if update-ts should be set to now when row is inserted? I think setting it to null on creation will provide more information----so people know this records has never been changed. But of course, this is more about convention.