### PR TITLE
Add some configurable options to pagination plugin

### DIFF
--- a/lib/plugins/pagination.js
+++ b/lib/plugins/pagination.js
@@ -26,8 +26,9 @@ const DEFAULT_PAGE = 1;
  *
  * ORM.plugin('bookshelf-pagination-plugin');
  */
-module.exports = function paginationPlugin (bookshelf) {
+module.exports = function paginationPlugin (bookshelf, settings) {
   const Model = bookshelf.Model;
+  settings = settings || {}
   /**
    * In order to use this function, you must have the {@link
    * https://github.com/bookshelf/bookshelf/wiki/Plugin:-Pagination Pagination}
@@ -103,7 +104,7 @@ module.exports = function paginationPlugin (bookshelf) {
 
     const isModel = this instanceof Model;
     const page = options.page;
-    const pageSize = options.pageSize;
+    const pageSize = Math.min(options.pageSize || settings.defaultPageSize || DEFAULT_LIMIT, settings.maxPageSize);
     const limit = options.limit;
     const offset = options.offset;
     const fetchOptions = _.omit(options, ['page', 'pageSize', 'limit', 'offset']);


### PR DESCRIPTION
## Introduction

Add an option to specify `defaultPageSize` and `maxPageSize` rather than use the internal constant.

## Motivation

Improve API simplicity, for not having to specify pageSize in each using method.
