### PR TITLE
Add example of how to use custom collections

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -8,22 +8,43 @@ const Promise = require('bluebird');
 const createError = require('create-error');
 
 /**
+ * When creating a {@link Collection}, you may choose to pass in the initial array of
+ * {@link Model models}. The collection's {@link Collection#comparator comparator} may be included
+ * as an option. Passing `false` as the comparator option will prevent sorting. If you define an
+ * {@link Collection#initialize initialize} function, it will be invoked when the collection is
+ * created.
+ *
+ * If you would like to customize the Collection used by your models when calling
+ * {@link Model#fetchAll} or {@link Model#fetchPage} you can use the following process:
+ *
+ *     const Test = bookshelf.model('Test', {
+ *       tableName: 'test'
+ *     }, {
+ *       collection(...args) {
+ *         return new Tests(...args)
+ *       }
+ *     })
+ *     const Tests = bookshelf.collection('Tests', {
+ *       get model() {
+ *         return Test
+ *       },
+ *       doStuff() {
+ *         // This method will be available in the results collection returned
+ *         // by Test.fetchAll() and Test.fetchPage()
+ *       }
+ *     })
+ *
+ * @example
+ * const TabSet = bookshelf.collection('TabSet', {
+ *   model: Tab
+ * })
+ * const tabs = new TabSet([tab1, tab2, tab3])
+ *
  * @class Collection
  * @extends CollectionBase
  * @classdesc
  *   Collections are ordered sets of models returned from the database, from a
  *   {@link Model#fetchAll fetchAll} call.
- *
- * @description
- *   When creating a {@link Collection}, you may choose to pass in the initial array of
- *   {@link Model models}. The collection's {@link Collection#comparator comparator} may be included
- *   as an option. Passing `false` as the comparator option will prevent sorting. If you define an
- *   {@link Collection#initialize initialize} function, it will be invoked when the collection is
- *   created.
- *
- * @example
- * let tabs = new TabSet([tab1, tab2, tab3]);
- *
  * @param {(Model[])=} models Initial array of models.
  * @param {Object=} options
  * @param {Boolean} [options.comparator=false]


### PR DESCRIPTION
* Related Issues: #1466 

## Introduction

Document how to use a custom collection for the results of every call to `.fetchAll()`. This includes calls to `.fetchPage()` and `.related()` as well, in case the relation is a one to many. Basically any time a new collection of the Model is created.

## Motivation

Collections are a bit hard to understand. This should help users that want to attach custom behavior to the collections associated with a certain model.

Currently a new anonymous collection is created when trying to compose the results of a `.fetchAll()`, but it's sometimes useful to add extra behavior to this collection in a predictable way.

Fixes #1466.
