### PR TITLE
fixed fetchPage can't set attribute in event

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -99,8 +99,8 @@ module.exports = {
             // https://github.com/tgriesser/knex/issues/3315.
             const keys = Object.keys(result.models[0].attributes);
 
-            if (keys.length === 1) {
-              const key = Object.keys(result.models[0].attributes)[0];
+            if (keys.length >= 1) {
+              const key = keys[0];
               metadata.rowCount = parseInt(result.models[0].attributes[key]);
             }
           }


### PR DESCRIPTION
when
```js
    this.on('fetched:collection', function(collection, response, options) {
      collection.forEach(model => {
        model.set('abc', 0)
      })
    })
```

the keys is `[ 'count(distinct `stock_agu_data`.`id`)', 'abc' ]`，pagination is wrong

* Related Issues: _#IssueNumber if necessary_
* Previous PRs: _#PRNumber if this PR is a follow-up_

## Introduction

_A short description of what the feature or the bug-fix is. Try to keep it to a single paragraph "elevator pitch" style
so the reader easily understands what problem this proposal is addressing._

## Motivation

_Describe the problems that this proposal seeks to address and why it's important. If it's completely new functionality
explain why this new functionality is necessary._

## Proposed solution

_Describe your solution to the problem. If possible provide examples and describe how they work. Show why your solution
is better than what's currently available: is it cleaner, safer, or more efficient?_

## Current PR Issues

_Are there any known issues in this Pull Request? This will help others understand if more work will be needed._

## Alternatives considered

_Describe any alternative approaches to addressing the same problem that you have thought about, and why you chose this
approach instead._
