### PR TITLE
Remove some Model and Collection lodash based methods

### DIFF
--- a/lib/base/collection.js
+++ b/lib/base/collection.js
@@ -480,7 +480,7 @@ CollectionBase.prototype.remove = function(models, options) {
     if (!model) continue;
     delete this._byId[this.idKey(model.id)];
     delete this._byId[model.cid];
-    const index = this.indexOf(model);
+    const index = this.models.indexOf(model);
     this.models.splice(index, 1);
     this.length = this.length - 1;
     if (!options.silent) {
@@ -681,10 +681,6 @@ CollectionBase.prototype[Symbol.iterator] = function*() {
  * @see http://lodash.com/docs/#forEach
  */
 /**
- * @method CollectionBase#each
- * @see http://lodash.com/docs/#each
- */
-/**
  * @method CollectionBase#map
  * @see http://lodash.com/docs/#map
  */
@@ -725,83 +721,18 @@ CollectionBase.prototype[Symbol.iterator] = function*() {
  * @see http://lodash.com/docs/#invokeMap
  */
 /**
- * @method CollectionBase#max
- * @see http://lodash.com/docs/#max
- */
-/**
- * @method CollectionBase#maxBy
- * @see http://lodash.com/docs/#maxBy
- */
-/**
- * @method CollectionBase#min
- * @see http://lodash.com/docs/#min
- */
-/**
- * @method CollectionBase#minBy
- * @see http://lodash.com/docs/#minBy
- */
-/**
  * @method CollectionBase#toArray
  * @see http://lodash.com/docs/#toArray
  */
 /**
- * @method CollectionBase#size
- * @see http://lodash.com/docs/#size
- */
-/**
- * @method CollectionBase#head
- * @see http://lodash.com/docs/#head
- */
-/**
- * @method CollectionBase#take
- * @see http://lodash.com/docs/#take
- */
-/**
- * @method CollectionBase#initial
- * @see http://lodash.com/docs/#initial
- */
-/**
- * @method CollectionBase#tail
- * @see http://lodash.com/docs/#tail
- */
-/**
- * @method CollectionBase#drop
- * @see http://lodash.com/docs/#drop
- */
-/**
- * @method CollectionBase#without
- * @see http://lodash.com/docs/#without
- */
-/**
- * @method CollectionBase#difference
- * @see http://lodash.com/docs/#difference
- */
-/**
- * @method CollectionBase#indexOf
- * @see http://lodash.com/docs/#indexOf
- */
-/**
- * @method CollectionBase#shuffle
- * @see http://lodash.com/docs/#shuffle
- */
-/**
- * @method CollectionBase#lastIndexOf
- * @see http://lodash.com/docs/#lastIndexOf
- */
-/**
  * @method CollectionBase#isEmpty
  * @see http://lodash.com/docs/#isEmpty
- */
-/**
- * @method CollectionBase#chain
- * @see http://lodash.com/docs/#chain
  */
 // Lodash methods that we want to implement on the Collection.
 // 90% of the core usefulness of Backbone Collections is actually implemented
 // right here:
 const methods = [
   'forEach',
-  'each',
   'map',
   'reduce',
   'reduceRight',
@@ -811,24 +742,8 @@ const methods = [
   'some',
   'includes',
   'invokeMap',
-  'max',
-  'min',
-  'maxBy',
-  'minBy',
   'toArray',
-  'size',
-  'head',
-  'take',
-  'initial',
-  'tail',
-  'drop',
-  'without',
-  'difference',
-  'indexOf',
-  'shuffle',
-  'lastIndexOf',
-  'isEmpty',
-  'chain'
+  'isEmpty'
 ];
 
 // Mix in each Lodash method as a proxy to `Collection#models`.

--- a/lib/base/collection.js
+++ b/lib/base/collection.js
@@ -132,6 +132,24 @@ CollectionBase.prototype.tableName = function() {
 };
 
 /**
+ * Returns the first model in the collection or `undefined` if the collection is empty.
+ *
+ * @return {Model|undefined} The first model or `undefined`.
+ */
+CollectionBase.prototype.first = function() {
+  return this.at(0);
+};
+
+/**
+ * Returns the last model in the collection or `undefined` if the collection is empty.
+ *
+ * @return {Model|undefined} The last model or `undefined`.
+ */
+CollectionBase.prototype.last = function() {
+  return this.slice(-1)[0];
+};
+
+/**
  * @method
  * @private
  * @description
@@ -731,10 +749,6 @@ CollectionBase.prototype[Symbol.iterator] = function*() {
  * @see http://lodash.com/docs/#size
  */
 /**
- * @method CollectionBase#first
- * @see http://lodash.com/docs/#first
- */
-/**
  * @method CollectionBase#head
  * @see http://lodash.com/docs/#head
  */
@@ -753,10 +767,6 @@ CollectionBase.prototype[Symbol.iterator] = function*() {
 /**
  * @method CollectionBase#drop
  * @see http://lodash.com/docs/#drop
- */
-/**
- * @method CollectionBase#last
- * @see http://lodash.com/docs/#last
  */
 /**
  * @method CollectionBase#without
@@ -807,13 +817,11 @@ const methods = [
   'minBy',
   'toArray',
   'size',
-  'first',
   'head',
   'take',
   'initial',
   'tail',
   'drop',
-  'last',
   'without',
   'difference',
   'indexOf',

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -864,22 +864,6 @@ ModelBase.prototype._reset = function() {
 };
 
 /**
- * @method ModelBase#keys
- * @see http://lodash.com/docs/#keys
- */
-/**
- * @method ModelBase#values
- * @see http://lodash.com/docs/#values
- */
-/**
- * @method ModelBase#toPairs
- * @see http://lodash.com/docs/#toPairs
- */
-/**
- * @method ModelBase#invert
- * @see http://lodash.com/docs/#invert
- */
-/**
  * @method ModelBase#pick
  * @see http://lodash.com/docs/#pick
  */
@@ -888,7 +872,7 @@ ModelBase.prototype._reset = function() {
  * @see http://lodash.com/docs/#omit
  */
 // "_" methods that we want to implement on the Model.
-const modelMethods = ['keys', 'values', 'toPairs', 'invert', 'pick', 'omit'];
+const modelMethods = ['pick', 'omit'];
 
 // Mix in each "_" method as a proxy to `Model#attributes`.
 _.each(modelMethods, function(method) {

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -510,7 +510,7 @@ module.exports = function(Bookshelf) {
                   .related('admins')
                   .fetch()
                   .then(function(c) {
-                    c.each(function(m) {
+                    c.forEach(function(m) {
                       equal(m.hasChanged(), false);
                     });
                     equal(c.at(0).pivot.get('item'), 'test');
@@ -592,7 +592,7 @@ module.exports = function(Bookshelf) {
                   .related('admins')
                   .fetch()
                   .then(function(c) {
-                    c.each(function(m) {
+                    c.forEach(function(m) {
                       equal(m.hasChanged(), false);
                     });
                     equal(c.at(0).pivot.get('item'), 'test');

--- a/test/unit/collection.js
+++ b/test/unit/collection.js
@@ -1,5 +1,4 @@
-var assert = require('assert');
-var equal = assert.equal;
+const {deepEqual, equal} = require('assert');
 var _ = require('lodash');
 
 module.exports = function() {
@@ -21,7 +20,7 @@ module.exports = function() {
     });
 
     beforeEach(function() {
-      collection = new Collection([{some_id: 1, name: 'Test'}, {name: 'No Id'}]);
+      collection = new Collection([{some_id: 1, name: 'Test'}, {name: 'Test2'}, {name: 'Test3'}]);
     });
 
     it('should have a tableName method that returns the tableName of the model', function() {
@@ -42,7 +41,7 @@ module.exports = function() {
     });
 
     it('should initialize the items passed to the constructor', function() {
-      equal(collection.length, 2);
+      equal(collection.length, 3);
       equal(collection.at(0).id, 1);
       equal(collection.at(1).id, undefined);
     });
@@ -56,7 +55,7 @@ module.exports = function() {
       var model = new ModelBase({id: 1});
       expect(model).to.equal(collection._prepareModel(model));
       var newModel = collection._prepareModel({some_id: 1});
-      assert.ok(newModel instanceof collection.model);
+      equal(newModel instanceof collection.model, true);
     });
 
     it('contains a mapThen method which calls map on the models and returns a when.all promise', function() {
@@ -65,8 +64,8 @@ module.exports = function() {
       });
 
       return collection.mapThen(spyIterator).then(function(resp) {
-        spyIterator.should.have.been.calledTwice;
-        expect(_.compact(resp)).to.eql([1]);
+        equal(spyIterator.callCount, 3);
+        deepEqual(_.compact(resp), [1]);
       });
     });
 
@@ -105,6 +104,34 @@ module.exports = function() {
         var originalLength = collection.length;
         var newLength = collection.add({some_id: 3, name: 'Alice'}, {add: false}).length;
         expect(newLength).to.be.above(originalLength);
+      });
+    });
+
+    describe('#first()', function() {
+      it('returns the first element in the collection', function() {
+        const first = collection.first();
+        equal(first instanceof ModelBase, true);
+        equal(first.get('name'), 'Test');
+      });
+
+      it('returns undefined if the collection is empty', function() {
+        collection = new Collection();
+        const first = collection.first();
+        equal(typeof first, 'undefined');
+      });
+    });
+
+    describe('#last()', function() {
+      it('returns the last element in the collection', function() {
+        const last = collection.last();
+        equal(last instanceof ModelBase, true);
+        equal(last.get('name'), 'Test3');
+      });
+
+      it('returns undefined if the collection is empty', function() {
+        collection = new Collection();
+        const last = collection.last();
+        equal(typeof last, 'undefined');
       });
     });
 
@@ -153,7 +180,7 @@ module.exports = function() {
 
       it('should not remove models with {remove: false} option set', function() {
         collection.set([{some_id: 2, name: 'Item2'}], {remove: false});
-        equal(collection.length, 3);
+        equal(collection.length, 4);
       });
 
       it('should not merge new attribute values with {merge: false} option set', function() {


### PR DESCRIPTION
* Related Issues: #2004 

## Introduction

This removes some Model and Collection methods that are just a pass-through to the same named lodash methods.

## Motivation

These methods are not very useful or they duplicate functionality, so they should be removed. Some of them are so strange that no one is really sure why they're still around or if they even make sense, like `Model#invert`.

In the case of `Collection#first` and `Collection#last`, they are useful as shortcuts for some often needed model, but there is no need to use lodash for that functionality.

Closes #2004.

## Proposed solution

A lot of these methods are simply removed. See the linked issue for the complete list. A [migration guide](https://github.com/bookshelf/bookshelf/wiki/Migrating-from-0.15.1-to-1.0.0#model-lodash-methods-invert-keys-topairs-values) is provided to help people that might be using these methods.

There are also two methods that are re-implemented using functionality that is already available in Bookshelf, without the need to involve lodash: `Collection#first` and `Collection#last`. There is no difference in terms of functionality in this case.

## Current PR Issues

Breaks backwards-compatibility.
