### PR TITLE
Fix crash when using groupBy with table qualifier

### DIFF
--- a/lib/plugins/pagination.js
+++ b/lib/plugins/pagination.js
@@ -166,8 +166,7 @@ module.exports = function paginationPlugin(bookshelf) {
           // for a count, and grouping returns the entire result set
           // What we want instead is to use `DISTINCT`
           _.remove(qb._statements, (statement) => {
-            if (statement.grouping === 'group')
-              statement.value.forEach((value) => groupColumns.push(`${tableName}.${value}`));
+            if (statement.grouping === 'group') statement.value.forEach((value) => groupColumns.push(value));
 
             return notNeededQueries.indexOf(statement.type) > -1 || statement.grouping === 'columns';
           });

--- a/test/integration/plugins/pagination.js
+++ b/test/integration/plugins/pagination.js
@@ -180,6 +180,25 @@ module.exports = function(bookshelf) {
             expect(blogs.length).to.be.below(total);
           });
       });
+
+      it('counts grouped rows when using table name qualifier', function() {
+        var total;
+
+        return Models.Blog.count()
+          .then(function(count) {
+            total = parseInt(count, 10);
+
+            return Models.Blog.query(function(qb) {
+              qb.max('id');
+              qb.groupBy('blogs.site_id');
+              qb.whereNotNull('site_id');
+            }).fetchPage();
+          })
+          .then(function(blogs) {
+            expect(blogs.pagination.rowCount).to.equal(blogs.length);
+            expect(blogs.length).to.be.below(total);
+          });
+      });
     });
 
     describe('with fetch Options', function() {


### PR DESCRIPTION
* Related Issues: #1925
* Previous PRs: #1852

## Introduction

This fixes a bug that creates an incorrect query when using `groupBy` with the pagination plugin. The issue is only in the row count part of `fetchPage`.

## Motivation

Fixes #1925.

## Proposed solution

The solution is taken straight out of the linked issue. All tests pass and a new one was added to ensure this isn't re-introduced again in the future.
