### PR TITLE
Add option to control auto refresh after save

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -965,12 +965,6 @@ const BookshelfModel = ModelBase.extend(
      *         // ...
      *       })
      *
-     * After a model is saved it will be populated with all the attributes that are
-     * present in the database, so you don't need to manually call
-     * {@link Model#refresh refresh} to update it. This will use two queries unless
-     * the database supports the `RETURNING` statement, in which case the model will
-     * be saved and its data fetched with a single query.
-     *
      * Several events fire on the model when starting the save process:
      * - {@link Model#event:creating "creating"} if the model is being inserted.
      * - {@link Model#event:updating "updating"} event if the model is being updated.
@@ -1030,6 +1024,12 @@ const BookshelfModel = ModelBase.extend(
      * @param {boolean} [options.debug=false]
      *   Whether to enable debugging mode or not. When enabled will show information about the
      *   queries being run.
+     * @param {boolean} [options.autoRefresh=true]
+     *   Weather to enable auto refresh such that after a model is saved it will be populated with all
+     *   the attributes that are present in the database, so you don't need to manually call
+     *   {@link Model#refresh refresh} to update it. This will use two queries unless
+     *   the database supports the `RETURNING` statement, in which case the model will
+     *   be saved and its data fetched with a single query.
      * @fires Model#saving
      * @fires Model#creating
      * @fires Model#updating
@@ -1187,7 +1187,7 @@ const BookshelfModel = ModelBase.extend(
 
               if (resp === 0 || resp.length === 0) return resp;
               if (isObjectResponse) return this;
-
+              if (options.autoRefresh === false) return this;
               return this.refresh({silent: true, transacting: options.transacting});
             })
             .then(function() {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -209,7 +209,7 @@ _.extend(Sync.prototype, {
     const syncing = this.syncing;
     return this.query.insert(
       syncing.format(_.extend(Object.create(null), syncing.attributes)),
-      supportsReturning(this.query.client) ? '*' : null
+      supportsReturning(this.query.client) && this.options.autoRefresh !== false ? '*' : null
     );
   }),
 
@@ -225,7 +225,7 @@ _.extend(Sync.prototype, {
     if (syncing.id === updating[syncing.idAttribute]) {
       delete updating[syncing.idAttribute];
     }
-    if (supportsReturning(query.client)) query.returning('*');
+    if (supportsReturning(query.client) && this.options.autoRefresh !== false) query.returning('*');
     return query.update(updating);
   }),
 

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1312,6 +1312,12 @@ module.exports = function(bookshelf) {
         });
       });
 
+      it('does not refresh the model if {autoRefresh: false} option is passed', function() {
+        return new Models.Member({id: 1}).save({name: 'Okoye'}, {autoRefresh: false}).then((member) => {
+          deepEqual(member.attributes, {id: 1, name: 'Okoye'});
+        });
+      });
+
       it('does not trigger a "fetched" event after refreshing the model', function() {
         const member = new Models.Member({id: 1});
         let isFetchedTriggered = false;


### PR DESCRIPTION
* Related Issues: #2047

## Introduction

Add option to control auto refresh after save.

## Motivation

The newly introduced "auto refresh" functionality does not work properly in all cases yet and a part from that it might still be situations where you don't want/need to run the extra select query. 

## Proposed solution

Added the autoRefresh option to the save method to control weather or not auto refresh the model after save. Defaulted to true to not break the current behavior and also made it affect databases that supports the RETURNING statement for completeness. Of course there might not be many real life cases where you would turn it off for those.

## Current PR Issues

-

## Alternatives considered

Tried to get the refresh to actually work for my use case but gave up since even fixing the linked issue with "withSchema" option didn't solve everything. Don't have the time currently to get into this code base well enough to dig deeper into that and I believe this change is a reasonable thing to have and it solves the issue we are seeing.
