### PR TITLE
fix non-object attributes being passed to model.parse()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1179,7 +1179,7 @@ const BookshelfModel = ModelBase.extend(
                 if (options.require !== false) {
                   throw new this.constructor.NoRowsUpdatedError('No Rows Updated');
                 }
-              } else {
+              } else if (isObjectResponse) {
                 Object.assign(this.attributes, this.parse(resp[0]));
               }
 
@@ -1254,7 +1254,7 @@ const BookshelfModel = ModelBase.extend(
      * @param {Transaction} [options.transacting] Optionally run the query in a transaction.
      * @param {Boolean} [options.require=true]
      *   Throw a {@link Model.NoRowsDeletedError} if no records are affected by destroy. This is
-     *   the default behavior as of version 0.13.0.
+     *   the default behavior as of ersion 0.13.0.
      * @param {boolean} [options.debug=false]
      *   Whether to enable debugging mode or not. When enabled will show information about the
      *   queries being run.

--- a/lib/model.js
+++ b/lib/model.js
@@ -1254,7 +1254,7 @@ const BookshelfModel = ModelBase.extend(
      * @param {Transaction} [options.transacting] Optionally run the query in a transaction.
      * @param {Boolean} [options.require=true]
      *   Throw a {@link Model.NoRowsDeletedError} if no records are affected by destroy. This is
-     *   the default behavior as of ersion 0.13.0.
+     *   the default behavior as of version 0.13.0.
      * @param {boolean} [options.debug=false]
      *   Whether to enable debugging mode or not. When enabled will show information about the
      *   queries being run.

--- a/test/unit/model.js
+++ b/test/unit/model.js
@@ -49,6 +49,25 @@ module.exports = function() {
           });
         });
       });
+
+      describe('when the save method is insert', () => {
+        it('should not call model.parse with a non-object argument', () => {
+          const model = new Model();
+          model.id = '12345';
+          model.sync = () => {
+            return {
+              insert: () => {
+                return Promise.resolve(['12345']);
+              }
+            };
+          };
+          model.refresh = () => Promise.resolve({});
+          const parse = sinon.spy(model, 'parse');
+          return model.save(null, {method: 'insert'}).then(function() {
+            expect(parse).not.to.have.been.calledWith('12345');
+          });
+        });
+      });
     });
 
     describe('#timestamp()', function() {

--- a/test/unit/model.js
+++ b/test/unit/model.js
@@ -48,6 +48,23 @@ module.exports = function() {
             expect(parse).not.to.have.been.calledWith(undefined);
           });
         });
+
+        it('should merge the updated attributes on the existing model', () => {
+          const model = new Model({oldProp: 'b'});
+          model.sync = () => {
+            return {
+              update: () => {
+                return Promise.resolve([{newProp: 'a'}]);
+              }
+            };
+          };
+          model.refresh = () => Promise.resolve({});
+          const parse = sinon.spy(model, 'parse');
+          return model.save(null, {method: 'update'}).then(function(updatedModel) {
+            expect(parse).to.have.been.calledWith({newProp: 'a'});
+            expect(updatedModel.toJSON()).to.eql({oldProp: 'b', newProp: 'a'});
+          });
+        });
       });
 
       describe('when the save method is insert', () => {

--- a/test/unit/model.js
+++ b/test/unit/model.js
@@ -31,6 +31,24 @@ module.exports = function() {
           equal(_.difference(Object.keys(options), ['query']).length, 0);
         });
       });
+
+      describe('when the save method is update', () => {
+        it('should not call model.parse with a non-object argument', () => {
+          const model = new Model();
+          model.sync = () => {
+            return {
+              update: () => {
+                return Promise.resolve(1);
+              }
+            };
+          };
+          model.refresh = () => Promise.resolve({});
+          const parse = sinon.spy(model, 'parse');
+          return model.save(null, {method: 'update'}).then(function() {
+            expect(parse).not.to.have.been.calledWith(undefined);
+          });
+        });
+      });
     });
 
     describe('#timestamp()', function() {


### PR DESCRIPTION
* Related Issues: https://github.com/bookshelf/bookshelf/issues/2026


## Introduction

When model.save() is executed with method: 'update', the `resp` argument is first the number of rows that were updated. This causes `undefined` to be passed into this.parse on line 1183 in model.save(). Any custom model.parse functions on a model are expecting an object of attributes to be passed.

Also, this branch can be reached if the save method is 'insert' and this.id is not null, which we have found to occur when query.options.returning was set to 'id' instead of the default '*' which bookshelf expects. 

## Motivation

Any custom model.parse functions are not expecting to be receiving any argument other than an object, potentially causing unexpected errors.


## Proposed solution

Check that the response is an object before passing it to model.parse and merging with this.attributes.


