### PR TITLE
Count on relation should work for belongsToMany relations.

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -84,7 +84,11 @@ _.extend(Sync.prototype, {
               fks[relatedData.key('foreignKey')] = relatedData.parentFk;
               const through = new relatedData.throughTarget(fks);
               relatedData.pivotColumns = through.parse(relatedData.pivotColumns);
-            } else if (relatedData.type === 'hasMany') {
+            } else if (relatedData.type === 'hasMany' || relatedData.type === 'belongsToMany') {
+              if (relatedData.type === 'belongsToMany') {
+                relatedData.joinClauses(knex)
+              }
+
               const fk = relatedData.key('foreignKey');
               knex.where(fk, relatedData.parentFk);
             }


### PR DESCRIPTION
* Related Issues: _#1075 if necessary_

## Introduction

There's a bug that prevents the counting of a belongsToMany relation from working. The belongsToMany case did not seem to be handled at all previously in sync.js.

## Motivation

_Describe the problems that this proposal seeks to address and why it's important. If it's completely new functionality
explain why this new functionality is necessary._

## Proposed solution

_Describe your solution to the problem. If possible provide examples and describe how they work. Show why your solution
is better than what's currently available: is it cleaner, safer, or more efficient?_

## Current PR Issues

_Are there any known issues in this Pull Request? This will help others understand if more work will be needed._

## Alternatives considered

_Describe any alternative approaches to addressing the same problem that you have thought about, and why you chose this
approach instead._
