### PR TITLE
Refresh model attributes after a save operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ It's a lean object-relational mapper, allowing you to drop down to the raw Knex 
 You'll need to install a copy of [Knex](http://knexjs.org/), and either `mysql`, `pg`, or `sqlite3` from npm.
 
 ```js
-$ npm install knex --save
-$ npm install bookshelf --save
+$ npm install knex
+$ npm install bookshelf
 
 # Then add one of the following:
 $ npm install pg
 $ npm install mysql
-$ npm install mariasql
 $ npm install sqlite3
 ```
 
 The Bookshelf library is initialized by passing an initialized [Knex](http://knexjs.org/) client instance. The [Knex documentation](http://knexjs.org/) provides a number of examples for different databases.
 
 ```js
-var knex = require('knex')({
+// Setting up the database connection
+const knex = require('knex')({
   client: 'mysql',
   connection: {
     host     : '127.0.0.1',
@@ -46,28 +46,28 @@ var knex = require('knex')({
     database : 'myapp_test',
     charset  : 'utf8'
   }
-});
+})
+const bookshelf = require('bookshelf')(knex)
 
-var bookshelf = require('bookshelf')(knex);
-
-var User = bookshelf.Model.extend({
+// Defining models
+const User = bookshelf.model('User', {
   tableName: 'users'
-});
+})
 ```
 
 This initialization should likely only ever happen once in your application. As it creates a connection pool for the current database, you should use the `bookshelf` instance returned throughout your library. You'll need to store this instance created by the initialize somewhere in the application so you can reference it. A common pattern to follow is to initialize the client in a module so you can easily reference it later:
 
 ```js
-// In a file named something like bookshelf.js
-var knex = require('knex')(dbConfig);
-module.exports = require('bookshelf')(knex);
+// In a file named, e.g. bookshelf.js
+const knex = require('knex')(dbConfig)
+module.exports = require('bookshelf')(knex)
 
 // elsewhere, to use the bookshelf client:
-var bookshelf = require('./bookshelf');
+const bookshelf = require('./bookshelf')
 
-var Post = bookshelf.Model.extend({
+const Post = bookshelf.model('Post', {
   // ...
-});
+})
 ```
 
 ## Examples
@@ -75,35 +75,35 @@ var Post = bookshelf.Model.extend({
 Here is an example to get you started:
 
 ```js
-var knex = require('knex')({
+const knex = require('knex')({
   client: 'mysql',
   connection: process.env.MYSQL_DATABASE_CONNECTION
-});
-var bookshelf = require('bookshelf')(knex);
+})
+const bookshelf = require('bookshelf')(knex)
 
-var User = bookshelf.Model.extend({
+const User = bookshelf.model('User', {
   tableName: 'users',
-  posts: function() {
-    return this.hasMany(Posts);
+  posts() {
+    return this.hasMany(Posts)
   }
-});
+})
 
-var Posts = bookshelf.Model.extend({
-  tableName: 'messages',
-  tags: function() {
-    return this.belongsToMany(Tag);
+const Post = bookshelf.model('Post', {
+  tableName: 'posts',
+  tags() {
+    return this.belongsToMany(Tag)
   }
-});
+})
 
-var Tag = bookshelf.Model.extend({
+const Tag = bookshelf.model('Tag', {
   tableName: 'tags'
 })
 
-User.where('id', 1).fetch({withRelated: ['posts.tags']}).then(function(user) {
-  console.log(user.related('posts').toJSON());
-}).catch(function(err) {
-  console.error(err);
-});
+new User({id: 1}).fetch({withRelated: ['posts.tags']}).then((user) => {
+  console.log(user.related('posts').toJSON())
+}).catch((error) => {
+  console.error(error)
+})
 ```
 
 ## Official Plugins
@@ -131,7 +131,7 @@ User.where('id', 1).fetch({withRelated: ['posts.tags']}).then(function(user) {
 
 ## Support
 
-Have questions about the library? Come join us in the [#bookshelf freenode IRC channel](http://webchat.freenode.net/?channels=bookshelf) for support on [knex.js](http://knexjs.org/) and bookshelf.js, or post an issue on [Stack Overflow](http://stackoverflow.com/questions/tagged/bookshelf.js) or in the GitHub [issue tracker](https://github.com/bookshelf/bookshelf/issues).
+Have questions about the library? Come join us in the [#bookshelf freenode IRC channel](http://webchat.freenode.net/?channels=bookshelf) for support on [knex.js](http://knexjs.org/) and bookshelf.js, or post an issue on [Stack Overflow](http://stackoverflow.com/questions/tagged/bookshelf.js).
 
 ## Contributing
 
@@ -147,13 +147,13 @@ available on GitHub.
 
 ### Can I use standard node.js style callbacks?
 
-Yes - you can call `.asCallback(function(err, resp) {` on any "sync" method and use the standard `(err, result)` style callback interface if you prefer.
+Yes, you can call `.asCallback(function(err, resp) {` on any database operation method and use the standard `(err, result)` style callback interface if you prefer.
 
 ### My relations don't seem to be loading, what's up?
 
-Make sure you check that the type is correct for the initial parameters passed to the initial model being fetched. For example `new Model({id: '1'}).load([relations...])` will not return the same as `Model({id: 1}).load([relations...])` - notice that the id is a string in one case and a number in the other. This can be a common mistake if retrieving the id from a url parameter.
+Make sure to check that the type is correct for the initial parameters passed to the initial model being fetched. For example `new Model({id: '1'}).load([relations...])` will not return the same as `new Model({id: 1}).load([relations...])` - notice that the id is a string in one case and a number in the other. This can be a common mistake if retrieving the id from a url parameter.
 
-This is only an issue if you're eager loading data with load without first fetching the original model. `Model({id: '1'}).fetch({withRelated: [relations...]})` should work just fine.
+This is only an issue if you're eager loading data with load without first fetching the original model. `new Model({id: '1'}).fetch({withRelated: [relations...]})` should work just fine.
 
 ### My process won't exit after my script is finished, why?
 
@@ -163,11 +163,11 @@ The issue here is that Knex, the database abstraction layer used by Bookshelf, u
 
 If you pass `{debug: true}` as one of the options in your initialize settings, you can see all of the query calls being made. Sometimes you need to dive a bit further into the various calls and see what all is going on behind the scenes. I'd recommend [node-inspector](https://github.com/dannycoates/node-inspector), which allows you to debug code with `debugger` statements like you would in the browser.
 
-Bookshelf uses its own copy of the "bluebird" promise library, you can read up here for more on debugging these promises... but in short, adding:
+Bookshelf uses its own copy of the `bluebird` Promise library, you can read up here for more on debugging these promises... but in short, adding:
 ```js
-process.stderr.on('data', function(data) {
-  console.log(data);
-});
+process.stderr.on('data', (data) => {
+  console.log(data)
+})
 ```
 At the start of your application code will catch any errors not otherwise caught in the normal promise chain handlers, which is very helpful in debugging.
 
@@ -178,7 +178,7 @@ document on GitHub.
 
 ### Can I use Bookshelf outside of Node.js?
 
-While it primarily targets Node.js, all dependencies are browser compatible, and it could be adapted to work with other javascript environments supporting a sqlite3 database, by providing a custom [Knex adapter](http://knexjs.org/#Adapters).
+While it primarily targets Node.js, all dependencies are browser compatible, and it could be adapted to work with other javascript environments supporting a sqlite3 database, by providing a custom [Knex adapter](http://knexjs.org/#Adapters). No such adapter exists though.
 
 ### Which open-source projects are using Bookshelf?
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1115,6 +1115,12 @@ const BookshelfModel = ModelBase.extend(
                 }
               }
 
+              if (resp === 0) return resp;
+
+              return this.refresh({silent: true, transacting: options.transacting});
+            })
+            .then(function(updatedModel) {
+              const eventsToTrigger = method === 'insert' ? 'created saved' : 'updated saved';
               this._reset();
 
               /**
@@ -1158,7 +1164,7 @@ const BookshelfModel = ModelBase.extend(
                * @param {Object} options Options object passed to {@link Model#save save}.
                * @returns {Promise}
                */
-              return this.triggerThen(method === 'insert' ? 'created saved' : 'updated saved', this, resp, options);
+              return this.triggerThen(eventsToTrigger, this, updatedModel, options);
             });
         })
         .return(this);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1155,11 +1155,8 @@ const BookshelfModel = ModelBase.extend(
                *
                * @event Model#saved
                * @tutorial events
-               * @param {Model} model The model firing the event.
-               * @param {(Array|Number)} response
-               *   A list containing the id of the newly created model in case of an
-               *   `insert` or a number representing the affected rows in the case of
-               *   an `update` query.
+               * @param {Model} model
+               *   The model firing the event with its attributes matching what's in the database.
                * @param {Object} options Options object passed to {@link Model#save save}.
                * @returns {Promise}
                */
@@ -1171,8 +1168,8 @@ const BookshelfModel = ModelBase.extend(
                *
                * @event Model#created
                * @tutorial events
-               * @param {Model}  model    The model firing the event.
-               * @param {Array}  newId    A list containing the id of the newly created model.
+               * @param {Model} model
+               *   The model firing the event with its attributes matching what's in the database.
                * @param {Object} options  Options object passed to {@link Model#save save}.
                * @returns {Promise}
                */
@@ -1184,12 +1181,12 @@ const BookshelfModel = ModelBase.extend(
                *
                * @event Model#updated
                * @tutorial events
-               * @param {Model} model The model firing the event.
-               * @param {Number} affectedRows Number of rows affected by the update.
+               * @param {Model} model
+               *   The model firing the event with its attributes matching what's in the database.
                * @param {Object} options Options object passed to {@link Model#save save}.
                * @returns {Promise}
                */
-              return this.triggerThen(eventsToTrigger, this, updatedModel, options);
+              return this.triggerThen(eventsToTrigger, this, options);
             });
         })
         .return(this);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1114,19 +1114,33 @@ const BookshelfModel = ModelBase.extend(
               return sync[options.method](attributesToSave);
             })
             .then(function(resp) {
+              // Only valid for databases that support RETURNING
+              const isObjectResponse = resp && typeof resp[0] === 'object';
+
               // After a successful database save, the id is updated if the model was created
               if (method === 'insert' && this.id == null) {
-                const updatedCols = {};
-                updatedCols[this.idAttribute] = this.id = resp[0];
-                const updatedAttrs = this.parse(updatedCols);
+                let updatedAttrs;
+
+                if (!isObjectResponse) {
+                  const updatedCols = {};
+                  updatedCols[this.idAttribute] = this.id = resp[0];
+                  updatedAttrs = this.parse(updatedCols);
+                } else {
+                  updatedAttrs = this.parse(resp[0]);
+                  this.id = updatedAttrs[this.parsedIdAttribute()];
+                }
+
                 Object.assign(this.attributes, updatedAttrs);
-              } else if (method === 'update' && resp === 0) {
+              } else if (method === 'update' && (resp === 0 || resp.length === 0)) {
                 if (options.require !== false) {
                   throw new this.constructor.NoRowsUpdatedError('No Rows Updated');
                 }
+              } else {
+                Object.assign(this.attributes, this.parse(resp[0]));
               }
 
-              if (resp === 0) return resp;
+              if (resp === 0 || resp.length === 0) return resp;
+              if (isObjectResponse) return this;
 
               return this.refresh({silent: true, transacting: options.transacting});
             })

--- a/lib/model.js
+++ b/lib/model.js
@@ -731,7 +731,7 @@ const BookshelfModel = ModelBase.extend(
              *   If the handler returns a promise, `fetch` will wait for it to
              *   be resolved.
              */
-            return this.triggerThen('fetched', this, response, options);
+            if (!options.silent) return this.triggerThen('fetched', this, response, options);
           })
           .return(this)
           .catch(this.constructor.NotFoundError, function(err) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -919,13 +919,12 @@ const BookshelfModel = ModelBase.extend(
      * The type of operation to perform (either `insert` or `update`) can be
      * overriden with the `method` option:
      *
-     *     // This forces an insert with the specified id instead of the expected
-     *     // update
+     *     // This forces an insert with the specified id instead of the expected update
      *     new Post({name: 'New Article', id: 34})
      *       .save(null, {method: 'insert'})
-     *       .then(function(model) {
+     *       .then((model) => {
      *         // ...
-     *       });
+     *       })
      *
      * If you only wish to update with the params passed to the save, you may pass
      * a `{patch: true}` option in the second argument to `save`:
@@ -933,66 +932,77 @@ const BookshelfModel = ModelBase.extend(
      *     // UPDATE authors SET "bio" = 'Short user bio' WHERE "id" = 1
      *     new Author({id: 1, first_name: 'User'})
      *       .save({bio: 'Short user bio'}, {patch: true})
-     *       .then(function(model) {
+     *       .then((model) => {
      *         // ...
-     *       });
+     *       })
      *
-     * Several events fire on the model when saving: a {@link Model#event:creating
-     * "creating"}, or {@link Model#event:updating "updating"} event if the model is
-     * being inserted or updated, and a "saving" event in either case.
+     * After a model is saved it will be populated with all the attributes that are
+     * present in the database, so you don't need to manually call
+     * {@link Model#refresh refresh} to update it. This will use two queries unless
+     * the database supports the `RETURNING` statement, in which case the model will
+     * be saved and its data fetched with a single query.
+     *
+     * Several events fire on the model when starting the save process:
+     * - {@link Model#event:creating "creating"} if the model is being inserted.
+     * - {@link Model#event:updating "updating"} event if the model is being updated.
+     * - {@link Model#event:saving "saving"} event in either case.
      *
      * To prevent saving the model (for example, with validation), throwing an error
-     * inside one of these event listeners will stop saving the model and reject the
-     * promise.
+     * inside one of these event listeners will stop the save process and reject the
+     * Promise.
      *
-     * A {@link Model#event:created "created"}, or {@link Model#event:updated "updated"}
-     * event is fired after the model is saved, as well as a {@link Model#event:saved "saved"}
-     * event either way. If you wish to modify the query when the {@link Model#event:saving
-     * "saving"} event is fired, the knex query object is available in `options.query`.
+     * If you wish to modify the query when the {@link Model#event:saving "saving"}
+     * event is fired, the `knex` query object is available in `options.query`.
+     *
+     * After the save is complete the following events will fire:
+     * - {@link Model#event:created "created"} if a new model was inserted in the
+     *   database
+     * - {@link Model#event:updated "updated"} if an existing model was updated.
+     * - {@link Model#event:saved "saved"} event either way.
      *
      * See the {@tutorial events} guide for further details.
      *
      * @example
      * // Save with no arguments
-     * Model.forge({id: 5, firstName: 'John', lastName: 'Smith'}).save().then(function() {
+     * Model.forge({id: 5, firstName: 'John', lastName: 'Smith'}).save().then((model) => {
      *   //...
-     * });
+     * })
      *
      * // Or add attributes during save
-     * Model.forge({id: 5}).save({firstName: 'John', lastName: 'Smith'}).then(function() {
+     * Model.forge({id: 5}).save({firstName: 'John', lastName: 'Smith'}).then((model) => {
      *   //...
-     * });
+     * })
      *
      * // Or, if you prefer, for a single attribute
-     * Model.forge({id: 5}).save('name', 'John Smith').then(function() {
+     * Model.forge({id: 5}).save('name', 'John Smith').then((model) => {
      *   //...
-     * });
+     * })
      *
-     * @param {string=}      key                      Attribute name.
-     * @param {string=}      val                      Attribute value.
-     * @param {Object=}      attrs                    A hash of attributes.
-     * @param {Object=}      options
-     * @param {Transaction=} options.transacting
-     *   Optionally run the query in a transaction.
-     * @param {string=} options.method
+     * @param {string} [key] Attribute name.
+     * @param {*} [val] Attribute value.
+     * @param {Object} [attrs]
+     *   You can use a single object argument with all the values you wish to save
+     *   instead of specifying both the `key` and `value` arguments.
+     * @param {Object} [options]
+     * @param {Transaction} [options.transacting] Optionally run the query in a transaction.
+     * @param {string} [options.method]
      *   Explicitly select a save method, either `"update"` or `"insert"`.
      * @param {Boolean} [options.defaults=false]
      *   Whether to assign or not {@link Model#defaults default} attribute values
      *   on a model when performing an update or create operation.
      * @param {Boolean} [options.patch=false]
-     *   Only save attributes supplied in arguments to `save`.
+     *   Only save attributes supplied as arguments to the `save` call, ignoring any
+     *   attributes that may be already set on the model.
      * @param {Boolean} [options.require=true]
-     *   Throw a {@link Model.NoRowsUpdatedError} if no records are affected by save.
-     *
+     *   Whether or not to throw a {@link Model.NoRowsUpdatedError} if no records
+     *   are affected by save.
      * @fires Model#saving
      * @fires Model#creating
      * @fires Model#updating
      * @fires Model#created
      * @fires Model#updated
      * @fires Model#saved
-     *
      * @throws {Model.NoRowsUpdatedError}
-     *
      * @returns {Promise<Model>} A promise resolving to the saved and updated model.
      */
     save: Promise.method(function(key, val, options) {
@@ -1144,7 +1154,7 @@ const BookshelfModel = ModelBase.extend(
 
               return this.refresh({silent: true, transacting: options.transacting});
             })
-            .then(function(updatedModel) {
+            .then(function() {
               const eventsToTrigger = method === 'insert' ? 'created saved' : 'updated saved';
               this._reset();
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -531,7 +531,7 @@ const BookshelfModel = ModelBase.extend(
      * @returns {Promise<Model>}
      *   A promise resolving to this model.
      */
-    refresh(options) {
+    refresh(options = {}) {
       let attributes = {};
 
       // If this is new, we use all its attributes. Otherwise we just grab the primary key.
@@ -541,7 +541,9 @@ const BookshelfModel = ModelBase.extend(
         attributes[this.idAttribute] = this.attributes[this.idAttribute] || this.attributes[this.parsedIdAttribute()];
       }
 
-      return this._doFetch(attributes, options);
+      return this._doFetch(attributes, options).tap(() => {
+        if (!options.silent) this._previousAttributes = _.cloneDeep(this.attributes);
+      });
     },
 
     /**
@@ -689,7 +691,9 @@ const BookshelfModel = ModelBase.extend(
      *
      */
     fetch(options) {
-      return this._doFetch(this.attributes, options);
+      return this._doFetch(this.attributes, options).tap(() => {
+        this._previousAttributes = _.cloneDeep(this.attributes);
+      });
     },
 
     _doFetch: Promise.method(function(attributes, options) {
@@ -1443,7 +1447,6 @@ const BookshelfModel = ModelBase.extend(
       this.set(this.parse(response[0]), {silent: true})
         .formatTimestamps()
         ._reset();
-      this._previousAttributes = _.cloneDeep(this.attributes);
 
       if (relatedData && relatedData.isJoined()) {
         relatedData.parsePivot([this]);

--- a/lib/model.js
+++ b/lib/model.js
@@ -532,8 +532,15 @@ const BookshelfModel = ModelBase.extend(
      *   A promise resolving to this model.
      */
     refresh(options) {
+      let attributes = {};
+
       // If this is new, we use all its attributes. Otherwise we just grab the primary key.
-      const attributes = this.isNew() ? this.attributes : _.pick(this.attributes, this.idAttribute);
+      if (this.isNew()) {
+        attributes = this.attributes;
+      } else {
+        attributes[this.idAttribute] = this.attributes[this.idAttribute] || this.attributes[this.parsedIdAttribute()];
+      }
+
       return this._doFetch(attributes, options);
     },
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -4,8 +4,12 @@
 
 const _ = require('lodash');
 const Promise = require('bluebird');
-const supportsReturning = (client) => _.includes(['postgresql', 'postgres', 'pg', 'oracle', 'mssql'], client);
 const validLocks = ['forShare', 'forUpdate'];
+
+function supportsReturning(client = {}) {
+  if (!client.config || !client.config.client) return false;
+  return ['postgresql', 'postgres', 'pg', 'oracle', 'mssql'].includes(client.config.client);
+}
 
 // Sync is the dispatcher for any database queries,
 // taking the "syncing" `model` or `collection` being queried, along with
@@ -205,7 +209,7 @@ _.extend(Sync.prototype, {
     const syncing = this.syncing;
     return this.query.insert(
       syncing.format(_.extend(Object.create(null), syncing.attributes)),
-      supportsReturning(this.query.client.config.client) ? syncing.idAttribute : null
+      supportsReturning(this.query.client) ? '*' : null
     );
   }),
 
@@ -221,6 +225,7 @@ _.extend(Sync.prototype, {
     if (syncing.id === updating[syncing.idAttribute]) {
       delete updating[syncing.idAttribute];
     }
+    if (supportsReturning(query.client)) query.returning('*');
     return query.update(updating);
   }),
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -47,15 +47,16 @@ _.extend(Sync.prototype, {
     // operator.
     //
     // NOTE: `_.omit` returns an empty object, even if attributes are null.
-    const whereAttributes = _.omitBy(attributes, _.isPlainObject);
+    const whereAttributes = _.omitBy(attributes, (attribute, name) => {
+      return _.isPlainObject(attribute) || name === model.idAttribute;
+    });
+    const formattedAttributes = model.format(whereAttributes);
 
-    if (!_.isEmpty(whereAttributes)) {
-      // Format and prefix attributes.
-      const formatted = this.prefixFields(model.format(whereAttributes));
-      query.where(formatted);
+    if (model.idAttribute in attributes) {
+      formattedAttributes[model.idAttribute] = attributes[model.idAttribute];
     }
 
-    // Limit to a single result.
+    if (!_.isEmpty(formattedAttributes)) query.where(this.prefixFields(formattedAttributes));
     query.limit(1);
 
     return this.select();

--- a/test/integration/collection.js
+++ b/test/integration/collection.js
@@ -320,17 +320,6 @@ module.exports = function(bookshelf) {
           });
       });
 
-      it('should maintain the correct constraints when creating a model from a relation', function() {
-        var authors = new Site({id: 1}).authors();
-        var query = authors.query();
-        query.then = function(onFufilled, onRejected) {
-          // TODO: Make this doable again...
-          // expect(this.values[0]).to.eql([['first_name', 'Test'], ['last_name', 'User'], ['site_id', 1]]);
-          return Promise.resolve(this.toString()).then(onFufilled, onRejected);
-        };
-        return authors.create({first_name: 'Test', last_name: 'User'});
-      });
-
       it('should populate the nested relations with the proper keys', function() {
         return new Author({id: 1})
           .fetch({withRelated: 'site.photos'})

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -693,6 +693,36 @@ module.exports = function(bookshelf) {
             return new Models.Author({id: newAuthorId}).destroy();
           });
       });
+
+      it("does not try to format the idAttribute if it's already formatted", function() {
+        return new Models.OrgModel({organization_id: 2}).fetch().then((organization) => {
+          if (dialect === 'postgresql') {
+            expect(organization.attributes).to.deep.equal({
+              organization_id: 2,
+              id: 2,
+              name: 'Duplicates',
+              is_active: false
+            });
+          } else {
+            expect(organization.attributes).to.deep.equal({
+              organization_id: 2,
+              id: 2,
+              name: 'Duplicates',
+              is_active: 0
+            });
+          }
+        });
+      });
+
+      it("formats the idAttribute if it's not already formatted", function() {
+        return new Models.OrgModel({id: 2}).fetch().then((organization) => {
+          if (dialect === 'postgresql') {
+            expect(organization.attributes).to.deep.equal({id: 2, name: 'Duplicates', is_active: false});
+          } else {
+            expect(organization.attributes).to.deep.equal({id: 2, name: 'Duplicates', is_active: 0});
+          }
+        });
+      });
     });
 
     describe('#fetchAll()', function() {

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1283,9 +1283,15 @@ module.exports = function(bookshelf) {
         return user.save();
       });
 
-      it('refreshes the model after saving', function() {
+      it('refreshes the model after updating', function() {
         return new Models.Member({id: 1}).save({name: 'Okoye'}).then((member) => {
           deepEqual(member.attributes, {id: 1, name: 'Okoye', organization_id: 1});
+        });
+      });
+
+      it('refreshes the model after inserting', function() {
+        return new Models.Tag({name: 'books'}).save().then((tag) => {
+          deepEqual(tag.attributes, {id: 5, name: 'books'});
         });
       });
 
@@ -1376,8 +1382,6 @@ module.exports = function(bookshelf) {
             equal(acmeOrg1.attributes.organization_id, undefined);
             equal(acmeOrg1.attributes.organization_name, undefined);
             expect(acmeOrg.attributes.name).to.equal('ACME, Inc');
-            // field name needs to be processed through model.parse
-            equal(acmeOrg.attributes.organization_id, undefined);
           });
       });
     });
@@ -1679,7 +1683,6 @@ module.exports = function(bookshelf) {
               originalDate = savedAdmin.get('updated_at');
 
               return Promise.delay(1000).then(function() {
-                console.log('saving');
                 return savedAdmin.save('username', 'pablo');
               });
             })

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1084,7 +1084,11 @@ module.exports = function(bookshelf) {
     describe('save', function() {
       var Site = Models.Site;
 
-      after(() => Site.forge({id: 6}).destroy());
+      after(() => {
+        return Site.forge({id: 6})
+          .destroy()
+          .catch(() => {});
+      });
 
       it('saves a new object', function() {
         return new Site({name: 'Fourth Site'})

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1302,7 +1302,7 @@ module.exports = function(bookshelf) {
         return site.save(null, testOptions).call('destroy');
       });
 
-      it('Will not break with prefixed id, #583', function() {
+      it('will not break with prefixed id, #583', function() {
         var acmeOrg = new Models.OrgModel({
           name: 'ACME, Inc',
           is_active: true
@@ -1320,7 +1320,6 @@ module.exports = function(bookshelf) {
             equal(acmeOrg1.attributes.name, 'ACME, Inc');
             equal(acmeOrg1.attributes.organization_id, undefined);
             equal(acmeOrg1.attributes.organization_name, undefined);
-
             expect(acmeOrg.attributes.name).to.equal('ACME, Inc');
             // field name needs to be processed through model.parse
             equal(acmeOrg.attributes.organization_id, undefined);
@@ -1596,6 +1595,7 @@ module.exports = function(bookshelf) {
         });
 
         it("does not update created_at timestamp if the user doesn't set it", function() {
+          this.slow(2000);
           var admin = new Models.Admin();
           var originalDate;
 
@@ -1604,7 +1604,7 @@ module.exports = function(bookshelf) {
             .then(function(savedAdmin) {
               originalDate = savedAdmin.get('created_at');
 
-              return Promise.delay(100).then(function() {
+              return Promise.delay(1000).then(function() {
                 return savedAdmin.save('username', 'pablo');
               });
             })
@@ -1614,6 +1614,7 @@ module.exports = function(bookshelf) {
         });
 
         it("will automatically set the updated_at timestamp if the user doesn't set it", function() {
+          this.slow(2000);
           var admin = new Models.Admin();
           var originalDate;
 
@@ -1622,16 +1623,19 @@ module.exports = function(bookshelf) {
             .then(function(savedAdmin) {
               originalDate = savedAdmin.get('updated_at');
 
-              return Promise.delay(100).then(function() {
+              return Promise.delay(1000).then(function() {
+                console.log('saving');
                 return savedAdmin.save('username', 'pablo');
               });
             })
             .then(function(updatedAdmin) {
-              expect(updatedAdmin.get('updated_at')).to.not.be.eql(originalDate);
+              const updatedDate = updatedAdmin.get('updated_at');
+              expect(updatedDate.getTime()).to.not.equal(originalDate.getTime());
             });
         });
 
         it("will not update the updated_at timestamp if the model hasn't changed", function() {
+          this.slow(2000);
           var admin = new Models.Admin();
           var originalDate;
 
@@ -1640,7 +1644,7 @@ module.exports = function(bookshelf) {
             .then(function(savedAdmin) {
               originalDate = savedAdmin.get('updated_at');
 
-              return Promise.delay(100).then(function() {
+              return Promise.delay(1000).then(function() {
                 return savedAdmin.save();
               });
             })
@@ -1652,8 +1656,8 @@ module.exports = function(bookshelf) {
         it('will set the updated_at timestamp to the user supplied value', function() {
           var admin = new Models.Admin();
           var oldUpdatedAt;
-          var newUpdatedAt = new Date();
-          newUpdatedAt.setMinutes(newUpdatedAt.getMinutes() + 1);
+          var newUpdatedAt = new Date('2019-09-01 12:13:14');
+          newUpdatedAt.setMinutes(newUpdatedAt.getMinutes() + 10);
 
           return admin
             .save()

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1081,7 +1081,7 @@ module.exports = function(bookshelf) {
       });
     });
 
-    describe('save', function() {
+    describe('#save()', function() {
       var Site = Models.Site;
 
       after(() => {

--- a/test/unit/model.js
+++ b/test/unit/model.js
@@ -25,6 +25,8 @@ module.exports = function() {
           };
         };
 
+        model.refresh = () => Promise.resolve({});
+
         return model.save(null, options).then(function() {
           equal(_.difference(Object.keys(options), ['query']).length, 0);
         });


### PR DESCRIPTION
* Related Issues: #507, #1002, #1065, #1665

## Introduction

Modify `Model#save()` so that it returns a fresh copy of the model from the database after a successful save.

## Motivation

It is often necessary to get all the attributes from the database immediately after a save. The current behavior is also not very intuitive, where after a save some attributes will be set but not others. For example, the timestamp columns might be missing entirely if the user didn't set them manually (#507).

This should lead to a much better experience when working with models, since the model will always have the most up-to-date attributes without needing to manually call `Model#refresh`.

Fixes #507. Closes #1665.

## Proposed solution

This will call `Model#refresh` after a successful save on databases that do not support the `RETURNING` statement. On those that do a more efficient single `INSERT` OR `UPDATE` query will be generated allowing this feature to have negligible performance impact in that case. 

Note that the after save event signatures were changed to make them more consistent. Namely the second argument was removed since it wasn't very useful in any case (for update events it was always `1` and for inserts it was `[1]` or whatever the new inserted id was). Nonetheless this is a small breaking change, so a [migration guide](https://github.com/bookshelf/bookshelf/wiki/Migrating-from-0.15.1-to-1.0.0/_edit#different-arguments-on-after-save-event-listeners-saved-created-and-updated) has been added.

## Current PR Issues

Requires two queries on database that do not support `RETURNING`, but there's no way around that.
