### PR TITLE
Pass the options object when fetching related data

### DIFF
--- a/lib/base/eager.js
+++ b/lib/base/eager.js
@@ -50,7 +50,7 @@ _.extend(EagerBase.prototype, {
         throw new Error(relationName + ' is not defined on the model.');
       }
 
-      const relation = target[relationName]();
+      const relation = target[relationName](options);
 
       handled[relationName] = relation;
     }


### PR DESCRIPTION
## Introduction

The `options` object is passed a bit everywhere and isn't passed to relations. By passing the options object into relations, this opens countless possibilities, such as filtering data according to logged-in user rights directly into the relation.

## Motivation

Our main use case is filtering related data according to the user rights. To be able to do this, we need to access a context object to know who is the logged-in user. Currently, relations can't be "dynamic"  and adapt to a tenant or other contextual data.

## Proposed solution

By simply passing the `options` object to the related fetching, we can implement something like this:

```js
topics: function (options) {
    return this
        .hasMany('Topic')
        .query(qb => {
            qb
                .whereExists(MeetingDbQueries.filterByTopicsAccess(options.context.user.id));
        });
}
```

## Current PR Issues

I didn't encounter any issues up to now.

## Alternatives considered

I've tried many ways to access some data from the relation function unsuccessfully.

Thank you for considering this PR.
