### PR TITLE
fix #1913

### DIFF
--- a/lib/plugins/pagination.js
+++ b/lib/plugins/pagination.js
@@ -107,7 +107,7 @@ module.exports = function paginationPlugin(bookshelf) {
     const limit = options.limit;
     const offset = options.offset;
     const fetchOptions = _.omit(options, ['page', 'pageSize', 'limit', 'offset']);
-    const transacting = fetchOptions.transacting;
+    const countOptions = _.omit(fetchOptions, ['require', 'columns', 'withRelated', 'lock']);
     const fetchMethodName = isModel ? 'fetchAll' : 'fetch';
     const targetModel = isModel ? this.constructor : this.target || this.model;
     const tableName = targetModel.prototype.tableName;
@@ -180,7 +180,7 @@ module.exports = function paginationPlugin(bookshelf) {
 
           qb.countDistinct.apply(qb, groupColumns.length > 0 ? groupColumns : targetIdColumn);
         })
-        [fetchMethodName]({transacting})
+        [fetchMethodName](countOptions)
         .then((result) => {
           const metadata = usingPageSize ? {page: _page, pageSize: _limit} : {offset: _offset, limit: _limit};
 


### PR DESCRIPTION
* Related Issues: _#1913_

## Introduction

Make the pagination plugin fully compatible with others bookshelf plugins

## Motivation

In my project, I use the plugin bookshelf-paranoia to use the soft delete feature. I have a problem with pagination. 

If I want to show soft deleted items using pagination, the `fetchPaginate` function return correctly the models but don't return correct count. 

After resarch, it appears the count part don't use passed fetch options except the transacting parameter.

## Proposed solution

_I propose to use others fetch options on count part omit all default fetch params (withRelated, ...) to avoid problems_
