### PR TITLE
Fixed model attribute synchronization for update method

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1085,7 +1085,9 @@ const BookshelfModel = ModelBase.extend(
             Helpers.saveConstraints(this, this.relatedData);
           }
 
-          const attributesToSave = method === 'update' && options.patch ? attrs : this.attributes;
+          const getAttributesToSave = function(method, options, model) {
+            return method === 'update' && options.patch ? attrs : model.attributes;
+          };
 
           // Gives access to the `query` object in the `options`, in case we need it
           // in any event handlers.
@@ -1150,12 +1152,12 @@ const BookshelfModel = ModelBase.extend(
           return this.triggerThen(
             method === 'insert' ? 'saving creating' : 'saving updating',
             this,
-            attributesToSave,
+            getAttributesToSave(method, options, this),
             options
           )
             .bind(this)
             .then(function() {
-              return sync[options.method](attributesToSave);
+              return sync[options.method](getAttributesToSave(method, options, this));
             })
             .then(function(resp) {
               // Only valid for databases that support RETURNING


### PR DESCRIPTION
* Related Issues: #2007

## Introduction

When model's `attributes` are modified during even hooks, e.g. `on('save')`, changes are not detected and incorrect `attributes` are persisted in the db. 

## Motivation

As described in the https://github.com/bookshelf/bookshelf/issues/2007.

> When making changes to the saved object during even hooks they should be persisted.

## Proposed solution

The keep `.attributes` available for modification and avoid loosing reference to that object during `triggerThen` stage we could refetch attributesToSave through a method instead of keeping an object around.

## Alternatives considered

Alternatively we could be explicit about not allowing to modify `attributes` directly by the bookshelf clients. This would mean forcing use of `set` (sometimes with `unset` flag) method on the model to do any modifications. This approach is rather inflexible and would require clients to modify code.  
