### PR TITLE
Fix number of arguments in Model#save doclet

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1005,11 +1005,13 @@ const BookshelfModel = ModelBase.extend(
      *   //...
      * })
      *
-     * @param {string} [key] Attribute name.
-     * @param {*} [val] Attribute value.
      * @param {Object} [attrs]
-     *   You can use a single object argument with all the values you wish to save
-     *   instead of specifying both the `key` and `value` arguments.
+     *   Object containing the key: value pairs that you wish to save. If used with the `patch`
+     *   option only these values will be saved and any values already set on the model will be
+     *   ignored.
+     *
+     *   Instead of specifying this argument you can provide both a `key` and `value`
+     *   arguments to save a single value. This is demonstrated in the example.
      * @param {Object} [options]
      * @param {Transaction} [options.transacting] Optionally run the query in a transaction.
      * @param {string} [options.method]


### PR DESCRIPTION
* Related Issues: #902

## Introduction

The number of arguments in the documentation for `Model#save` shows 4 arguments, when in reality it should be 2, with the possibility of 3 in a special case.

## Motivation

Fixes #902.
