### PR TITLE
Rg require fetch

### DIFF
--- a/lib/base/collection.js
+++ b/lib/base/collection.js
@@ -10,6 +10,34 @@ const Promise = require('bluebird');
 const ModelBase = require('./model');
 const extend = require('../extend');
 
+// List of attributes attached directly from the constructor's options object.
+//
+// RE: 'relatedData'
+// It's okay for two `Collection`s to share a `Relation` instance.
+// `relatedData` does not mutate itself after declaration. This is only
+// here because `clone` needs to duplicate this property. It should not
+// be documented as a valid argument for consumer code.
+//
+// RE: 'attach', 'detach', 'updatePivot', 'withPivot', '_processPivot', '_processPlainPivot', '_processModelPivot'
+// It's okay to whitelist also given method references to be copied when cloning
+// a collection. These methods are present only when `relatedData` is present and
+// its `type` is 'belongsToMany'. So it is safe to put them in the list and use them
+// without any additional verification.
+// These should not be documented as a valid arguments for consumer code.
+const collectionProps = [
+  'model',
+  'comparator',
+  'relatedData',
+  // `belongsToMany` pivotal collection properties
+  'attach',
+  'detach',
+  'updatePivot',
+  'withPivot',
+  '_processPivot',
+  '_processPlainPivot',
+  '_processModelPivot'
+];
+
 /**
  * @class CollectionBase
  * @extends Events
@@ -55,34 +83,6 @@ function CollectionBase(models, options) {
  * @see Events#trigger
  */
 inherits(CollectionBase, Events);
-
-// List of attributes attached directly from the constructor's options object.
-//
-// RE: 'relatedData'
-// It's okay for two `Collection`s to share a `Relation` instance.
-// `relatedData` does not mutate itself after declaration. This is only
-// here because `clone` needs to duplicate this property. It should not
-// be documented as a valid argument for consumer code.
-//
-// RE: 'attach', 'detach', 'updatePivot', 'withPivot', '_processPivot', '_processPlainPivot', '_processModelPivot'
-// It's okay to whitelist also given method references to be copied when cloning
-// a collection. These methods are present only when `relatedData` is present and
-// its `type` is 'belongsToMany'. So it is safe to put them in the list and use them
-// without any additional verification.
-// These should not be documented as a valid arguments for consumer code.
-const collectionProps = [
-  'model',
-  'comparator',
-  'relatedData',
-  // `belongsToMany` pivotal collection properties
-  'attach',
-  'detach',
-  'updatePivot',
-  'withPivot',
-  '_processPivot',
-  '_processPlainPivot',
-  '_processModelPivot'
-];
 
 // Copied over from Backbone.
 const setOptions = {add: true, remove: true, merge: true};

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -7,9 +7,6 @@ const inherits = require('util').inherits;
 const Events = require('./events');
 const constants = require('../constants');
 
-// List of attributes attached directly from the `options` passed to the constructor.
-const modelProps = ['tableName', 'hasTimestamps'];
-
 /**
  * @class
  * @classdesc
@@ -28,11 +25,15 @@ function ModelBase(attributes, options) {
   this._reset();
   this.relations = {};
   this.cid = _.uniqueId('c');
-  _.extend(this, _.pick(options, modelProps));
 
   if (options.parse) attrs = this.parse(attrs, options) || {};
   if (options.visible) this.visible = _.clone(options.visible);
   if (options.hidden) this.hidden = _.clone(options.hidden);
+  if (typeof options.requireFetch === 'boolean') this.requireFetch = options.requireFetch;
+  if (options.tableName) this.tableName = options.tableName;
+  if (typeof options.hasTimestamps === 'boolean' || Array.isArray(options.hasTimestamps)) {
+    this.hasTimestamps = options.hasTimestamps;
+  }
 
   this.set(attrs, options);
   this.initialize.apply(this, arguments);
@@ -155,6 +156,39 @@ ModelBase.prototype.idAttribute = 'id';
  * })
  */
 ModelBase.prototype.defaults = null;
+
+/**
+ * Allows defining the default behavior when there are no results when fetching a model from the
+ * database. This applies to all fetch style operations: {@link Model#fetch fetch},
+ * {@link Model#fetchAll fetchAll}, {@link Model.fetchAll}, {@link Model#fetchPage fetchPage}.
+ *
+ * You can override this model option when fetching by passing the `{require: false}` or
+ * `{require: true}` option to any of the fetch methods.
+ *
+ * @default true
+ * @since 1.0.0
+ * @example
+ *
+ * // Default behavior
+ * const MyModel = bookshelf.model('MyModel', {
+ *   tableName: 'my_models'
+ * })
+ *
+ * new MyModel({id: 1}).fetch().catch(error => {
+ *   // Will throw NotFoundError if there are no results
+ * })
+ *
+ * // Overriding the default behavior
+ * const MyModel = bookshelf.model('MyModel', {
+ *   requireFetch: false,
+ *   tableName: 'my_models'
+ * })
+ *
+ * new MyModel({id: 1}).fetch(model => {
+ *   // model will be null if there are no results
+ })
+ */
+ModelBase.prototype.requireFetch = true;
 
 /**
  * @member {Boolean|Array}

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -160,11 +160,13 @@ ModelBase.prototype.defaults = null;
 /**
  * Allows defining the default behavior when there are no results when fetching a model from the
  * database. This applies to all fetch style operations: {@link Model#fetch fetch},
- * {@link Model#fetchAll fetchAll}, {@link Model.fetchAll}, {@link Model#fetchPage fetchPage}.
+ * {@link Model#fetchAll fetchAll}, {@link Model.fetchAll}, {@link Model#fetchPage fetchPage},
+ * {@link Collection#fetch} and {@link Collection#fetchOne}.
  *
  * You can override this model option when fetching by passing the `{require: false}` or
  * `{require: true}` option to any of the fetch methods.
  *
+ * @type {boolean}
  * @default true
  * @since 1.0.0
  * @example

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -159,12 +159,11 @@ ModelBase.prototype.defaults = null;
 
 /**
  * Allows defining the default behavior when there are no results when fetching a model from the
- * database. This applies to all fetch style operations: {@link Model#fetch fetch},
- * {@link Model#fetchAll fetchAll}, {@link Model.fetchAll}, {@link Model#fetchPage fetchPage},
- * {@link Collection#fetch} and {@link Collection#fetchOne}.
+ * database. This applies only when fetching a single model using {@link Model#fetch fetch} or
+ * {@link Collection#fetchOne}.
  *
  * You can override this model option when fetching by passing the `{require: false}` or
- * `{require: true}` option to any of the fetch methods.
+ * `{require: true}` option to any of the fetch methods mentioned above.
  *
  * @type {boolean}
  * @default true

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -947,7 +947,7 @@ _.each(modelMethods, function(method) {
  *       throw new Error('Email and password are both required')
  *
  *     return new this({email: email.toLowerCase()})
- *       .fetch({require: true})
+ *       .fetch()
  *       .tap(function(customer) {
  *         if (!compare(password, customer.get('password'))
  *           throw new Error('Invalid password')

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -226,8 +226,8 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      *
      * @param {Object=}  options
      * @param {Boolean} [options.require=true]
-     *   Rejects the returned Promise with a {@link Model.NotFoundError} if no records can be
-     *   fetched from the database.
+     *   Whether or not to reject the returned Promise with a {@link Model.NotFoundError} if no
+     *   records can be fetched from the database.
      * @param {(string|string[])} [options.columns='*']
      *   Limit the number of columns fetched.
      * @param {Transaction} [options.transacting] Optionally run the query in a transaction.
@@ -235,10 +235,11 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      *  Type of row-level lock to use. Valid options are `forShare` and
      *  `forUpdate`. This only works in conjunction with the `transacting`
      *  option, and requires a database that supports it.
-     *
      * @throws {Model.NotFoundError}
      * @returns {Promise<Model|null>}
-     *  A promise resolving to the fetched {@link Model model} or `null` if none exists.
+     *  A promise resolving to the fetched {@link Model} or `null` if none exists and the
+     *  `require: false` option is passed or {@link Model#requireFetch requireFetch} is set to
+     *  `false`.
      */
     fetchOne: Promise.method(function(options) {
       const model = new this.model();

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -119,7 +119,7 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      *   Upon a sucessful query resulting in no records returned. Only fired if `require: true` is
      *   passed as an option.
      * @param {Object=} options
-     * @param {Boolean} [options.require=false]
+     * @param {Boolean} [options.require=true]
      *   Whether or not to throw a {@link Collection.EmptyError} if no records are found.
      * @param {string|string[]} [options.withRelated=[]]
      *   A relation, or list of relations, to be eager loaded as part of the `fetch` operation.
@@ -226,9 +226,9 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      *   });
      *
      * @param {Object=}  options
-     * @param {Boolean} [options.require=false]
-     *   If `true`, will reject the returned response with a {@link
-     *   Model.NotFoundError NotFoundError} if no result is found.
+     * @param {Boolean} [options.require=true]
+     *   Rejects the returned Promise with a {@link Model.NotFoundError} if no records can be
+     *   fetched from the databse.
      * @param {(string|string[])} [options.columns='*']
      *   Limit the number of columns fetched.
      * @param {Transaction} [options.transacting] Optionally run the query in a transaction.

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -96,16 +96,16 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
 
     /**
      * Fetch the default set of models for this collection from the database,
-     * resetting the collection when they arrive. If you wish to trigger an error
-     * if the fetched collection is empty, pass `{require: true}` as one of the
-     * options to the {@link Collection#fetch fetch} call. A {@link
+     * resetting the collection when they arrive. If you do not wish to trigger
+     * an error if the fetched collection is empty, pass `{require: false}` as
+     * one of the options to the {@link Collection#fetch fetch} call. A {@link
      * Collection#fetched "fetched"} event will be fired when records are
      * successfully retrieved. If you need to constrain the query performed by
      * `fetch`, you can call the {@link Collection#query query} method before
      * calling `fetch`.
      *
-     * *If you'd like to only fetch specific columns, you may specify a `columns`
-     * property in the options for the `fetch` call.*
+     * If you'd like to only fetch specific columns, you may specify a `columns`
+     * property in the options for the `fetch` call.
      *
      * The `withRelated` option may be specified to fetch the models of the
      * collection, eager loading any specified {@link Relation relations} named on
@@ -116,8 +116,9 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      *
      * @fires Collection#fetched
      * @throws {Collection.EmptyError}
-     *   Upon a sucessful query resulting in no records returned. Only fired if `require: true` is
-     *   passed as an option.
+     *   Thrown if no records are found. You can pass the `require: false` option
+     *   to override this behavior or set it at the model level for all fetch
+     *   operations with the {@link Model#requireFetch} option.
      * @param {Object=} options
      * @param {Boolean} [options.require=true]
      *   Whether or not to throw a {@link Collection.EmptyError} if no records are found.
@@ -228,7 +229,7 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      * @param {Object=}  options
      * @param {Boolean} [options.require=true]
      *   Rejects the returned Promise with a {@link Model.NotFoundError} if no records can be
-     *   fetched from the databse.
+     *   fetched from the database.
      * @param {(string|string[])} [options.columns='*']
      *   Limit the number of columns fetched.
      * @param {Transaction} [options.transacting] Optionally run the query in a transaction.
@@ -495,8 +496,9 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
        * @class Collection.EmptyError
        * @description
        *   Thrown when no records are found by {@link Collection#fetch fetch},
-       *   {@link Model#fetchAll}, or {@link Model.fetchAll} when called with
-       *   the `{require: true}` option.
+       *   {@link Model#fetchAll}, {@link Model#fetchPage} or
+       *   {@link Model.fetchAll} by default. This behavior can be overrided with
+       *   the {@link Model#requireFetch} option.
        */
       child.EmptyError = createError(this.EmptyError);
     }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -96,9 +96,9 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
 
     /**
      * Fetch the default set of models for this collection from the database,
-     * resetting the collection when they arrive. If you do not wish to trigger
-     * an error if the fetched collection is empty, pass `{require: false}` as
-     * one of the options to the {@link Collection#fetch fetch} call.A {@link
+     * resetting the collection when they arrive. If you wish to trigger an
+     * error if the fetched collection is empty, pass `{require: true}` as one
+     * of the options to the {@link Collection#fetch fetch} call. A {@link
      * Collection#fetched "fetched"} event will be fired when records are
      * successfully retrieved. If you need to constrain the query performed by
      * `fetch`, you can call the {@link Collection#query query} method before
@@ -117,10 +117,9 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      * @fires Collection#fetched
      * @throws {Collection.EmptyError} Thrown if no records are found.
      * @param {Object=} options
-     * @param {Boolean} [options.require=true]
+     * @param {Boolean} [options.require=false]
      *   Whether or not to throw a {@link Collection.EmptyError} if no records are found.
-     *   You can pass the `require: false` option to override this behavior or set it at
-     *   the model level for all fetch operations with the {@link Model#requireFetch} option.
+     *   You can pass the `require: true` option to override this behavior.
      * @param {string|string[]} [options.withRelated=[]]
      *   A relation, or list of relations, to be eager loaded as part of the `fetch` operation.
      * @returns {Promise<Collection>}
@@ -168,7 +167,7 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
             return this.triggerThen('fetched', this, response, options);
           })
           .catch(this.constructor.EmptyError, function(err) {
-            if ((this.model.prototype.requireFetch && options.require !== false) || options.require) throw err;
+            if (options.require) throw err;
             this.reset([], {silent: true});
           })
           .return(this)
@@ -494,10 +493,9 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
       /**
        * @class Collection.EmptyError
        * @description
-       *   Thrown when no records are found by {@link Collection#fetch fetch},
-       *   {@link Model#fetchAll}, {@link Model#fetchPage} or
-       *   {@link Model.fetchAll} by default. This behavior can be overrided with
-       *   the {@link Model#requireFetch} option.
+       *   Thrown by default when no records are found by {@link Collection#fetch fetch} or
+       *   {@link Collection#fetchOne}. This behavior can be overrided with the
+       *   {@link Model#requireFetch} option.
        */
       child.EmptyError = createError(this.EmptyError);
     }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -168,9 +168,7 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
             return this.triggerThen('fetched', this, response, options);
           })
           .catch(this.constructor.EmptyError, function(err) {
-            if (options.require) {
-              throw err;
-            }
+            if (options.require !== false) throw err;
             this.reset([], {silent: true});
           })
           .return(this)

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -168,7 +168,7 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
             return this.triggerThen('fetched', this, response, options);
           })
           .catch(this.constructor.EmptyError, function(err) {
-            if (options.require !== false) throw err;
+            if ((this.model.prototype.requireFetch && options.require !== false) || options.require) throw err;
             this.reset([], {silent: true});
           })
           .return(this)

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -98,7 +98,7 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      * Fetch the default set of models for this collection from the database,
      * resetting the collection when they arrive. If you do not wish to trigger
      * an error if the fetched collection is empty, pass `{require: false}` as
-     * one of the options to the {@link Collection#fetch fetch} call. A {@link
+     * one of the options to the {@link Collection#fetch fetch} call.A {@link
      * Collection#fetched "fetched"} event will be fired when records are
      * successfully retrieved. If you need to constrain the query performed by
      * `fetch`, you can call the {@link Collection#query query} method before
@@ -115,13 +115,12 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      * may be retrieved with the {@link Model#related related} method.
      *
      * @fires Collection#fetched
-     * @throws {Collection.EmptyError}
-     *   Thrown if no records are found. You can pass the `require: false` option
-     *   to override this behavior or set it at the model level for all fetch
-     *   operations with the {@link Model#requireFetch} option.
+     * @throws {Collection.EmptyError} Thrown if no records are found.
      * @param {Object=} options
      * @param {Boolean} [options.require=true]
      *   Whether or not to throw a {@link Collection.EmptyError} if no records are found.
+     *   You can pass the `require: false` option to override this behavior or set it at
+     *   the model level for all fetch operations with the {@link Model#requireFetch} option.
      * @param {string|string[]} [options.withRelated=[]]
      *   A relation, or list of relations, to be eager loaded as part of the `fetch` operation.
      * @returns {Promise<Collection>}

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -20,17 +20,16 @@ function ModelNotResolvedError() {
 }
 
 module.exports = {
-  // Thrown when the model is not found and {require: true} is passed in the fetch options
+  // Thrown when a model is not found.
   NotFoundError: createError('NotFoundError'),
 
-  // Thrown when the collection is empty and {require: true} is passed in model.fetchAll or
-  // collection.fetch
+  // Thrown when the collection is empty upon fetching it.
   EmptyError: createError('EmptyError'),
 
-  // Thrown when an update affects no rows and {require: true} is passed in model.save.
+  // Thrown when an update affects no rows
   NoRowsUpdatedError: createError('NoRowsUpdatedError'),
 
-  // Thrown when a delete affects no rows and {require: true} is passed in model.destroy.
+  // Thrown when a delete affects no rows.
   NoRowsDeletedError: createError('NoRowsDeletedError'),
 
   ModelNotResolvedError

--- a/lib/model.js
+++ b/lib/model.js
@@ -585,7 +585,7 @@ const BookshelfModel = ModelBase.extend(
      *   options that can be specified.
      * @param {boolean} [options.require=true]
      *   Rejects the returned Promise with a {@link Collection.EmptyError} if no records can be
-     *   fetched from the databse.
+     *   fetched from the database.
      * @param {number} [options.pageSize]
      *   How many models to include in each page, defaulting to 10 if not specified. Used only together with the `page`
      *   option.
@@ -785,24 +785,26 @@ const BookshelfModel = ModelBase.extend(
     /**
      * Fetches a collection of {@link Model models} from the database, using any
      * query parameters currently set on the model to form a select query. Returns
-     * a Promise, which will resolve with the fetched collection. If you wish to
-     * trigger an error if no models are found, pass `{require: true}` as one of
-     * the options.
+     * a Promise, which will resolve with the fetched collection. If there are no
+     * results it will trigger a {@link Collection.EmptyError}. If you wish to
+     * return an empty collection if no models are found, pass the
+     * `require: false` option. You can override this behavior at the model level
+     * for all fetch calls with the {@link Model#requireFetch} option.
      *
-     * If you need to constrain the query performed by fetch, you can call the
-     * {@link Model#query query} method before calling fetch.
+     * If you need to constrain the results, you can call the {@link Model#query query}
+     * or {@link Model#where where} methods before calling this method.
      *
      * @method Model#fetchAll
      * @param {Object} [options] Set of options to modify the request.
      * @param {Boolean} [options.require=true]
-     *   Rejects the returned Promise with a {@link Collection.EmptyError} if no records can be
-     *   fetched from the databse.
+     *   Whether or not to reject with a {@link Collection.EmptyError} if no records can be
+     *   fetched from the database.
      * @param {Transaction} [options.transacting] Optionally run the query in a transaction.
      * @fires Model#fetching:collection
      * @fires Model#fetched:collection
      * @throws {Collection.EmptyError}
      *   This error is used to reject the Promise in the event of an empty response from the
-     *   database if the `require: true` option is used.
+     *   database.
      * @returns {Promise} A Promise resolving to the fetched {@link Collection collection}.
      */
     fetchAll(options) {
@@ -1459,30 +1461,26 @@ const BookshelfModel = ModelBase.extend(
   {
     extended(child) {
       /**
-       * @class Model.NotFoundError
-       * @description
+       * Thrown when no records are found by {@link Model#fetch fetch} or
+       * {@link Model#refresh} unless called with the `{require: false}` option.
        *
-       *   Thrown when no records are found by {@link Model#fetch fetch} or
-       *   {@link Model#refresh} when called with the
-       *   `{require: true}` option.
+       * @class Model.NotFoundError
        */
       child.NotFoundError = createError(this.NotFoundError);
 
       /**
-       * @class Model.NoRowsUpdatedError
-       * @description
+       * Thrown when no records are saved by {@link Model#save save}
+       * unless called with the `{require: false}` option.
        *
-       *   Thrown when no records are saved by {@link Model#save save}
-       *   unless called with the `{require: false}` option.
+       * @class Model.NoRowsUpdatedError
        */
       child.NoRowsUpdatedError = createError(this.NoRowsUpdatedError);
 
       /**
-       * @class Model.NoRowsDeletedError
-       * @description
+       * Thrown when no record is deleted by {@link Model#destroy destroy}
+       * unless called with the `{require: false}` option.
        *
-       *   Thrown when no record is deleted by {@link Model#destroy destroy}
-       *   if called with the `{require: true}` option.
+       * @class Model.NoRowsDeletedError
        */
       child.NoRowsDeletedError = createError(this.NoRowsDeletedError);
     },

--- a/lib/model.js
+++ b/lib/model.js
@@ -583,6 +583,9 @@ const BookshelfModel = ModelBase.extend(
      * @param {Object} [options]
      *   Besides the basic options that can be passed to {@link Model#fetchAll}, there are some additional pagination
      *   options that can be specified.
+     * @param {boolean} [options.require=true]
+     *   Rejects the returned Promise with a {@link Collection.EmptyError} if no records can be
+     *   fetched from the databse.
      * @param {number} [options.pageSize]
      *   How many models to include in each page, defaulting to 10 if not specified. Used only together with the `page`
      *   option.
@@ -663,11 +666,10 @@ const BookshelfModel = ModelBase.extend(
      *     });
      *
      * @method Model#fetch
-     *
      * @param {Object=}  options - Hash of options.
-     * @param {Boolean=} [options.require=false]
+     * @param {Boolean=} [options.require=true]
      *   Reject the returned response with a {@link Model.NotFoundError
-     *   NotFoundError} if results are empty.
+     *   NotFoundError} if there are no results when fetching.
      * @param {string|string[]} [options.columns='*']
      *   Specify columns to be retrieved.
      * @param {Transaction} [options.transacting]
@@ -679,12 +681,9 @@ const BookshelfModel = ModelBase.extend(
      * @param {string|Object|mixed[]} [options.withRelated]
      *  Relations to be retrieved with `Model` instance. Either one or more
      *  relation names or objects mapping relation names to query callbacks.
-     *
      * @fires Model#fetching
      * @fires Model#fetched
-     *
      * @throws {Model.NotFoundError}
-     *
      * @returns {Promise<Model|null>}
      *  A promise resolving to the fetched {@link Model model} or `null` if
      *  none exists.
@@ -795,7 +794,7 @@ const BookshelfModel = ModelBase.extend(
      *
      * @method Model#fetchAll
      * @param {Object} [options] Set of options to modify the request.
-     * @param {Boolean} [options.require=false]
+     * @param {Boolean} [options.require=true]
      *   Rejects the returned Promise with a {@link Collection.EmptyError} if no records can be
      *   fetched from the databse.
      * @param {Transaction} [options.transacting] Optionally run the query in a transaction.

--- a/lib/model.js
+++ b/lib/model.js
@@ -743,7 +743,7 @@ const BookshelfModel = ModelBase.extend(
           })
           .return(this)
           .catch(this.constructor.NotFoundError, function(err) {
-            if (options.require !== false) throw err;
+            if ((this.requireFetch && options.require !== false) || options.require) throw err;
             return null;
           })
       );

--- a/lib/model.js
+++ b/lib/model.js
@@ -744,9 +744,7 @@ const BookshelfModel = ModelBase.extend(
           })
           .return(this)
           .catch(this.constructor.NotFoundError, function(err) {
-            if (options.require) {
-              throw err;
-            }
+            if (options.require !== false) throw err;
             return null;
           })
       );

--- a/lib/model.js
+++ b/lib/model.js
@@ -590,8 +590,7 @@ const BookshelfModel = ModelBase.extend(
      * @param {number} [options.offset]
      *   Index to begin fetching results from. The default and initial value is `0`. Used only with the `limit` option.
      * @returns {Promise<Collection>}
-     *   Returns a Promise that will resolve to the paginated collection of models. Note that if there are no results
-     *   the Promise will reject unless the `require: false` option is passed.
+     *   Returns a Promise that will resolve to the paginated collection of models.
      */
     fetchPage(options = {}) {
       return Helpers.fetchPage.call(this, options);
@@ -658,7 +657,7 @@ const BookshelfModel = ModelBase.extend(
      *     });
      *
      * @method Model#fetch
-     * @param {Object=}  options - Hash of options.
+     * @param {Object=} options Hash of options.
      * @param {Boolean=} [options.require=true]
      *   Whether or not to reject the returned response with a
      *   {@link Model.NotFoundError NotFoundError} if there are no results when
@@ -780,26 +779,24 @@ const BookshelfModel = ModelBase.extend(
      * query parameters currently set on the model to constrain the results.
      *
      * Returns a Promise that will resolve with the fetched collection. If there
-     * are no results it will reject with a {@link Collection.EmptyError}. If
-     * instead you wish to return an empty collection in this situation, pass the
-     * `require: false` option. You can override this behavior at the model level
-     * for all fetch calls with the {@link Model#requireFetch} option.
+     * are no results it will resolve with an empty collection. If instead you
+     * wish the Promise to be rejected with a {@link Collection.EmptyError},
+     * pass the `require: true` option.
      *
      * If you need to constrain the results, you can call the {@link Model#query query}
      * or {@link Model#where where} methods before calling this method.
      *
      * @method Model#fetchAll
      * @param {Object} [options] Set of options to modify the request.
-     * @param {boolean} [options.require=true]
+     * @param {boolean} [options.require=false]
      *   Whether or not to reject the returned Promise with a {@link Collection.EmptyError} if no records can be
-     *   fetched from the database. If set to `false` the Promise will resolve with an empty collection instead of
-     *   being rejected.
+     *   fetched from the database.
      * @param {Transaction} [options.transacting] Optionally run the query in a transaction.
      * @fires Model#fetching:collection
      * @fires Model#fetched:collection
      * @throws {Collection.EmptyError}
      *   This error is used to reject the Promise in the event of an empty response from the
-     *   database.
+     *   database in case the `require: true` fetch option is used.
      * @returns {Promise} A Promise resolving to the fetched {@link Collection collection}.
      */
     fetchAll(options) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -549,12 +549,7 @@ const BookshelfModel = ModelBase.extend(
      * values of `{page: 1, pageSize: 10}`.
      *
      * @example
-     * Car
-     *   .query(function(qb) {
-     *     qb.innerJoin('manufacturers', 'cars.manufacturer_id', 'manufacturers.id')
-     *     qb.groupBy('cars.id')
-     *     qb.where('manufacturers.country', '=', 'Sweden')
-     *   })
+     * new Car()
      *   .fetchPage({
      *     pageSize: 15, // Defaults to 10 if not specified
      *     page: 3, // Defaults to 1 if not specified
@@ -583,9 +578,6 @@ const BookshelfModel = ModelBase.extend(
      * @param {Object} [options]
      *   Besides the basic options that can be passed to {@link Model#fetchAll}, there are some additional pagination
      *   options that can be specified.
-     * @param {boolean} [options.require=true]
-     *   Rejects the returned Promise with a {@link Collection.EmptyError} if no records can be
-     *   fetched from the database.
      * @param {number} [options.pageSize]
      *   How many models to include in each page, defaulting to 10 if not specified. Used only together with the `page`
      *   option.
@@ -599,26 +591,25 @@ const BookshelfModel = ModelBase.extend(
      *   Index to begin fetching results from. The default and initial value is `0`. Used only with the `limit` option.
      * @returns {Promise<Collection>}
      *   Returns a Promise that will resolve to the paginated collection of models. Note that if there are no results
-     *   the return value will be an empty Collection.
+     *   the Promise will reject unless the `require: false` option is passed.
      */
-    fetchPage(options) {
-      if (!options) options = {};
+    fetchPage(options = {}) {
       return Helpers.fetchPage.call(this, options);
     },
 
     /**
      * Fetches a {@link Model model} from the database, using any {@link
-     * Model#attributes attributes} currently set on the model to form a `select`
-     * query.
+     * Model#attributes attributes} currently set on the model to constrain the
+     * results.
      *
      * A {@link Model#event:fetching "fetching"} event will be fired just before the
      * record is fetched; a good place to hook into for validation. {@link
      * Model#event:fetched "fetched"} event will be fired when a record is
      * successfully retrieved.
      *
-     * If you need to constrain the query
-     * performed by fetch, you can call {@link Model#query query} before calling
-     * {@link Model#fetch fetch}.
+     * If you need to constrain the query performed by fetch, you can call
+     * {@link Model#query query} or {@link Model#where where} before calling
+     * fetch.
      *
      *     // select * from `books` where `ISBN-13` = '9780440180296'
      *     new Book({'ISBN-13': '9780440180296'})
@@ -628,10 +619,11 @@ const BookshelfModel = ModelBase.extend(
      *         console.log(model.get('title'));
      *       });
      *
-     * _If you'd like to only fetch specific columns, you may specify a `columns`
-     * property in the `options` for the {@link Model#fetch fetch} call, or use
-     * {@link Model#query query}, tapping into the {@link Knex} {@link
-     * Knex#column column} method to specify which columns will be fetched._
+     * If you'd like to only fetch specific columns, you may specify a `columns`
+     * property in the `options` for the fetch call, or use
+     * {@link Model#query query}, tapping into the
+     * {@link https://knexjs.org/#Builder-column|Knex column} method to specify
+     * which columns will be fetched.
      *
      * A single property, or an array of properties can be specified as a value for
      * the `withRelated` property. You can also execute callbacks on relations
@@ -668,8 +660,9 @@ const BookshelfModel = ModelBase.extend(
      * @method Model#fetch
      * @param {Object=}  options - Hash of options.
      * @param {Boolean=} [options.require=true]
-     *   Reject the returned response with a {@link Model.NotFoundError
-     *   NotFoundError} if there are no results when fetching.
+     *   Whether or not to reject the returned response with a
+     *   {@link Model.NotFoundError NotFoundError} if there are no results when
+     *   fetching. If set to `false` it will resolve with `null` instead.
      * @param {string|string[]} [options.columns='*']
      *   Specify columns to be retrieved.
      * @param {Transaction} [options.transacting]
@@ -686,7 +679,7 @@ const BookshelfModel = ModelBase.extend(
      * @throws {Model.NotFoundError}
      * @returns {Promise<Model|null>}
      *  A promise resolving to the fetched {@link Model model} or `null` if
-     *  none exists.
+     *  none exists and the `require: false` option is passed.
      *
      */
     fetch(options) {
@@ -784,10 +777,11 @@ const BookshelfModel = ModelBase.extend(
 
     /**
      * Fetches a collection of {@link Model models} from the database, using any
-     * query parameters currently set on the model to form a select query. Returns
-     * a Promise, which will resolve with the fetched collection. If there are no
-     * results it will trigger a {@link Collection.EmptyError}. If you wish to
-     * return an empty collection if no models are found, pass the
+     * query parameters currently set on the model to constrain the results.
+     *
+     * Returns a Promise that will resolve with the fetched collection. If there
+     * are no results it will reject with a {@link Collection.EmptyError}. If
+     * instead you wish to return an empty collection in this situation, pass the
      * `require: false` option. You can override this behavior at the model level
      * for all fetch calls with the {@link Model#requireFetch} option.
      *
@@ -796,9 +790,10 @@ const BookshelfModel = ModelBase.extend(
      *
      * @method Model#fetchAll
      * @param {Object} [options] Set of options to modify the request.
-     * @param {Boolean} [options.require=true]
-     *   Whether or not to reject with a {@link Collection.EmptyError} if no records can be
-     *   fetched from the database.
+     * @param {boolean} [options.require=true]
+     *   Whether or not to reject the returned Promise with a {@link Collection.EmptyError} if no records can be
+     *   fetched from the database. If set to `false` the Promise will resolve with an empty collection instead of
+     *   being rejected.
      * @param {Transaction} [options.transacting] Optionally run the query in a transaction.
      * @fires Model#fetching:collection
      * @fires Model#fetched:collection
@@ -1462,7 +1457,8 @@ const BookshelfModel = ModelBase.extend(
     extended(child) {
       /**
        * Thrown when no records are found by {@link Model#fetch fetch} or
-       * {@link Model#refresh} unless called with the `{require: false}` option.
+       * {@link Model#refresh refresh} unless called with the `{require: false}`
+       * option.
        *
        * @class Model.NotFoundError
        */

--- a/lib/relation.js
+++ b/lib/relation.js
@@ -934,9 +934,7 @@ const PivotHelpers = {
 
     return joinModel
       .set(fks)
-      .fetch({
-        require: true
-      })
+      .fetch()
       .then(function(instance) {
         if (method === 'delete') {
           return instance.destroy(options);

--- a/test/integration/collection.js
+++ b/test/integration/collection.js
@@ -115,7 +115,7 @@ module.exports = function(bookshelf) {
           .roles()
           .fetchPage()
           .then(function(results) {
-            expect(results.length).to.equal(1);
+            expect(results.length).to.equal(2);
             expect(results).to.have.property('models');
             expect(results).to.have.property('pagination');
           });
@@ -129,7 +129,7 @@ module.exports = function(bookshelf) {
           })
           .fetchPage()
           .then(function(results) {
-            expect(results.length).to.equal(0);
+            expect(results.length).to.equal(1);
             expect(results).to.have.property('models');
             expect(results).to.have.property('pagination');
           });
@@ -151,31 +151,37 @@ module.exports = function(bookshelf) {
           .authors()
           .query({where: {id: 40}})
           .fetchOne()
-          .then(function(model) {
-            equal(model, null);
+          .then((model) => {
+            assert.fail('Expected the promise to be rejected but it resolved');
+          })
+          .catch((error) => {
+            equal(error instanceof Author.NotFoundError, true);
           });
       });
 
-      it('follows the typical model options, like require: true', function() {
-        return new Site({id: 1})
-          .authors()
-          .query({where: {id: 40}})
-          .fetchOne({require: true})
-          .throw(new Error())
-          .catch(function(err) {
-            equal(
-              err instanceof Author.NotFoundError,
-              true,
-              'Expected error to be an instance of Author.NotFoundError'
-            );
-          });
-      });
-
-      it('resolves to null if no model exists', function() {
+      it('rejects with an error if no record exists', function() {
         return new Site({id: 1})
           .authors()
           .query({where: {id: 40}})
           .fetchOne()
+          .then((model) => {
+            assert.fail('Expected the promise to be rejected but it resolved');
+          })
+          .catch((error) => {
+            equal(
+              error instanceof Author.NotFoundError,
+              true,
+              'Expected error to be an instance of Author.NotFoundError'
+            );
+            equal(error.message, 'EmptyResponse');
+          });
+      });
+
+      it('resolves to null with the {require: false} option if no model exists', function() {
+        return new Site({id: 1})
+          .authors()
+          .query({where: {id: 40}})
+          .fetchOne({require: false})
           .then(function(model) {
             equal(model, null);
           });

--- a/test/integration/helpers/inserts.js
+++ b/test/integration/helpers/inserts.js
@@ -280,9 +280,9 @@ module.exports = function(bookshelf) {
 
     knex('users').insert({uid: 1, username: 'root'}),
 
-    knex('roles').insert({rid: 4, name: 'admin'}),
+    knex('roles').insert([{rid: 4, name: 'admin'}, {rid: 5, name: 'accouting'}]),
 
-    knex('users_roles').insert({uid: 1, rid: 4}),
+    knex('users_roles').insert([{uid: 1, rid: 4}, {uid: 1, rid: 5}]),
 
     knex('Customer').insert([
       {id: 1, name: 'Customer1'},

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -355,34 +355,10 @@ module.exports = function(bookshelf) {
             });
         });
 
-        it('allows overriding the model level {require: false} option', function() {
-          return new FalseAuthor()
-            .where({id: 200})
-            .fetchAll({require: true})
-            .then((models) => {
-              assert.fail('Expected the promise to be rejected but it resolved');
-            })
-            .catch((error) => {
-              equal(error.message, 'EmptyResponse');
-            });
-        });
-
-        it('rejects with NotFoundError by default', function() {
+        it('is not affected by the model level {require: true} option', function() {
           return new Models.Author()
             .where({id: 200})
             .fetchAll()
-            .then((models) => {
-              assert.fail('Expected the promise to be rejected but it resolved');
-            })
-            .catch((error) => {
-              equal(error.message, 'EmptyResponse');
-            });
-        });
-
-        it('allows overriding the default Model level option', function() {
-          return new FalseAuthor()
-            .where({id: 200})
-            .fetchAll({require: false})
             .then((models) => {
               equal(models.length, 0);
             });
@@ -759,15 +735,12 @@ module.exports = function(bookshelf) {
         });
       });
 
-      it('rejects if there are no results', function() {
+      it('returns an empty collection if there are no results', function() {
         return new Models.Member()
           .where('name', 'hal9000')
           .fetchAll()
-          .then(() => {
-            assert.fail('Expected the Promise to be rejected but it resolved');
-          })
-          .catch((error) => {
-            equal(error.message, 'EmptyResponse');
+          .then((models) => {
+            equal(models.length, 0);
           });
       });
     });
@@ -791,16 +764,13 @@ module.exports = function(bookshelf) {
           });
       });
 
-      it('rejects if there are no results', function() {
+      it('returns an empty collection if there are no results', function() {
         return bookshelf
           .knex('critics_comments')
           .del()
           .then(() => Models.CriticComment.forge().fetchPage())
-          .then(function(results) {
-            assert.fail('Expected the Promise to be rejected but it resolved');
-          })
-          .catch((error) => {
-            equal(error.message, 'EmptyResponse');
+          .then((results) => {
+            equal(results.length, 0);
           });
       });
 

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -304,6 +304,92 @@ module.exports = function(bookshelf) {
       });
     });
 
+    describe('#requireFetch', function() {
+      const FalseAuthor = Models.Author.extend({requireFetch: false});
+
+      describe('with #fetch()', function() {
+        it('resolves to null if no record exists and the {require: false} model option is set', function() {
+          return new FalseAuthor({id: 200}).fetch().then((model) => {
+            equal(model, null);
+          });
+        });
+
+        it('allows overriding the model level {require: false} option', function() {
+          return new FalseAuthor({id: 200})
+            .fetch({require: true})
+            .then((model) => {
+              assert.fail('Expected the promise to be rejected but it resolved');
+            })
+            .catch((error) => {
+              equal(error instanceof FalseAuthor.NotFoundError, true);
+              equal(error.message, 'EmptyResponse');
+            });
+        });
+
+        it('rejects with NotFoundError by default', function() {
+          return new Models.Author({id: 200})
+            .fetch()
+            .then((model) => {
+              assert.fail('Expected the promise to be rejected but it resolved');
+            })
+            .catch((error) => {
+              equal(error instanceof Models.Author.NotFoundError, true);
+              equal(error.message, 'EmptyResponse');
+            });
+        });
+
+        it('allows overriding the default Model level option', function() {
+          return new FalseAuthor({id: 200}).fetch({require: false}).then((model) => {
+            equal(model, null);
+          });
+        });
+      });
+
+      describe('with #fetchAll()', function() {
+        it('resolves to null if no record exists and the {require: false} model option is set', function() {
+          return new FalseAuthor()
+            .where({id: 200})
+            .fetchAll()
+            .then((models) => {
+              equal(models.length, 0);
+            });
+        });
+
+        it('allows overriding the model level {require: false} option', function() {
+          return new FalseAuthor()
+            .where({id: 200})
+            .fetchAll({require: true})
+            .then((models) => {
+              assert.fail('Expected the promise to be rejected but it resolved');
+            })
+            .catch((error) => {
+              equal(error.message, 'EmptyResponse');
+            });
+        });
+
+        it('rejects with NotFoundError by default', function() {
+          return new Models.Author()
+            .where({id: 200})
+            .fetchAll()
+            .then((models) => {
+              assert.fail('Expected the promise to be rejected but it resolved');
+            })
+            .catch((error) => {
+              equal(error.message, 'EmptyResponse');
+            });
+        });
+
+        it('allows overriding the default Model level option', function() {
+          return new FalseAuthor()
+            .where({id: 200})
+            .fetchAll({require: false})
+            .then((models) => {
+              equal(models.length, 0);
+            });
+        });
+      });
+    });
+
     describe('query', function() {
       var model;
 

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -1852,6 +1852,12 @@ module.exports = {
           name: 'admin',
           _pivot_uid: 1,
           _pivot_rid: 4
+        },
+        {
+          _pivot_rid: 5,
+          _pivot_uid: 1,
+          name: 'accouting',
+          rid: 5
         }
       ]
     },
@@ -1862,6 +1868,12 @@ module.exports = {
           name: 'admin',
           _pivot_uid: 1,
           _pivot_rid: 4
+        },
+        {
+          _pivot_rid: 5,
+          _pivot_uid: 1,
+          name: 'accouting',
+          rid: 5
         }
       ]
     },
@@ -1872,6 +1884,12 @@ module.exports = {
           name: 'admin',
           _pivot_uid: 1,
           _pivot_rid: 4
+        },
+        {
+          _pivot_rid: 5,
+          _pivot_uid: 1,
+          name: 'accouting',
+          rid: 5
         }
       ]
     }
@@ -1887,6 +1905,12 @@ module.exports = {
             name: 'admin',
             _pivot_uid: 1,
             _pivot_rid: 4
+          },
+          {
+            _pivot_rid: 5,
+            _pivot_uid: 1,
+            name: 'accouting',
+            rid: 5
           }
         ]
       }
@@ -1901,6 +1925,12 @@ module.exports = {
             name: 'admin',
             _pivot_uid: 1,
             _pivot_rid: 4
+          },
+          {
+            _pivot_rid: 5,
+            _pivot_uid: 1,
+            name: 'accouting',
+            rid: 5
           }
         ]
       }
@@ -1915,6 +1945,12 @@ module.exports = {
             name: 'admin',
             _pivot_uid: 1,
             _pivot_rid: 4
+          },
+          {
+            _pivot_rid: 5,
+            _pivot_uid: 1,
+            name: 'accouting',
+            rid: 5
           }
         ]
       }

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -544,7 +544,7 @@ module.exports = function(Bookshelf) {
                   });
                 }),
                 admins2.on('detached', function(c) {
-                  return c.fetch().then(function(c) {
+                  return c.fetch({require: false}).then(function(c) {
                     equal(c.length, 0);
                   });
                 })
@@ -626,7 +626,7 @@ module.exports = function(Bookshelf) {
                   });
                 }),
                 admins2.on('detached', function(c) {
-                  return c.fetch().then(function(c) {
+                  return c.fetch({require: false}).then(function(c) {
                     equal(c.length, 0);
                   });
                 })

--- a/tutorials/models.md
+++ b/tutorials/models.md
@@ -27,7 +27,7 @@ const Customer = bookshelf.model('Customer', {
   // Static class properties and methods
   login: Promise.method((email, password) => {
     return new this({email})
-      .fetch({require: true})
+      .fetch()
       .tap((customer) => {
         return bcrypt.compareAsync(password, customer.get('password'))
           .then((valid) => {


### PR DESCRIPTION
* Related Issues: #718

## Introduction

Make `require: true` the default for `Model#fetch` and `Collection#fetchOne` calls.

## Motivation

When fetching a single model there is usually a precise set of constraints, so as a user I'm interested in getting that model, not any other value. This is especially true when logging in a user, or when looking for a specific record of something. Usually all further processing of said model should be skipped since it wouldn't make sense, so this facilitates that mechanism by default.

This change ensures that fetch calls like:
```
new MyModel({id: 1}).fetch()
```
will always resolve with a model, avoiding the need to additionally check if the result is not `null`. If the model cannot be fetched because it does not exist in the database an error will be thrown and the `fetch` call will be rejected with `MyModel.NotFoundError`. This specific error class can be caught and dealt with appropriately:
```
new MyModel({id: 1})
  .fetch()
  .then(myModel => {
    // do something with the fetched model
  })
  .catch(MyModel.NotFoundError, error => {
    // handle no results error
  })
```
Closes #718.

## Proposed solution

This adds a new `Model#requireFetch` property that can be used to set the default behavior when handling empty responses of `Model#fetch`, and sets its default value to `true`, meaning that the default is to reject the `fetch` Promise.

The new model level property also means that users that prefer the previous behavior can easily adapt their code by simply adding `requireFetch: false` to their model definitions.

There is a migration guide in the Wiki to help with the transition to this new default. 

## Current PR Issues

This does not change the default behavior when fetching collections, mainly because it's not easy to catch an `EmptyResponse` error from a collection built from model methods like `Model#fetchAll` or `Model#fetchPage`. It can also be argued that when fetching collections, the requirements are not as strict, and it's usually OK for them to be empty.

Not everyone is going to like this change, but it should be relatively easy to keep using the previous behavior for those that prefer to think is terms of SQL and less about abstract higher level objects.

## Alternatives considered

There are some commits in this series that actually made `require: true` the default also for fetching collections, unifying all fetch interfaces in terms of behavior, but it was proving very difficult (impossible?) to catch errors by a specific collection's `EmptyResponse` error.
