### PR TITLE
Corrected possible typo on docs

### DIFF
--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -267,7 +267,7 @@ ModelBase.prototype.hasTimestamps = false;
  * @description
  *
  * List of model attributes to exclude from the output when serializing it. This works as a
- * blacklist, and all attributes not present in this list will be shown whan calling
+ * blacklist, and all attributes not present in this list will be shown when calling
  * {@link Model#toJSON toJSON}.
  *
  * By default this is `null` which means that no attributes will be excluded from the output.
@@ -304,7 +304,7 @@ ModelBase.prototype.hidden = null;
  * @description
  *
  * List of model attributes to include in the output when serializing it. This works as a
- * whitelist, and all attributes not present in this list will be hidden whan calling
+ * whitelist, and all attributes not present in this list will be hidden when calling
  * {@link Model#toJSON toJSON}.
  *
  * By default this is `null` which means that all attributes will be included in the output.


### PR DESCRIPTION
I noticed a possible typo on two methods in the docs, the use of the word 'whan' which I think might be meant to be 'when'.

Please ignore if this is something regional that I'm unaware of.

I haven't included the built `/docs` folder as it looks like you generally update them only on a release.