### PR TITLE
Returning option in save method

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1178,9 +1178,9 @@ const BookshelfModel = ModelBase.extend(
                 } else {
                   updatedAttrs = this.parse(resp[0]);
                   this.id = updatedAttrs[this.parsedIdAttribute()];
+                  if (options.returning) this.clear();
                 }
 
-                if (options.returning) this.clear();
                 Object.assign(this.attributes, updatedAttrs);
               } else if (method === 'update' && (resp === 0 || resp.length === 0)) {
                 if (options.require !== false) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1030,6 +1030,10 @@ const BookshelfModel = ModelBase.extend(
      *   {@link Model#refresh refresh} to update it. This will use two queries unless
      *   the database supports the `RETURNING` statement, in which case the model will
      *   be saved and its data fetched with a single query.
+     * @param {(string|string[])} [options.returning='*']
+     *   Limit the number of columns fetched by knex query.
+     *   See {@link https://knexjs.org/#Builder-returning Knex returning}.
+     *   This will only be used if autoRefresh is true and the database supports the `RETURNING` statement.
      * @fires Model#saving
      * @fires Model#creating
      * @fires Model#updating
@@ -1176,12 +1180,14 @@ const BookshelfModel = ModelBase.extend(
                   this.id = updatedAttrs[this.parsedIdAttribute()];
                 }
 
+                if (options.returning) this.clear();
                 Object.assign(this.attributes, updatedAttrs);
               } else if (method === 'update' && (resp === 0 || resp.length === 0)) {
                 if (options.require !== false) {
                   throw new this.constructor.NoRowsUpdatedError('No Rows Updated');
                 }
               } else if (isObjectResponse) {
+                if (options.returning) this.clear();
                 Object.assign(this.attributes, this.parse(resp[0]));
               }
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -209,7 +209,7 @@ _.extend(Sync.prototype, {
     const syncing = this.syncing;
     return this.query.insert(
       syncing.format(_.extend(Object.create(null), syncing.attributes)),
-      supportsReturning(this.query.client) && this.options.autoRefresh !== false ? '*' : null
+      supportsReturning(this.query.client) && this.options.autoRefresh !== false ? this.options.returning || '*' : null
     );
   }),
 
@@ -225,7 +225,7 @@ _.extend(Sync.prototype, {
     if (syncing.id === updating[syncing.idAttribute]) {
       delete updating[syncing.idAttribute];
     }
-    if (supportsReturning(query.client) && this.options.autoRefresh !== false) query.returning('*');
+    if (supportsReturning(query.client) && this.options.autoRefresh !== false) query.returning(this.options.returning || '*');
     return query.update(updating);
   }),
 


### PR DESCRIPTION
## Introduction

Knex provide a returning method when an insert or update query is built. This pull request allow the same option in the save method in bookshelf.

## Proposed solution

The solution consist in passing the returning option during the building of the knex query.
And then when the resulting object is retrived we clear the model in order to have only the desired columns.

## Current PR Issues

The option is not built for database without RETURNING statement (I do not have one for test right now).