### PR TITLE
Fix JSON.stringify causing TypeErrors

### DIFF
--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -485,7 +485,7 @@ ModelBase.prototype.isNew = function() {
  * @returns {Object} Serialized model as a plain object.
  */
 ModelBase.prototype.serialize = function(options) {
-  if (!_.isPlainObject(options)) options = {};
+  if (typeof options !== 'object' || options === null) options = {};
   if (options.visibility === null || options.visibility === undefined) options.visibility = true;
 
   if (options.omitNew && this.isNew()) return null;

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -485,7 +485,7 @@ ModelBase.prototype.isNew = function() {
  * @returns {Object} Serialized model as a plain object.
  */
 ModelBase.prototype.serialize = function(options) {
-  if (!options) options = {};
+  if (!_.isPlainObject(options)) options = {};
   if (options.visibility === null || options.visibility === undefined) options.visibility = true;
 
   if (options.omitNew && this.isNew()) return null;

--- a/test/unit/model.js
+++ b/test/unit/model.js
@@ -224,6 +224,12 @@ module.exports = function() {
         deepEqual(json, {id: 1, firstName: 'Joe', lastName: 'Shmoe', address: '123 Main St.'});
       });
       describe('with JSON.stringify', function() {
+        it('serializes correctly', function() {
+          testModel.visible = ['firstName'];
+
+          deepEqual(JSON.stringify(testModel), '{"firstName":"Joe"}');
+        });
+
         it('serializes correctly when placed as object property', function() {
           testModel.visible = ['firstName'];
           var obj = {

--- a/test/unit/model.js
+++ b/test/unit/model.js
@@ -223,6 +223,21 @@ module.exports = function() {
 
         deepEqual(json, {id: 1, firstName: 'Joe', lastName: 'Shmoe', address: '123 Main St.'});
       });
+      describe('with JSON.stringify', function() {
+        it('serializes correctly when placed as object property', function() {
+          testModel.visible = ['firstName'];
+          var obj = {
+            model: testModel
+          };
+          deepEqual(JSON.stringify(obj), '{"model":{"firstName":"Joe"}}');
+        });
+
+        it('serializes correctly when placed in an array', function() {
+          testModel.visible = ['firstName'];
+          var arr = [testModel];
+          deepEqual(JSON.stringify(arr), '[{"firstName":"Joe"}]');
+        });
+      });
     });
 
     describe('#hasChanged()', function() {


### PR DESCRIPTION
* Related Issues: #2028 

## Introduction

Fix JSON.stringify throwing TypeError if Model object is placed as object property or in an array.

## Motivation

JSON.stringify calls .toJSON on object to be serialized. When called in array, it passes index as parameter to .toJSON. When called in object it passes the property name as parameter:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON_behavior

Bookshelf model accepts options object as parameter for toJSON, it however does not check if passed parameter is object before trying to put properties in it. This results in ```TypeError: Cannot create property 'visibility' on string 'propertyname'```

## Proposed solution

The proposed solution is to check if options is really an object by checking it with lodash.isPlainObject.

## Current PR Issues

Not benchmarked this, so can't know the performance implications.

## Alternatives considered

Simpler Object check might be more performant. One from redux:
https://github.com/reduxjs/redux/blob/master/src/utils/isPlainObject.ts
