### PR TITLE
Fix throwing of constructor function instead of ModelNotResolvedError

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -32,5 +32,5 @@ module.exports = {
   // Thrown when a delete affects no rows.
   NoRowsDeletedError: createError('NoRowsDeletedError'),
 
-  ModelNotResolvedError
+  ModelNotResolvedError: ModelNotResolvedError()
 };

--- a/test/unit/bookshelf.js
+++ b/test/unit/bookshelf.js
@@ -49,11 +49,11 @@ module.exports = function() {
           testMorphTo: function() {
             return this.morphTo('morphable', ['relType', 'relId'], 'TestModel', ['TestModel', 'relValue']);
           },
-          testThrough: function() {
-            return this.hasMany('TestCollection').through('TestModel');
-          },
           testNotResolved: function() {
             return this.hasOne('NonexistentModel');
+          },
+          testThrough: function() {
+            return this.hasMany('TestCollection').through('TestModel');
           }
         });
 

--- a/test/unit/bookshelf.js
+++ b/test/unit/bookshelf.js
@@ -51,6 +51,9 @@ module.exports = function() {
           },
           testThrough: function() {
             return this.hasMany('TestCollection').through('TestModel');
+          },
+          testNotResolved: function() {
+            return this.hasOne('NonexistentModel');
           }
         });
 
@@ -71,6 +74,12 @@ module.exports = function() {
         relationSpy.restore();
 
         sinon.assert.calledWith(relationSpy, 'hasOne', 'TestModel');
+      });
+
+      it('throws a ModelNotResolved error for nonexistent relations', function() {
+        assert.throws(() => modelWithRelations.testNotResolved(), {
+          message: 'The model NonexistentModel could not be resolved from the registry.'
+        });
       });
 
       it('can be used in through() relations', function() {


### PR DESCRIPTION
## Introduction

Currently, when a user tries to resolve a model that doesn't exist, Bookshelf throws the ModelNotResolvedError constructor function instead of an instance of the error. This PR fixes that.

## Proposed solution

In [lib/errors](https://github.com/bookshelf/bookshelf/blob/6076bd0d46d94c99ea9c853590dc511ac02ab9fd/lib/errors.js), `ModelNotResolvedError` is a function that returns an error constructor function also called `ModelNotResolvedError`. The outer function, rather than the inner function, gets exported. As a result, when Bookshelf tries to `throw new ModelNotResolvedError(...)` [here](https://github.com/bookshelf/bookshelf/blob/97ea1e9b79a84ea2ed1ce34e5417e9e225363332/lib/bookshelf.js#L43) (the only place that error is used), it throws the inner `ModelNotResolvedError` rather than an actual error.

This PR just exports the inner function rather than the outer function from `lib/errors` as `ModelNotResolvedError`.