### PR TITLE
Count unique occurrences of a column when using distinct to calculate pagination details

### DIFF
--- a/lib/plugins/pagination.js
+++ b/lib/plugins/pagination.js
@@ -167,6 +167,8 @@ module.exports = function paginationPlugin(bookshelf) {
           // What we want instead is to use `DISTINCT`
           _.remove(qb._statements, (statement) => {
             if (statement.grouping === 'group') statement.value.forEach((value) => groupColumns.push(value));
+            if (statement.grouping === 'columns' && statement.distinct)
+              statement.value.forEach((value) => groupColumns.push(value));
 
             return notNeededQueries.indexOf(statement.type) > -1 || statement.grouping === 'columns';
           });

--- a/test/integration/plugins/pagination.js
+++ b/test/integration/plugins/pagination.js
@@ -201,6 +201,25 @@ module.exports = function(bookshelf) {
       });
     });
 
+    describe('with distinct', function() {
+      it('counts distinct occurences of a column instead of total rows', function() {
+        var total;
+
+        return Models.Post.count()
+          .then(function(count) {
+            total = parseInt(count, 10);
+
+            return Models.Post.query(function(qb) {
+              qb.distinct('owner_id');
+            }).fetchPage();
+          })
+          .then(function(distinctPostOwners) {
+            expect(distinctPostOwners.pagination.rowCount).to.equal(distinctPostOwners.length);
+            expect(distinctPostOwners.length).to.be.below(total);
+          });
+      });
+    });
+
     describe('with fetch Options', function() {
       var Site = Models.Site;
 


### PR DESCRIPTION
* Related Issues: #1948

## Introduction

The pagination plugin is returning the wrong `rowCount` when the query contains a `SELECT DISTINCT` statement. 

## Motivation

In one of the projects we're working on, we need to paginate different occurrences of a column within a table. When we reached the last page, we've noticed that we were still getting pagination details. Not only so, but if we requested a page with an offset greater that the total, we still got pagination details along with an empty set of results. This was due to calculating the `rowCount` incorrectly.

Fixes #1948.

## Proposed solution

When counting the total number of rows, the pagination plugin is excluding all `columns` statements from the grouping columns, even when they are part of a `distinct` statement. Therefore, the resulting count query selects all the records in the table, rather than only unique occurrences of a column in that table, and returning a wrong `rowCount`. The proposed solution simply keeps `columns` statements when `distinct` is `true`.
