### PR TITLE
Add documentation for Model#id

### DIFF
--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -110,6 +110,31 @@ ModelBase.prototype.initialize = function() {};
  */
 
 /**
+ * A special property of models which represents their unique identifier, named by the
+ * {@link Model#idAttribute idAttribute}. If you set the `id` in the attributes hash,
+ * it will be copied onto the model as a direct property.
+ *
+ * Models can be retrieved by their id from collections, and the id is used when fetching
+ * models and building model relations.
+ *
+ * Note that a model's `id` property can always be accessed even when the value of its
+ * {@link Model#idAttribute idAttribute} is not `'id'`.
+ *
+ * @member {(number|string)}
+ * @example
+ * const Television = bookshelf.model('Television', {
+ *   tableName: 'televisions',
+ *   idAttribute: 'coolId'
+ * })
+ *
+ * new Television({coolId: 1}).fetch(tv => {
+ *   tv.get('coolId') // 1
+ *   tv.id // 1
+ * })
+ */
+ModelBase.prototype.id;
+
+/**
  * @member {string}
  * @default "id"
  * @description


### PR DESCRIPTION
* Related Issues: #931

## Introduction

Adds documentation for the Model's `id` property.

## Motivation

Fixes #931.
