### PR TITLE
Improve documentation related to debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,15 +161,34 @@ The issue here is that Knex, the database abstraction layer used by Bookshelf, u
 
 ### How do I debug?
 
-If you pass `{debug: true}` as one of the options in your initialize settings, you can see all of the query calls being made. Sometimes you need to dive a bit further into the various calls and see what all is going on behind the scenes. I'd recommend [node-inspector](https://github.com/dannycoates/node-inspector), which allows you to debug code with `debugger` statements like you would in the browser.
+If you pass `debug: true` in the options object to your `knex` initialize call, you can see all of the query calls being made. You can also pass that same option to all methods that access the database, like `model.fetch()` or `model.destroy()`. Examples:
 
-Bookshelf uses its own copy of the `bluebird` Promise library, you can read up here for more on debugging these promises... but in short, adding:
+```js
+// Turning on debug mode for all queries
+const knex = require('knex')({
+  debug: true,
+  client: 'mysql',
+  connection: process.env.MYSQL_DATABASE_CONNECTION
+})
+const bookshelf = require('bookshelf')(knex)
+
+// Debugging a single query
+new User({id: 1}).fetch({debug: true, withRelated: ['posts.tags']}).then(user => {
+  // ...
+})
+```
+
+Sometimes you need to dive a bit further into the various calls and see what all is going on behind the scenes. You can use [node-inspector](https://github.com/dannycoates/node-inspector), which allows you to debug code with `debugger` statements like you would in the browser.
+
+Bookshelf uses its own copy of the `bluebird` Promise library. You can read up [here](http://bluebirdjs.com/docs/api/promise.config.html) for more on debugging Promises.
+
+Adding the following block at the start of your application code will catch any errors not otherwise caught in the normal Promise chain handlers, which is very helpful in debugging:
+
 ```js
 process.stderr.on('data', (data) => {
   console.log(data)
 })
 ```
-At the start of your application code will catch any errors not otherwise caught in the normal promise chain handlers, which is very helpful in debugging.
 
 ### How do I run the test suite?
 

--- a/lib/bookshelf.js
+++ b/lib/bookshelf.js
@@ -265,6 +265,9 @@ function Bookshelf(knex) {
        * @param {string} [column='*']
        *   Specify a column to count. Rows with `null` values in this column will be excluded.
        * @param {Object} [options] Hash of options.
+       * @param {boolean} [options.debug=false]
+       *   Whether to enable debugging mode or not. When enabled will show information about the
+       *   queries being run.
        * @returns {Promise<number|string>}
        */
       count(column, options) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -122,6 +122,9 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      *   You can pass the `require: true` option to override this behavior.
      * @param {string|string[]} [options.withRelated=[]]
      *   A relation, or list of relations, to be eager loaded as part of the `fetch` operation.
+     * @param {boolean} [options.debug=false]
+     *   Whether to enable debugging mode or not. When enabled will show information about the
+     *   queries being run.
      * @returns {Promise<Collection>}
      */
     fetch: Promise.method(function(options) {
@@ -236,6 +239,9 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      *  Type of row-level lock to use. Valid options are `forShare` and
      *  `forUpdate`. This only works in conjunction with the `transacting`
      *  option, and requires a database that supports it.
+     * @param {boolean} [options.debug=false]
+     *   Whether to enable debugging mode or not. When enabled will show information about the
+     *   queries being run.
      * @throws {Model.NotFoundError}
      * @returns {Promise<Model|null>}
      *  A promise resolving to the fetched {@link Model} or `null` if none exists and the
@@ -256,12 +262,15 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      * specified by separating the nested relations with `.`.
      *
      * @param {string|string[]} relations The relation, or relations, to be loaded.
-     * @param {Object=} options Hash of options.
-     * @param {Transaction=} options.transacting
-     * @param {string=} options.lock
+     * @param {Object} [options] Hash of options.
+     * @param {Transaction} [options.transacting]
+     * @param {string} [options.lock]
      *   Type of row-level lock to use. Valid options are `forShare` and `forUpdate`. This only
      *   works in conjunction with the `transacting` option, and requires a database that supports
      *   it.
+     * @param {boolean} [options.debug=false]
+     *   Whether to enable debugging mode or not. When enabled will show information about the
+     *   queries being run.
      * @returns {Promise<Collection>} A promise resolving to this {@link Collection collection}.
      */
     load: Promise.method(function(relations, options) {
@@ -294,8 +303,11 @@ const BookshelfCollection = (module.exports = CollectionBase.extend(
      * );
      *
      * @param {Object} model A set of attributes to be set on the new model.
-     * @param {Object=} options
-     * @param {Transaction=} options.transacting
+     * @param {Object} [options]
+     * @param {Transaction} [options.transacting]
+     * @param {boolean} [options.debug=false]
+     *   Whether to enable debugging mode or not. When enabled will show information about the
+     *   queries being run.
      * @returns {Promise<Model>} A promise resolving with the new {@link Model model}.
      */
     create: Promise.method(function(model, options) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -598,6 +598,9 @@ const BookshelfModel = ModelBase.extend(
      *   `offset` option.
      * @param {number} [options.offset]
      *   Index to begin fetching results from. The default and initial value is `0`. Used only with the `limit` option.
+     * @param {boolean} [options.debug=false]
+     *   Whether to enable debugging mode or not. When enabled will show information about the
+     *   queries being run.
      * @returns {Promise<Collection>}
      *   Returns a Promise that will resolve to the paginated collection of models.
      */
@@ -682,6 +685,9 @@ const BookshelfModel = ModelBase.extend(
      * @param {string|Object|mixed[]} [options.withRelated]
      *  Relations to be retrieved with `Model` instance. Either one or more
      *  relation names or objects mapping relation names to query callbacks.
+     * @param {boolean} [options.debug=false]
+     *   Whether to enable debugging mode or not. When enabled will show information about the
+     *   queries being run.
      * @fires Model#fetching
      * @fires Model#fetched
      * @throws {Model.NotFoundError}
@@ -788,6 +794,9 @@ const BookshelfModel = ModelBase.extend(
      * @param {string} [column='*']
      *   Specify a column to count. Rows with `null` values in this column will be excluded.
      * @param {Object} [options] Hash of options.
+     * @param {boolean} [options.debug=false]
+     *   Whether to enable debugging mode or not. When enabled will show information about the
+     *   queries being run.
      * @returns {Promise<number|string>}
      *   A promise resolving to the number of matching rows. By default this will be a number,
      *   except with PostgreSQL where it will be a string. Check the description to see how to
@@ -815,6 +824,9 @@ const BookshelfModel = ModelBase.extend(
      *   Whether or not to reject the returned Promise with a {@link Collection.EmptyError} if no records can be
      *   fetched from the database.
      * @param {Transaction} [options.transacting] Optionally run the query in a transaction.
+     * @param {boolean} [options.debug=false]
+     *   Whether to enable debugging mode or not. When enabled will show information about the
+     *   queries being run.
      * @fires Model#fetching:collection
      * @fires Model#fetched:collection
      * @throws {Collection.EmptyError}
@@ -906,6 +918,9 @@ const BookshelfModel = ModelBase.extend(
      * @param {string} [options.lock]
      *   Type of row-level lock to use. Valid options are `forShare` and `forUpdate`. This only works in conjunction
      *   with the `transacting` option, and requires a database that supports it.
+     * @param {boolean} [options.debug=false]
+     *   Whether to enable debugging mode or not. When enabled will show information about the
+     *   queries being run.
      * @returns {Promise<Model>} A promise resolving to this {@link Model model}.
      */
     load: Promise.method(function(relations, options) {
@@ -1008,6 +1023,9 @@ const BookshelfModel = ModelBase.extend(
      * @param {Boolean} [options.require=true]
      *   Whether or not to throw a {@link Model.NoRowsUpdatedError} if no records
      *   are affected by save.
+     * @param {boolean} [options.debug=false]
+     *   Whether to enable debugging mode or not. When enabled will show information about the
+     *   queries being run.
      * @fires Model#saving
      * @fires Model#creating
      * @fires Model#updating
@@ -1228,11 +1246,14 @@ const BookshelfModel = ModelBase.extend(
      *
      * @method Model#destroy
      *
-     * @param {Object=}      options                  Hash of options.
-     * @param {Transaction=} options.transacting      Optionally run the query in a transaction.
+     * @param {Object} [options] Hash of options.
+     * @param {Transaction} [options.transacting] Optionally run the query in a transaction.
      * @param {Boolean} [options.require=true]
      *   Throw a {@link Model.NoRowsDeletedError} if no records are affected by destroy. This is
      *   the default behavior as of version 0.13.0.
+     * @param {boolean} [options.debug=false]
+     *   Whether to enable debugging mode or not. When enabled will show information about the
+     *   queries being run.
      *
      * @example
      *


### PR DESCRIPTION
* Related Issues: #1822

## Introduction

Add more information about debug mode.

## Motivation

The current documentation is not clear on how to enable it and make use of it.

Fixes #1822.