### PR TITLE
Fix Docker-compose.yml default postgres user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,4 @@ services:
     ports:
     - "5432:5432"
     environment:
-      POSTGRES_PASSWORD:
-      POSTGRES_USER: root
       POSTGRES_DB: bookshelf_test


### PR DESCRIPTION
The user was set as "root" with no password.
When running the tests, it stated that "postgres" user was not available.
This happened because postgres image was being built with the user "root"

* Related Issues: #1971 

## Introduction

Fix docker-compose user to use the postgres default one, so the tests can run.

Fixes #1971.

## Motivation

You should be able to run the tests with only the following commands:
```shell
$ npm i
$ docker-compose up -d
$ npm test
```

## Proposed solution

Pretty simple, just remove the defined user, and let it fallback to the postgres image default user.


## Alternatives considered

Well, maybe we could change the user being set for the tests, and set it as root. But that's adding code, whereas removing code is more elegant IMO.
