### PR TITLE
Change Collection#where so it behaves like Model#where

### DIFF
--- a/lib/base/collection.js
+++ b/lib/base/collection.js
@@ -580,24 +580,6 @@ CollectionBase.prototype.at = function(index) {
 
 /**
  * @method
- * @description
- * Return the first model with matching attributes. Useful for simple cases of
- * `find`.
- * @returns {Model} The first matching model.
- */
-CollectionBase.prototype.findWhere = function findWhere(attrs) {
-  if (_.isEmpty(attrs)) return;
-
-  return this.find((model) => {
-    for (const key in attrs) {
-      if (attrs[key] !== model.get(key)) return false;
-    }
-    return true;
-  });
-};
-
-/**
- * @method
  * @private
  * @description
  * Force the collection to re-sort itself, based on a comporator defined on the model.

--- a/lib/base/collection.js
+++ b/lib/base/collection.js
@@ -581,28 +581,19 @@ CollectionBase.prototype.at = function(index) {
 /**
  * @method
  * @description
- * Return models with matching attributes. Useful for simple cases of `filter`.
- * @returns {Model[]} Array of matching models.
+ * Return the first model with matching attributes. Useful for simple cases of
+ * `find`.
+ * @returns {Model} The first matching model.
  */
-CollectionBase.prototype.where = function(attrs, first) {
-  if (_.isEmpty(attrs)) return first ? void 0 : [];
-  return this[first ? 'find' : 'filter'](function(model) {
+CollectionBase.prototype.findWhere = function findWhere(attrs) {
+  if (_.isEmpty(attrs)) return;
+
+  return this.find((model) => {
     for (const key in attrs) {
       if (attrs[key] !== model.get(key)) return false;
     }
     return true;
   });
-};
-
-/**
- * @method
- * @description
- * Return the first model with matching attributes. Useful for simple cases of
- * `find`.
- * @returns {Model} The first matching model.
- */
-CollectionBase.prototype.findWhere = function(attrs) {
-  return this.where(attrs, true);
 };
 
 /**

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -376,6 +376,48 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
     },
 
     /**
+     * This is used as convenience for the most common {@link Collection#query query} method:
+     * adding a `WHERE` clause to the builder. Any additional knex methods may be accessed using
+     * {@link Collection#query query}.
+     *
+     * Accepts either `key, value` syntax, or a hash of attributes to constrain the results.
+     *
+     * @example
+     * collection
+     *   .where('favorite_color', '<>', 'green')
+     *   .fetch()
+     *   .then(results => {
+     *     // ...
+     *   })
+     *
+     * // or
+     *
+     * collection
+     *   .where('favorite_color', 'red')
+     *   .fetch()
+     *   .then(results => {
+     *     // ...
+     *   })
+     *
+     * collection
+     *   .where({favorite_color: 'red', shoe_size: 12})
+     *   .fetch()
+     *   .then(results => {
+     *     // ...
+     *   })
+     *
+     * @see Collection#query
+     * @param {Object|...string} conditions
+     *   Either `key, [operator], value` syntax, or a hash of attributes to match. Note that these
+     *   must be formatted as they are in the database, not how they are stored after
+     *   {@link Model#parse}.
+     * @returns {Collection} Self, this method is chainable.
+     */
+    where() {
+      return this.query.apply(this, ['where'].concat(Array.from(arguments)));
+    },
+
+    /**
      * Specifies the column to sort on and sort order.
      *
      * The order parameter is optional, and defaults to 'ASC'. You may

--- a/test/base/tests/collection.js
+++ b/test/base/tests/collection.js
@@ -47,6 +47,35 @@ module.exports = function() {
       equal(collection.at(1).id, undefined);
     });
 
+    it('should use the `reset` method, to reset the collection', function() {
+      collection.reset([]);
+      equal(collection.length, 0);
+    });
+
+    it('should use _prepareModel to prep model instances', function() {
+      var model = new ModelBase({id: 1});
+      expect(model).to.equal(collection._prepareModel(model));
+      var newModel = collection._prepareModel({some_id: 1});
+      assert.ok(newModel instanceof collection.model);
+    });
+
+    it('contains a mapThen method which calls map on the models and returns a when.all promise', function() {
+      var spyIterator = sinon.spy(function(model) {
+        return model.id;
+      });
+
+      return collection.mapThen(spyIterator).then(function(resp) {
+        spyIterator.should.have.been.calledTwice;
+        expect(_.compact(resp)).to.eql([1]);
+      });
+    });
+
+    it('contains an invokeThen method which does an invoke on the models and returns a when.all promise', function() {
+      return collection.invokeThen('invokedMethod').then(function(resp) {
+        expect(_.compact(resp)).to.eql([1]);
+      });
+    });
+
     describe('#add()', function() {
       it('adds new models to the collection', function() {
         var originalLength = collection.length;
@@ -156,35 +185,6 @@ module.exports = function() {
         collection.set(models, {add: true, remove: false, merge: false});
 
         equal(collection.get(count - 1).get('name'), 'Large-' + (count - 1));
-      });
-    });
-
-    it('should use the `reset` method, to reset the collection', function() {
-      collection.reset([]);
-      equal(collection.length, 0);
-    });
-
-    it('should use _prepareModel to prep model instances', function() {
-      var model = new ModelBase({id: 1});
-      expect(model).to.equal(collection._prepareModel(model));
-      var newModel = collection._prepareModel({some_id: 1});
-      assert.ok(newModel instanceof collection.model);
-    });
-
-    it('contains a mapThen method which calls map on the models and returns a when.all promise', function() {
-      var spyIterator = sinon.spy(function(model) {
-        return model.id;
-      });
-
-      return collection.mapThen(spyIterator).then(function(resp) {
-        spyIterator.should.have.been.calledTwice;
-        expect(_.compact(resp)).to.eql([1]);
-      });
-    });
-
-    it('contains an invokeThen method which does an invoke on the models and returns a when.all promise', function() {
-      return collection.invokeThen('invokedMethod').then(function(resp) {
-        expect(_.compact(resp)).to.eql([1]);
       });
     });
   });

--- a/test/integration/collection.js
+++ b/test/integration/collection.js
@@ -355,5 +355,30 @@ module.exports = function(bookshelf) {
         expect(cloned.query()._events).to.have.property('query');
       });
     });
+
+    describe('#where()', function() {
+      it('constrains the fetch call with the specified query conditions', function() {
+        const Sites = bookshelf.Collection.extend({model: Site});
+        return new Sites()
+          .where({name: 'bookshelfjs.org'})
+          .fetch()
+          .then((sites) => {
+            equal(sites.length, 1);
+            equal(sites.models[0].get('name'), 'bookshelfjs.org');
+          });
+      });
+
+      it('can constrain the fetch call with the "key, comparator, value" type conditions', function() {
+        const Sites = bookshelf.Collection.extend({model: Site});
+        return new Sites()
+          .where('name', '<>', 'bookshelfjs.org')
+          .fetch()
+          .then((sites) => {
+            equal(sites.length, 2);
+            equal(sites.models[0].get('name'), 'knexjs.org');
+            equal(sites.models[1].get('name'), 'backbonejs.org');
+          });
+      });
+    });
   });
 };

--- a/test/integration/collection.js
+++ b/test/integration/collection.js
@@ -1,6 +1,4 @@
-var Promise = require('bluebird');
-var assert = require('assert');
-var equal = assert.equal;
+const {equal, deepEqual} = require('assert');
 
 module.exports = function(bookshelf) {
   describe('Collection', function() {
@@ -11,11 +9,11 @@ module.exports = function(bookshelf) {
     };
     var formatNumber = require('./helpers').formatNumber(dialect);
     var checkCount = function(actual, expected) {
-      expect(actual).to.equal(formatNumber(expected));
+      equal(actual, formatNumber(expected));
     };
     var checkTest = function(ctx) {
       return function(resp) {
-        expect(json(resp)).to.eql(output[ctx.test.title][dialect].result);
+        deepEqual(json(resp), output[ctx.test.title][dialect].result);
       };
     };
 
@@ -25,7 +23,7 @@ module.exports = function(bookshelf) {
     var Blog = Models.Blog;
     var Post = Models.Post;
 
-    describe('extend', function() {
+    describe('.extend()', function() {
       it('should have own EmptyError', function() {
         var Sites = bookshelf.Collection.extend({model: Site});
         var OtherSites = bookshelf.Collection.extend({model: Site});
@@ -38,52 +36,7 @@ module.exports = function(bookshelf) {
       });
     });
 
-    describe('fetch', function() {
-      it('fetches the models in a collection', function() {
-        return bookshelf.Collection.extend({tableName: 'posts'})
-          .forge()
-          .fetch()
-          .tap(checkTest(this));
-      });
-    });
-
-    describe('#fetchPage()', function() {
-      it('fetches a page from a collection', function() {
-        return Models.Customer.collection()
-          .fetchPage()
-          .then(function(results) {
-            expect(results).to.have.property('models');
-            expect(results).to.have.property('pagination');
-          });
-      });
-
-      it('fetches a page from a relation collection', function() {
-        return Models.User.forge({uid: 1})
-          .roles()
-          .fetchPage()
-          .then(function(results) {
-            expect(results.length).to.equal(1);
-            expect(results).to.have.property('models');
-            expect(results).to.have.property('pagination');
-          });
-      });
-
-      it('fetches a page from a relation collection with additional condition', function() {
-        return Models.User.forge({uid: 1})
-          .roles()
-          .query(function(query) {
-            query.where('roles.rid', '!=', 4);
-          })
-          .fetchPage()
-          .then(function(results) {
-            expect(results.length).to.equal(0);
-            expect(results).to.have.property('models');
-            expect(results).to.have.property('pagination');
-          });
-      });
-    });
-
-    describe('count', function() {
+    describe('#count()', function() {
       it('counts the number of models in a collection', function() {
         return bookshelf.Collection.extend({tableName: 'posts'})
           .forge()
@@ -138,7 +91,52 @@ module.exports = function(bookshelf) {
       });
     });
 
-    describe('fetchOne', function() {
+    describe('#fetch()', function() {
+      it('fetches the models in a collection', function() {
+        return bookshelf.Collection.extend({tableName: 'posts'})
+          .forge()
+          .fetch()
+          .tap(checkTest(this));
+      });
+    });
+
+    describe('#fetchPage()', function() {
+      it('fetches a page from a collection', function() {
+        return Models.Customer.collection()
+          .fetchPage()
+          .then(function(results) {
+            expect(results).to.have.property('models');
+            expect(results).to.have.property('pagination');
+          });
+      });
+
+      it('fetches a page from a relation collection', function() {
+        return Models.User.forge({uid: 1})
+          .roles()
+          .fetchPage()
+          .then(function(results) {
+            expect(results.length).to.equal(1);
+            expect(results).to.have.property('models');
+            expect(results).to.have.property('pagination');
+          });
+      });
+
+      it('fetches a page from a relation collection with additional condition', function() {
+        return Models.User.forge({uid: 1})
+          .roles()
+          .query(function(query) {
+            query.where('roles.rid', '!=', 4);
+          })
+          .fetchPage()
+          .then(function(results) {
+            expect(results.length).to.equal(0);
+            expect(results).to.have.property('models');
+            expect(results).to.have.property('pagination');
+          });
+      });
+    });
+
+    describe('#fetchOne()', function() {
       it('fetches a single model from the collection', function() {
         return new Site({id: 1})
           .authors()
@@ -165,7 +163,11 @@ module.exports = function(bookshelf) {
           .fetchOne({require: true})
           .throw(new Error())
           .catch(function(err) {
-            assert(err instanceof Author.NotFoundError, 'Error is a Site.NotFoundError');
+            equal(
+              err instanceof Author.NotFoundError,
+              true,
+              'Expected error to be an instance of Author.NotFoundError'
+            );
           });
       });
 
@@ -180,33 +182,39 @@ module.exports = function(bookshelf) {
       });
     });
 
-    describe('orderBy', function() {
-      it('orders the results by column', function() {
-        var asc = new Site({id: 1})
+    describe('#orderBy()', function() {
+      it('orders the results by column in ascending order', function() {
+        return new Site({id: 1})
           .authors()
           .orderBy('first_name', 'ASC')
-          .fetch();
-        var desc = new Site({id: 1})
+          .fetch()
+          .then(function(result) {
+            const expectedCollection = [
+              {id: 2, site_id: 1, first_name: 'Bazooka', last_name: 'Joe'},
+              {id: 1, site_id: 1, first_name: 'Tim', last_name: 'Griesser'}
+            ];
+
+            deepEqual(result.toJSON(), expectedCollection);
+          });
+      });
+
+      it('orders the results by column in descending order', function() {
+        return new Site({id: 1})
           .authors()
           .orderBy('first_name', 'DESC')
-          .fetch();
+          .fetch()
+          .then(function(result) {
+            const expectedCollection = [
+              {id: 1, site_id: 1, first_name: 'Tim', last_name: 'Griesser'},
+              {id: 2, site_id: 1, first_name: 'Bazooka', last_name: 'Joe'}
+            ];
 
-        return Promise.join(asc, desc).then(function(result) {
-          var r0 = result[0].toJSON().reverse();
-          var r1 = result[1].toJSON();
-          expect(r0).to.eql(r1);
-        });
+            deepEqual(result.toJSON(), expectedCollection);
+          });
       });
     });
 
-    describe('sync', function() {
-      it('creates a new instance of Sync', function() {
-        var model = new bookshelf.Model();
-        assert(model.sync(model) instanceof require('../../lib/sync'));
-      });
-    });
-
-    describe('create', function() {
+    describe('#create()', function() {
       it('creates and saves a new model instance, saving it to the collection', function() {
         return Site.collection()
           .create({name: 'google.com'})
@@ -332,7 +340,7 @@ module.exports = function(bookshelf) {
       });
     });
 
-    describe('clone', function() {
+    describe('#clone()', function() {
       it('should contain a copy of internal QueryBuilder object - #945', function() {
         var original = Post.collection()
           .query('where', 'share_count', '>', 10)

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1785,7 +1785,7 @@ module.exports = function(bookshelf) {
     describe('sync', function() {
       it('creates a new instance of Sync', function() {
         var model = new bookshelf.Model();
-        equal(model.sync(model) instanceof require('../../lib/sync'), true);
+        equal(model.sync() instanceof require('../../lib/sync'), true);
       });
     });
 


### PR DESCRIPTION
* Related Issues: #780

## Introduction

This makes `Collection#where()` constrain `fetch()` queries, so that it behaves like `Model#where()`.

## Motivation

The fact that there are two methods called `where` that do different things is confusing. It should be expected that when operating on both Models and Collections the `where()` method would always constrain additional queries.

Closes #780.

## Proposed solution

The current behavior of `Collection#where()` was changed so that it calls `.query('where', ...args)`. Additionally, `Collection#findWhere()` was removed since it too is a bit confusing and its functionality can be achieved with `Collection#find`.

## Current PR Issues

This change is not backwards compatible. Check the [migration guide](https://github.com/bookshelf/bookshelf/wiki/Migrating-from-0.15.1-to-1.0.0) on how to change your code if you were relying on any of the `Collection#where()` or `Collection#findWhere()` methods.
