### PR TITLE
Replace FlyptoX domain link with link to repo in the documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -256,7 +256,7 @@ document on GitHub.</p>
 <li><a href="http://soapee.com/">Soapee</a> (Soap Making Community and Resources) uses bookshelf. [<a href="https://github.com/nazar/soapee-api/tree/master/src/models">Link</a>]</li>
 <li><a href="http://nodeza.co.za/">NodeZA</a> (Node.js social platform for developers in South Africa) uses bookshelf. [<a href="https://github.com/qawemlilo/nodeza/tree/master/models">Link</a>]</li>
 <li><a href="https://github.com/sunday-cooks/sunday-cook">Sunday Cook</a> (A social cooking event platform) uses bookshelf. [<a href="https://github.com/sunday-cooks/sunday-cook/tree/master/server/bookshelf">Link</a>]</li>
-<li><a href="http://www.flyptox.com/">FlyptoX</a> (Open-source Node.js cryptocurrency exchange) uses bookshelf. [<a href="https://github.com/FlipSideHR/FlyptoX/tree/master/server/models">Link</a>]</li>
+<li><a href="https://github.com/FlipSideHR/FlyptoX">FlyptoX</a> (Open-source Node.js cryptocurrency exchange) uses bookshelf. [<a href="https://github.com/FlipSideHR/FlyptoX/tree/master/server/models">Link</a>]</li>
 <li>And of course, everything on <a href="https://www.npmjs.com/browse/depended/bookshelf">here</a> use bookshelf too.</li>
 </ul>
   </section>


### PR DESCRIPTION
## Introduction

There is a link to flyptox dot com in the documentation projects list, but the site seems to be taken down and replaced with a site ridden with ads and NSFW content.

## Motivation

The documentation of this project should not be linking readers to such sites. 

## Proposed solution

Replace the link with a link to the project's repo, which is still up, similarly to the Sunday Cook project in the list.
