### PR TITLE
Allow event.off to accept the callback that should be removed.

### DIFF
--- a/lib/base/events.js
+++ b/lib/base/events.js
@@ -41,13 +41,19 @@ class Events extends EventEmitter {
    * @param {string} nameOrNames
    *   The name of the event or space separated list of events to stop listening
    *   to.
+   * @param {function} callback That callback to remove.
    */
-  off(nameOrNames) {
+  off(nameOrNames, callback) {
     if (nameOrNames == null) {
       return this.removeAllListeners();
     }
 
-    eventNames(nameOrNames).forEach((name) => this.removeAllListeners(name));
+    eventNames(nameOrNames).forEach((name) => {
+      if (callback === undefined) {
+        return this.removeAllListeners(name);
+      }
+      return this.removeListener(name, callback);
+    });
     return this;
   }
 

--- a/test/base/tests/events.js
+++ b/test/base/tests/events.js
@@ -11,6 +11,43 @@ module.exports = function() {
     });
 
     describe('#off()', function() {
+      it('should only deregister the provided callback if passed', function() {
+        function eventHandler1() {
+          throw new Error('Expected event handler to have not been called');
+        }
+
+        function eventHandler2() {
+          /* Expected to be called */
+          eventHandler2.callCount += 1;
+        }
+        eventHandler2.callCount = 0;
+
+        events.on('A', eventHandler1);
+        events.on('A', eventHandler2);
+        events.off('A', eventHandler1);
+        expect(events._eventsCount).to.equal(1);
+
+        events.trigger('A');
+        expect(eventHandler2.callCount).to.equal(1);
+      });
+
+      it('should deregister all callbacks if no callback is passed', function() {
+        function eventHandler1() {
+          throw new Error('Expected event handler to have not been called');
+        }
+
+        function eventHandler2() {
+          throw new Error('Expected event handler to have not been called');
+        }
+
+        events.on('A', eventHandler1);
+        events.on('A', eventHandler2);
+        events.off('A');
+        events.trigger('A');
+
+        expect(events._eventsCount).to.equal(0);
+      });
+
       it('should deregister multiple space-separated events', function() {
         function eventHandler() {
           throw new Error('Expected event handler to have not been called');
@@ -33,6 +70,31 @@ module.exports = function() {
           expect(arg2).to.equal(2);
         });
         events.trigger('event', 1, 2);
+      });
+    });
+
+    describe('#once()', function() {
+      it('should remove itself but not other events', function() {
+        function onEventHandler() {
+          /* Expected to be called */
+          onEventHandler.callCount += 1;
+        }
+        onEventHandler.callCount = 0;
+
+        function onceEventHandler() {
+          /* Expected to be called */
+          onceEventHandler.callCount += 1;
+        }
+        onceEventHandler.callCount = 0;
+
+        events.on('A', onEventHandler);
+        events.once('A', onceEventHandler);
+        events.trigger('A');
+        expect(events._eventsCount).to.equal(1);
+
+        events.trigger('A');
+        expect(onEventHandler.callCount).to.equal(2);
+        expect(onceEventHandler.callCount).to.equal(1);
       });
     });
   });


### PR DESCRIPTION
* Related Issues: https://github.com/bookshelf/bookshelf/issues/1963

## Introduction

When using events, `once` should be independent of `on`. If you add an event with `once` it shouldn't clear other events after it files.

## Motivation

I've been using bookshelf with `on('saving')` events. When adding temporary events using `once`, I noticed my original events weren't firing.

Fixes #1963.

## Proposed solution

Update `event.off` to take the event name and the callback to remove. `once` already calls `off` to remove the event after it has fired.

## Current PR Issues

Should be unencumbered. 

## Alternatives considered

`once` could call `removeListener` directly, meaning `off` does not need to change. I chose to err towards a more expressive API.
