### PR TITLE
Update count methods docs

### DIFF
--- a/lib/bookshelf.js
+++ b/lib/bookshelf.js
@@ -251,20 +251,21 @@ function Bookshelf(knex) {
       },
 
       /**
+       * Shortcut to a model's `count` method so you don't need to instantiate a new model to count
+       * the number of records.
+       *
+       * @example
+       * Duck.count().then((count) => {
+       *   console.log('number of ducks', count)
+       * })
+       *
        * @method Model.count
        * @since 0.8.2
-       * @description
-       *
-       * Gets the number of matching records in the database, respecting any
-       * previous calls to {@link Model#query query}. If a `column` is provided,
-       * records with a null value in that column will be excluded from the count.
-       *
+       * @see Model#count
        * @param {string} [column='*']
-       *   Specify a column to count - rows with null values in this column will be excluded.
-       * @param {Object=} options
-       *   Hash of options.
-       * @returns {Promise<Number>}
-       *   A promise resolving to the number of matching rows.
+       *   Specify a column to count. Rows with `null` values in this column will be excluded.
+       * @param {Object} [options] Hash of options.
+       * @returns {Promise<number|string>}
        */
       count(column, options) {
         return this.forge().count(column, options);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -184,19 +184,20 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      *
      * @example
      * // select count(*) from shareholders where company_id = 1 and share &gt; 0.1;
-     * Company.forge({id:1})
+     * new Company({id: 1})
      *   .shareholders()
-     *   .query('where', 'share', '>', '0.1')
+     *   .where('share', '>', '0.1')
      *   .count()
-     *   .then(function(count) {
-     *     assert(count === 3);
-     *   });
+     *   .then((count) => {
+     *     assert(count === 3)
+     *   })
      *
      * @since 0.8.2
+     * @see Model#count
      * @param {string} [column='*']
-     *   Specify a column to count - rows with null values in this column will be excluded.
-     * @param {Object=} options Hash of options.
-     * @returns {Promise<Number>} A promise resolving to the number of matching rows.
+     *   Specify a column to count. Rows with `null` values in this column will be excluded.
+     * @param {Object} [options] Hash of options.
+     * @returns {Promise<number|string>}
      */
     count: Promise.method(function(column, options) {
       if (!_.isString(column)) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -769,8 +769,8 @@ const BookshelfModel = ModelBase.extend(
      * **Note** that in PostgreSQL the result is a string by default. To read more about the
      * reasons for this see the [pull request](https://github.com/brianc/node-postgres/pull/353)
      * that implemented it in the `node-postgres` database driver. If you're sure that the
-     * results will always be less than 2^53 (9007199254740991) you can override the default
-     * string parser:
+     * results will always be less than 2<sup>53</sup> (9007199254740991) you can override
+     * the default string parser like this:
      *
      *     const { types } = require('pg')
      *     types.setTypeParser(20, (value) => parseInt(value))

--- a/lib/model.js
+++ b/lib/model.js
@@ -772,8 +772,7 @@ const BookshelfModel = ModelBase.extend(
      * results will always be less than 2<sup>53</sup> (9007199254740991) you can override
      * the default string parser like this:
      *
-     *     const { types } = require('pg')
-     *     types.setTypeParser(20, (value) => parseInt(value))
+     *     require('pg').defaults.parseInt8 = true
      *
      * Put this snippet before the call to `require('knex')` wherever you are initalizing
      * `knex`.

--- a/lib/model.js
+++ b/lib/model.js
@@ -762,24 +762,36 @@ const BookshelfModel = ModelBase.extend(
     },
 
     /**
-     * @method Model#count
-     * @since 0.8.2
-     * @description
+     * Gets the number of matching records in the database, respecting any previous calls to
+     * {@link Model#query}. If the `column` argument is provided, records with a `null` value in
+     * that column will be excluded from the count.
      *
-     * Gets the number of matching records in the database, respecting any
-     * previous calls to {@link Model#query}.
+     * **Note** that in PostgreSQL the result is a string by default. To read more about the
+     * reasons for this see the [pull request](https://github.com/brianc/node-postgres/pull/353)
+     * that implemented it in the `node-postgres` database driver. If you're sure that the
+     * results will always be less than 2^53 (9007199254740991) you can override the default
+     * string parser:
+     *
+     *     const { types } = require('pg')
+     *     types.setTypeParser(20, (value) => parseInt(value))
+     *
+     * Put this snippet before the call to `require('knex')` wherever you are initalizing
+     * `knex`.
      *
      * @example
+     * new Duck().where('color', 'blue').count('name').then((count) => {
+     *   console.log('number of blue ducks', count)
+     * })
      *
-     * Duck.where('color', 'blue').count('name')
-     *   .then(function(count) { //...
-     *
+     * @method Model#count
+     * @since 0.8.2
      * @param {string} [column='*']
-     *   Specify a column to count - rows with null values in this column will be excluded.
-     * @param {Object=} options
-     *   Hash of options.
-     * @returns {Promise<Number>}
-     *   A promise resolving to the number of matching rows.
+     *   Specify a column to count. Rows with `null` values in this column will be excluded.
+     * @param {Object} [options] Hash of options.
+     * @returns {Promise<number|string>}
+     *   A promise resolving to the number of matching rows. By default this will be a number,
+     *   except with PostgreSQL where it will be a string. Check the description to see how to
+     *   return a number instead.
      */
     count(column, options) {
       return this.all().count(column, options);

--- a/lib/model.js
+++ b/lib/model.js
@@ -785,13 +785,14 @@ const BookshelfModel = ModelBase.extend(
      *
      * @method Model#count
      * @since 0.8.2
+     * @fires Model#counting
      * @param {string} [column='*']
      *   Specify a column to count. Rows with `null` values in this column will be excluded.
      * @param {Object} [options] Hash of options.
      * @returns {Promise<number|string>}
      *   A promise resolving to the number of matching rows. By default this will be a number,
      *   except with PostgreSQL where it will be a string. Check the description to see how to
-     *   return a number instead.
+     *   return a number instead in this case.
      */
     count(column, options) {
       return this.all().count(column, options);


### PR DESCRIPTION
* Related Issues: #1275 

## Introduction

This updates the documentation for all `count()` methods. The biggest change is linking them all to the `Model#count` method that contains information about the return value type in PostgreSQL.

## Motivation

It's a bit unexpected that the `count()` methods return strings in PostgreSQL, so this tries to help with that by making it more clear. There is also a solution in case the user would like to change the type parser to return numbers instead.

Fixes #1275.

### References

- https://github.com/brianc/node-pg-types
- https://github.com/brianc/node-postgres/pull/427
- https://github.com/tgriesser/knex/issues/387
- https://knexjs.org/#Builder-count
