### PR TITLE
Bump supported knex version to 0.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "husky": "^1.1.3",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.0",
-    "knex": "^0.16.5",
+    "knex": "^0.17.0",
     "lint-staged": "^8.0.0",
     "mocha": "^6.1.1",
     "mysql": "^2.15.0",
@@ -62,7 +62,7 @@
     "uuid": "^3.1.0"
   },
   "peerDependencies": {
-    "knex": ">=0.13.0 <0.17.0"
+    "knex": ">=0.13.0 <0.18.0"
   },
   "author": {
     "name": "Tim Griesser",


### PR DESCRIPTION
0.17 should be a drop-in replacement for bookshelf, as major changes are only related to TypeScript bindings.