### PR TITLE
super isn't valid unless using ES6 classes

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -28,8 +28,8 @@ const createError = require('create-error');
  *       get model() {
  *         return Test
  *       },
- *       initialize (...args) {
- *         super.initialize(...args)
+ *       initialize () {
+ *         this.constructor.__super__.initialize.apply(this, arguments)
  *         // Collection will emit fetching event as expected even on eager queries.
  *         this.on('fetching', () => {})
  *       },


### PR DESCRIPTION
## Introduction

The example is invalid, because bookshelf docs isn't using ES6 classes.
My bad.