### PR TITLE
Turbocolor has been deprecated. Upgraded to Colorette

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const _ = require('lodash');
-const tc = require('turbocolor');
+const tc = require('colorette');
 
 module.exports = {
   // Sets the constraints necessary during a `model.save` call.

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   ],
   "dependencies": {
     "bluebird": "^3.4.3",
+    "colorette": "^1.0.7",
     "create-error": "~0.3.1",
     "inflection": "^1.5.1",
-    "lodash": "^4.17.10",
-    "turbocolor": "2.3.0"
+    "lodash": "^4.17.10"
   },
   "lint-staged": {
     "*.{js,json}": [


### PR DESCRIPTION
* Related Issues: https://github.com/bookshelf/bookshelf/issues/1901

## Introduction

Turbocolour dependency was deprecated and has this warning: "Turbocolor has been deprecated. Please upgrade to Colorette 'npm i colorette'"

## Motivation

Get rid of deprecated package warning on npm install and upgrade

## Proposed solution

Changed dependencies to use colorette

## Current PR Issues

None - tests passed

## Alternatives considered

N/A
