### PR TITLE
WIP Implement support for composite ids

### DIFF
--- a/lib/plugins/pagination.js
+++ b/lib/plugins/pagination.js
@@ -112,7 +112,9 @@ module.exports = function paginationPlugin(bookshelf) {
     const targetModel = isModel ? this.constructor : this.target || this.model;
     const tableName = targetModel.prototype.tableName;
     const idAttribute = targetModel.prototype.idAttribute || 'id';
-    const targetIdColumn = [`${tableName}.${idAttribute}`];
+    const targetIdColumn = ((Array.isArray(idAttribute) && idAttribute) || [idAttribute]).map(
+      (attr) => `${tableName}.${attr}`
+    );
     let usingPageSize = false; // usingPageSize = false means offset/limit, true means page/pageSize
     let _page;
     let _pageSize;

--- a/test/integration/helpers/migration.js
+++ b/test/integration/helpers/migration.js
@@ -20,6 +20,7 @@ var drops = [
   'users_roles',
   'info',
   'Customer',
+  'CustomerThing',
   'Settings',
   'hostnames',
   'instances',
@@ -171,6 +172,11 @@ module.exports = function(Bookshelf) {
           .createTable('Customer', function(table) {
             table.increments('id');
             table.string('name');
+          })
+          .createTable('CustomerThing', function(table) {
+            table.integer('Customer_id').notNullable();
+            table.string('thing');
+            table.primary(['Customer_id', 'thing']);
           })
           .createTable('Settings', function(table) {
             table.increments('id');

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -267,6 +267,17 @@ module.exports = function(Bookshelf) {
     }
   });
 
+  var CustomerThing = Bookshelf.Model.extend({
+    tableName: 'CustomerThing',
+    idAttribute: ['Customer_id', 'thing'],
+    defaults: {
+      thing: ''
+    },
+    customer: function() {
+      return this.hasOne(Customer);
+    }
+  });
+
   var Hostname = Bookshelf.Model.extend({
     tableName: 'hostnames',
     idAttribute: 'hostname',
@@ -444,6 +455,7 @@ module.exports = function(Bookshelf) {
       Thumbnail: Thumbnail,
       Info: Info,
       Customer: Customer,
+      CustomerThing: CustomerThing,
       Settings: Settings,
       Instance: Instance,
       Hostname: Hostname,

--- a/test/integration/plugins/pagination.js
+++ b/test/integration/plugins/pagination.js
@@ -27,6 +27,26 @@ module.exports = function(bookshelf) {
           });
       });
 
+      it('fetches a single page of results with defaults', function() {
+        return Models.CustomerThing.forge()
+          .fetchPage()
+          .then(function(results) {
+            ['models', 'pagination'].forEach(function(prop) {
+              expect(results).to.have.property(prop);
+            });
+            ['rowCount', 'pageCount', 'page', 'pageSize'].forEach(function(prop) {
+              expect(results.pagination).to.have.property(prop);
+            });
+
+            var md = results.pagination;
+
+            expect(md.rowCount).to.equal(4);
+            expect(md.pageCount).to.equal(1);
+            expect(md.page).to.equal(1);
+            expect(md.pageSize).to.equal(10);
+          });
+      });
+
       it('returns the limit and offset instead of page and pageSize', function() {
         return Models.Customer.forge()
           .fetchPage({limit: 2, offset: 2})


### PR DESCRIPTION
* Related Issues: #1664

## Introduction

Adding composite id support to the Bookshelf Pagination plugin.

## Motivation

When using composite ids the Bookshelf Pagination plugin will convert the id to a string `['id1', 'id2']` --> `"myTable"."id1,id2"`.

## Proposed solution

This solution will add support for idAttributes to be an array. Converting `['id1', 'id2']` --> `"myTable"."id1","myTable"."id2"`.

## Current PR Issues

Waiting on support for sqlite https://github.com/tgriesser/knex/pull/2449#issuecomment-450590918

## Alternatives considered

Don't use composite ids.
