### PR TITLE
Remove some development files from NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,6 @@ test/
 .npmignore
 CNAME
 docker-compose.yml
+.prettierrc
+.nycrc.yml
+.eslintrc.json


### PR DESCRIPTION
.npmignore was last updated 2 years ago. Since then several new development files were introduced. This PR removes them from the NPM package.