### PR TITLE
Add support for schema's when using withRelated.

### DIFF
--- a/lib/relation.js
+++ b/lib/relation.js
@@ -101,10 +101,10 @@ const Relation = RelationBase.extend(
       if (this[keyName]) return this[keyName];
       switch (keyName) {
         case 'otherKey':
-          this[keyName] = singularMemo(this.targetTableName) + '_' + this.targetIdAttribute;
+          this[keyName] = singularMemo(noSchemaMemo(this.targetTableName)) + '_' + this.targetIdAttribute;
           break;
         case 'throughForeignKey':
-          this[keyName] = singularMemo(this.joinTable()) + '_' + this.throughIdAttribute;
+          this[keyName] = singularMemo(noSchemaMemo(this.joinTable())) + '_' + this.throughIdAttribute;
           break;
         case 'foreignKey':
           switch (this.type) {
@@ -114,14 +114,14 @@ const Relation = RelationBase.extend(
               break;
             }
             case 'belongsTo':
-              this[keyName] = singularMemo(this.targetTableName) + '_' + this.targetIdAttribute;
+              this[keyName] = singularMemo(noSchemaMemo(this.targetTableName)) + '_' + this.targetIdAttribute;
               break;
             default:
               if (this.isMorph()) {
                 this[keyName] = this.columnNames && this.columnNames[1] ? this.columnNames[1] : this.morphName + '_id';
                 break;
               }
-              this[keyName] = singularMemo(this.parentTableName) + '_' + this.parentIdAttribute;
+              this[keyName] = singularMemo(noSchemaMemo(this.parentTableName)) + '_' + this.parentIdAttribute;
               break;
           }
           break;
@@ -645,6 +645,18 @@ const singularMemo = (function() {
   return function(arg) {
     if (!(arg in cache)) {
       cache[arg] = inflection.singularize(arg);
+    }
+    return cache[arg];
+  };
+})();
+
+// Simple memoization that removes schema prefix.
+const noSchemaMemo = (function() {
+  const cache = Object.create(null);
+  return function(arg) {
+    if (!(arg in cache)) {
+      let splitArg = arg.split['.'];
+      cache[arg] = splitArg[splitArg.length-1];
     }
     return cache[arg];
   };

--- a/lib/relation.js
+++ b/lib/relation.js
@@ -655,8 +655,8 @@ const noSchemaMemo = (function() {
   const cache = Object.create(null);
   return function(arg) {
     if (!(arg in cache)) {
-      let splitArg = arg.split['.'];
-      cache[arg] = splitArg[splitArg.length-1];
+      const splitArg = arg.split['.'];
+      cache[arg] = splitArg[splitArg.length - 1];
     }
     return cache[arg];
   };

--- a/lib/relation.js
+++ b/lib/relation.js
@@ -10,6 +10,29 @@ const push = Array.prototype.push;
 const removePivotPrefix = (key) => key.slice(constants.PIVOT_PREFIX.length);
 const hasPivotPrefix = (key) => _.startsWith(key, constants.PIVOT_PREFIX);
 
+// Simple memoization of the singularize call.
+const singularMemo = (function() {
+  const cache = Object.create(null);
+  return function(arg) {
+    if (!(arg in cache)) {
+      cache[arg] = inflection.singularize(arg);
+    }
+    return cache[arg];
+  };
+})();
+
+// Simple memoization that removes schema prefix.
+const noSchemaMemo = (function() {
+  const cache = Object.create(null);
+  return function(arg) {
+    if (!(arg in cache)) {
+      const splitArg = arg.split('.');
+      cache[arg] = splitArg[splitArg.length - 1];
+    }
+    return cache[arg];
+  };
+})();
+
 /**
  * @classdesc
  *   Used internally, the `Relation` class helps in simplifying the relationship building,
@@ -638,29 +661,6 @@ const Relation = RelationBase.extend(
     }
   }
 );
-
-// Simple memoization of the singularize call.
-const singularMemo = (function() {
-  const cache = Object.create(null);
-  return function(arg) {
-    if (!(arg in cache)) {
-      cache[arg] = inflection.singularize(arg);
-    }
-    return cache[arg];
-  };
-})();
-
-// Simple memoization that removes schema prefix.
-const noSchemaMemo = (function() {
-  const cache = Object.create(null);
-  return function(arg) {
-    if (!(arg in cache)) {
-      const splitArg = arg.split('.');
-      cache[arg] = splitArg[splitArg.length - 1];
-    }
-    return cache[arg];
-  };
-})();
 
 /**
  * Specific to many-to-many relationships, these methods are mixed into the

--- a/lib/relation.js
+++ b/lib/relation.js
@@ -654,7 +654,7 @@ const singularMemo = (function() {
 const noSchemaMemo = (function() {
   const cache = Object.create(null);
   return function(arg) {
-    if (!(arg in cache)) {
+    if (!(arg in cache) && typeof arg === 'string') {
       const splitArg = arg.split['.'];
       cache[arg] = splitArg[splitArg.length - 1];
     }

--- a/lib/relation.js
+++ b/lib/relation.js
@@ -654,8 +654,8 @@ const singularMemo = (function() {
 const noSchemaMemo = (function() {
   const cache = Object.create(null);
   return function(arg) {
-    if (!(arg in cache) && typeof arg === 'string') {
-      const splitArg = arg.split['.'];
+    if (!(arg in cache)) {
+      const splitArg = arg.split('.');
       cache[arg] = splitArg[splitArg.length - 1];
     }
     return cache[arg];


### PR DESCRIPTION
* Related Issues: #458 

## Introduction

When using postgres (and probably also with other database system) schema's and bookshelf everything works fine if you set the tableName to something like 'organisation.locations'. However getting related table data using the `withRelated: ['modelname']` does currently not take schema into account.

## Motivation
It is conventional to have foreignkeys be the singular of the tablename with _id appended to them. It is not conventional to have that prefixed by the schema. Right now if you use bookshelf with database schema's foreign keys will look like `organisation.organisation_id` when they should look like organisation_id`.

## Solution
This PR fixes the issue by removing the schema prefix of the model's tablename before getting the singular of the table when creating foreign keys.

## Alternatives considered

Alternative is to use the full method:
`return this.belongsTo('organisations');` becomes `return this.belongsTo('organisations', organisation_id');` but I do not think this is according to convention. I have never seen anyone put schema into their columnnames on default.
