### PR TITLE
Pass proper context

### DIFF
--- a/lib/bookshelf.js
+++ b/lib/bookshelf.js
@@ -232,7 +232,7 @@ function Bookshelf(knex) {
      *    Bookshelf~transactionCallback transactionCallback}.
      */
     transaction() {
-      return this.knex.transaction.apply(this, arguments);
+      return this.knex.transaction.apply(this.knex, arguments);
     },
 
     /**


### PR DESCRIPTION
In version 0.16 of knex, not passing the knex context results in `this.client.transaction` being undefined.

